### PR TITLE
feat: layered rule resolution from .vaudeville directories

### DIFF
--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -21,7 +21,6 @@ PLUGIN_ROOT = os.environ.get(
     "CLAUDE_PLUGIN_ROOT",
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
 )
-RULES_DIR = os.path.join(PLUGIN_ROOT, "rules")
 
 if PLUGIN_ROOT not in sys.path:
     sys.path.insert(0, PLUGIN_ROOT)
@@ -31,14 +30,47 @@ from vaudeville.core.client import VaudevilleClient  # noqa: E402
 MIN_TEXT_LENGTH = 100
 
 
+def _rules_search_path() -> list[str]:
+    """Build search path: bundled → global → project (highest priority last)."""
+    import subprocess
+
+    dirs: list[str] = []
+
+    bundled = os.path.join(PLUGIN_ROOT, "rules")
+    if os.path.isdir(bundled):
+        dirs.append(bundled)
+
+    global_dir = os.path.join(os.path.expanduser("~"), ".vaudeville", "rules")
+    if os.path.isdir(global_dir):
+        dirs.append(global_dir)
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            project_dir = os.path.join(result.stdout.strip(), ".vaudeville", "rules")
+            if os.path.isdir(project_dir):
+                dirs.append(project_dir)
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+    return dirs
+
+
 def load_rule(name: str) -> dict | None:
-    """Load a rule YAML file by name."""
-    path = os.path.join(RULES_DIR, f"{name}.yaml")
-    if not os.path.isfile(path):
-        print(f"[vaudeville] rule not found: {path}", file=sys.stderr)
-        return None
-    with open(path) as f:
-        return yaml.safe_load(f)
+    """Load a rule YAML file by name, searching layered paths (project wins)."""
+    filename = f"{name}.yaml"
+    # Walk search path in reverse so highest priority wins
+    for rules_dir in reversed(_rules_search_path()):
+        path = os.path.join(rules_dir, filename)
+        if os.path.isfile(path):
+            with open(path) as f:
+                return yaml.safe_load(f)
+
+    print(f"[vaudeville] rule not found: {name}", file=sys.stderr)
+    return None
 
 
 def extract_field(data: dict, dotted_path: str) -> str:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,7 +6,7 @@ import tempfile
 
 from vaudeville.core.client import VaudevilleClient
 from vaudeville.core.protocol import ClassifyRequest, parse_verdict
-from vaudeville.core.rules import Rule, load_rules
+from vaudeville.core.rules import Rule, load_rules, load_rules_layered, rules_search_path
 
 
 # --- parse_verdict ---
@@ -213,3 +213,53 @@ class TestRuleContext:
         )
         ctx = rule.resolve_context({"tool_input": {"body": "value"}})
         assert ctx == ""
+
+
+# --- Layered rule resolution ---
+
+class TestRulesSearchPath:
+    def test_bundled_rules_always_in_path(self) -> None:
+        import os
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        path = rules_search_path(plugin_root)
+        assert len(path) >= 1
+        assert path[0].endswith("/rules")
+
+    def test_nonexistent_plugin_root_returns_empty(self) -> None:
+        path = rules_search_path("/nonexistent/plugin/root")
+        # Only global/project dirs that happen to exist would appear
+        for d in path:
+            assert "/nonexistent/" not in d
+
+
+class TestLoadRulesLayered:
+    def test_loads_bundled_rules(self) -> None:
+        import os
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        rules = load_rules_layered(plugin_root)
+        assert "violation-detector" in rules
+
+    def test_project_override_wins(self) -> None:
+        """A project .vaudeville/rules/ file overrides the bundled rule."""
+        import os
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+        with tempfile.TemporaryDirectory() as project_dir:
+            rules_dir = os.path.join(project_dir, ".vaudeville", "rules")
+            os.makedirs(rules_dir)
+            # Write a rule that overrides violation-detector with action=warn
+            with open(os.path.join(rules_dir, "violation-detector.yaml"), "w") as f:
+                f.write(
+                    "name: violation-detector\n"
+                    "event: Stop\n"
+                    "prompt: 'override {text}'\n"
+                    "labels: [violation, clean]\n"
+                    "action: warn\n"
+                    "message: '{reason}'\n"
+                )
+
+            from unittest.mock import patch
+            with patch("vaudeville.core.rules._find_project_root", return_value=project_dir):
+                rules = load_rules_layered(plugin_root)
+                assert rules["violation-detector"].action == "warn"
+                assert "override" in rules["violation-detector"].prompt

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -73,7 +73,7 @@ class TestHandleRequest:
 
 
 class TestDaemonSocketProtocol:
-    def test_daemon_serves_request_via_socket(self, rules_dir: str) -> None:
+    def test_daemon_serves_request_via_socket(self) -> None:
         import tempfile
         # Unix sockets have a 104-char path limit on macOS — use /tmp directly
         with tempfile.NamedTemporaryFile(suffix=".sock", dir="/tmp", delete=False) as f:
@@ -83,7 +83,9 @@ class TestDaemonSocketProtocol:
         import os; os.unlink(socket_path)  # daemon will re-create it
         backend = MockBackend(verdict="clean", reason="socket test")
 
-        daemon = VaudevilleDaemon(socket_path, pid_file, rules_dir, backend)
+        import os
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        daemon = VaudevilleDaemon(socket_path, pid_file, plugin_root, backend)
 
         thread = threading.Thread(target=daemon.serve, daemon=True)
         thread.start()

--- a/vaudeville/core/rules.py
+++ b/vaudeville/core/rules.py
@@ -1,4 +1,11 @@
-"""YAML rule loader.
+"""YAML rule loader with layered config resolution.
+
+Rules are resolved from multiple directories in priority order:
+  1. project/.vaudeville/rules/   (highest — project overrides)
+  2. ~/.vaudeville/rules/          (user-global rules)
+  3. <plugin_root>/rules/          (bundled defaults, lowest)
+
+Higher-priority rules override lower-priority ones by name.
 
 Uses PyYAML — only imported by daemon and eval, NOT by hook entry points.
 """
@@ -6,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import os
+import subprocess
 from dataclasses import dataclass
 from typing import Any
 
@@ -77,6 +85,55 @@ def load_rules(rules_dir: str) -> dict[str, Rule]:
             logging.warning("[vaudeville] Failed to load rule %s: %s", filename, exc)
 
     return rules
+
+
+def _find_project_root() -> str | None:
+    """Find the git working tree root, or None if not in a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def rules_search_path(plugin_root: str) -> list[str]:
+    """Build the rules directory search path (lowest → highest priority).
+
+    Returns directories that exist. Order: bundled → global → project.
+    """
+    dirs: list[str] = []
+
+    # Lowest priority: bundled defaults
+    bundled = os.path.join(plugin_root, "rules")
+    if os.path.isdir(bundled):
+        dirs.append(bundled)
+
+    # Mid priority: user-global
+    global_dir = os.path.join(os.path.expanduser("~"), ".vaudeville", "rules")
+    if os.path.isdir(global_dir):
+        dirs.append(global_dir)
+
+    # Highest priority: project-local
+    project_root = _find_project_root()
+    if project_root:
+        project_dir = os.path.join(project_root, ".vaudeville", "rules")
+        if os.path.isdir(project_dir):
+            dirs.append(project_dir)
+
+    return dirs
+
+
+def load_rules_layered(plugin_root: str) -> dict[str, Rule]:
+    """Load rules from all search path directories, higher priority wins."""
+    merged: dict[str, Rule] = {}
+    for rules_dir in rules_search_path(plugin_root):
+        merged.update(load_rules(rules_dir))
+    return merged
 
 
 def _parse_rule(data: dict[str, Any]) -> Rule:

--- a/vaudeville/eval.py
+++ b/vaudeville/eval.py
@@ -226,16 +226,15 @@ def main() -> None:
         "CLAUDE_PLUGIN_ROOT",
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     )
-    rules_dir = os.path.join(plugin_root, "rules")
     tests_dir = os.path.join(plugin_root, "tests")
 
-    from .core.rules import load_rules
+    from .core.rules import load_rules_layered
     from .server.mlx_backend import MLXBackend
 
     print(f"Loading model: {args.model}")
     backend = MLXBackend(args.model)
 
-    rules = load_rules(rules_dir)
+    rules = load_rules_layered(plugin_root)
     test_suites = load_test_cases(tests_dir)
 
     if args.test_file and args.rule:

--- a/vaudeville/server/__main__.py
+++ b/vaudeville/server/__main__.py
@@ -37,8 +37,6 @@ def main() -> None:
         "CLAUDE_PLUGIN_ROOT",
         str(Path(__file__).parent.parent.parent),
     )
-    rules_dir = os.path.join(plugin_root, "rules")
-
     logging.info("Loading backend: %s model=%s", args.backend, args.model)
     if args.backend == "mlx":
         from .mlx_backend import MLXBackend
@@ -53,7 +51,7 @@ def main() -> None:
     daemon = VaudevilleDaemon(
         socket_path=args.socket,
         pid_file=args.pid_file,
-        rules_dir=rules_dir,
+        plugin_root=plugin_root,
         backend=backend,
     )
     daemon.serve()

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -14,7 +14,7 @@ import time
 from pathlib import Path
 
 from ..core.protocol import parse_verdict
-from ..core.rules import Rule, load_rules
+from ..core.rules import Rule, load_rules_layered, rules_search_path
 from .inference import InferenceBackend
 
 IDLE_TIMEOUT = 30 * 60   # 30 minutes
@@ -66,12 +66,12 @@ class VaudevilleDaemon:
         self,
         socket_path: str,
         pid_file: str,
-        rules_dir: str,
+        plugin_root: str,
         backend: InferenceBackend,
     ) -> None:
         self._socket_path = socket_path
         self._pid_file = pid_file
-        self._rules_dir = rules_dir
+        self._plugin_root = plugin_root
         self._backend = backend
         self._rules: dict[str, Rule] = {}
         self._rules_lock = threading.Lock()
@@ -81,7 +81,7 @@ class VaudevilleDaemon:
     def serve(self) -> None:
         """Load rules, write PID, bind socket, serve until idle timeout."""
         with self._rules_lock:
-            self._rules = load_rules(self._rules_dir)
+            self._rules = load_rules_layered(self._plugin_root)
         logger.info("[vaudeville] Loaded %d rules", len(self._rules))
 
         Path(self._pid_file).write_text(str(os.getpid()))
@@ -144,22 +144,23 @@ class VaudevilleDaemon:
             time.sleep(RULE_POLL_INTERVAL)
             current = self._rules_mtime()
             if current != last_mtime:
-                new_rules = load_rules(self._rules_dir)
+                new_rules = load_rules_layered(self._plugin_root)
                 with self._rules_lock:
                     self._rules = new_rules
                 last_mtime = current
                 logger.info("[vaudeville] Rules reloaded (%d rules)", len(new_rules))
 
     def _rules_mtime(self) -> float:
-        try:
-            mtimes = [
-                os.path.getmtime(os.path.join(self._rules_dir, f))
-                for f in os.listdir(self._rules_dir)
-                if f.endswith(".yaml") or f.endswith(".yml")
-            ]
-            return max(mtimes) if mtimes else 0.0
-        except OSError:
-            return 0.0
+        max_mtime = 0.0
+        for rules_dir in rules_search_path(self._plugin_root):
+            try:
+                for f in os.listdir(rules_dir):
+                    if f.endswith(".yaml") or f.endswith(".yml"):
+                        mtime = os.path.getmtime(os.path.join(rules_dir, f))
+                        max_mtime = max(max_mtime, mtime)
+            except OSError:
+                continue
+        return max_mtime
 
     def _cleanup(self) -> None:
         for path in (self._socket_path, self._pid_file):


### PR DESCRIPTION
## Summary

- Rules now resolve from a three-tier search path: `project/.vaudeville/rules/` → `~/.vaudeville/rules/` → bundled defaults, with higher-priority directories overriding by rule name
- Runner, daemon, and eval harness all use the layered loader; daemon hot-reload watches all search path directories
- 4 new tests cover search path construction and project-override precedence

## Test plan

- [x] 48/48 tests pass (1 pre-existing `stop_guard` import failure excluded)
- [ ] Manual: drop a rule YAML in `project/.vaudeville/rules/` and verify it overrides the bundled default
- [ ] Manual: drop a rule YAML in `~/.vaudeville/rules/` and verify mid-priority resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)