### PR TITLE
feat: architecture-aware daemon with holistic fail-open

### DIFF
--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -17,8 +17,6 @@ import os
 import subprocess
 import sys
 
-import yaml
-
 PLUGIN_ROOT = os.environ.get(
     "CLAUDE_PLUGIN_ROOT",
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
@@ -28,6 +26,7 @@ if PLUGIN_ROOT not in sys.path:
     sys.path.insert(0, PLUGIN_ROOT)
 
 from vaudeville.core import VaudevilleClient, rules_search_path  # noqa: E402
+from vaudeville.core.client import SOCKET_TEMPLATE  # noqa: E402
 
 MIN_TEXT_LENGTH = 100
 
@@ -50,6 +49,8 @@ def _find_project_root() -> str | None:
 
 def load_rule(name: str) -> dict | None:
     """Load a rule YAML file by name, searching layered paths (project wins)."""
+    import yaml
+
     filename = f"{name}.yaml"
     project_root = _find_project_root()
     for rules_dir in reversed(rules_search_path(PLUGIN_ROOT, project_root)):
@@ -117,6 +118,15 @@ def verdict_to_hook_response(rule: dict, reason: str, action: str) -> dict:
 
 
 def main() -> None:
+    try:
+        _run()
+    except Exception as exc:
+        print(f"[vaudeville] runner crashed ({exc}) — fail open", file=sys.stderr)
+        print("{}")
+        sys.exit(0)
+
+
+def _run() -> None:
     rule_names = sys.argv[1:]
     if not rule_names:
         print("[vaudeville] runner: no rules specified", file=sys.stderr)
@@ -130,6 +140,13 @@ def main() -> None:
         sys.exit(0)
 
     session_id = hook_input.get("session_id", "unknown")
+
+    # Fast path: if daemon socket doesn't exist, skip immediately (~μs vs 8s timeout)
+    socket_path = SOCKET_TEMPLATE.format(session_id=session_id)
+    if not os.path.exists(socket_path):
+        print("{}")
+        sys.exit(0)
+
     client = VaudevilleClient(session_id)
 
     for name in rule_names:

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -8,6 +8,23 @@ set -euo pipefail
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
+# --- Architecture detection ---
+ARCH=$(uname -m)
+OS=$(uname -s)
+
+if [[ "$OS" == "Darwin" && "$ARCH" == "arm64" ]]; then
+  BACKEND="mlx"
+  DEP_GROUP="mlx"
+  MODEL_CACHE="${HOME}/.cache/huggingface/hub/models--mlx-community--Phi-3-mini-4k-instruct-4bit"
+elif [[ "$ARCH" == "x86_64" || "$ARCH" == "aarch64" ]]; then
+  BACKEND="gguf"
+  DEP_GROUP="gguf"
+  MODEL_CACHE="${HOME}/.cache/huggingface/hub/models--microsoft--Phi-3-mini-4k-instruct-gguf"
+else
+  echo "[vaudeville] Unsupported platform: ${OS}/${ARCH} — skipping daemon" >&2
+  exit 0
+fi
+
 # Read session_id from stdin JSON
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | python3 -c \
@@ -25,9 +42,8 @@ PID_FILE="/tmp/vaudeville-${SESSION_ID}.pid"
 LOG_FILE="/tmp/vaudeville-${SESSION_ID}.log"
 
 # Check if model cache exists
-MODEL_CACHE="${HOME}/.cache/huggingface/hub/models--mlx-community--Phi-3-mini-4k-instruct-4bit"
 if [ ! -d "${MODEL_CACHE}" ]; then
-  echo "[vaudeville] Model not downloaded. Run: cd ${PLUGIN_ROOT} && uv run python -m vaudeville.setup" >&2
+  echo "[vaudeville] Model not downloaded (${BACKEND}). Run: cd ${PLUGIN_ROOT} && uv run --group ${DEP_GROUP} python -m vaudeville.setup" >&2
   exit 0
 fi
 
@@ -42,13 +58,15 @@ if [ -f "${PID_FILE}" ]; then
   rm -f "${PID_FILE}" "${SOCKET_PATH}"
 fi
 
-# Spawn daemon as detached process (nohup + disown mirrors detached:true + unref())
-nohup uv run --project "${PLUGIN_ROOT}" python -m vaudeville.server \
+# Spawn daemon with platform-appropriate backend and deps
+nohup uv run --project "${PLUGIN_ROOT}" --group "${DEP_GROUP}" \
+  python -m vaudeville.server \
   --socket "${SOCKET_PATH}" \
   --pid-file "${PID_FILE}" \
+  --backend "${BACKEND}" \
   >> "${LOG_FILE}" 2>&1 &
 DAEMON_PID=$!
 disown "${DAEMON_PID}"
 
-echo "[vaudeville] Daemon spawned (PID ${DAEMON_PID}, socket ${SOCKET_PATH})" >&2
+echo "[vaudeville] Daemon spawned (${BACKEND}, PID ${DAEMON_PID}, socket ${SOCKET_PATH})" >&2
 exit 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -134,9 +134,7 @@ class TestFailOpen:
         try:
             from unittest.mock import patch
 
-            with patch(
-                "vaudeville.core.client.SOCKET_TEMPLATE", fake_socket
-            ):
+            with patch("vaudeville.core.client.SOCKET_TEMPLATE", fake_socket):
                 client = VaudevilleClient("")
                 result = client.classify("test-rule", {"text": "test"})
                 # File exists but not a real socket — should fail with connection error

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -114,6 +114,36 @@ class TestFailOpen:
         result = client.classify("violation-detector", {"text": "test"})
         assert result is None
 
+    def test_client_fast_path_missing_socket(self) -> None:
+        """Socket-exists guard returns None in <100ms, not the 1s connect timeout."""
+        import time
+
+        client = VaudevilleClient("nonexistent-fast-path-test")
+        start = time.monotonic()
+        result = client.classify("violation-detector", {"text": "test"})
+        elapsed = time.monotonic() - start
+        assert result is None
+        assert elapsed < 0.1, f"Expected <100ms, got {elapsed:.3f}s (socket timeout?)"
+
+    def test_client_fast_path_with_real_socket_file(self) -> None:
+        """When socket file exists but nothing listens, client gets ConnectionRefused."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".sock", dir="/tmp", delete=False) as f:
+            fake_socket = f.name
+        try:
+            from unittest.mock import patch
+
+            with patch(
+                "vaudeville.core.client.SOCKET_TEMPLATE", fake_socket
+            ):
+                client = VaudevilleClient("")
+                result = client.classify("test-rule", {"text": "test"})
+                # File exists but not a real socket — should fail with connection error
+                assert result is None
+        finally:
+            os.unlink(fake_socket)
+
     def test_runner_allows_when_daemon_unavailable(self) -> None:
         """runner.main() exits 0 when client returns None for all rules."""
         import importlib

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -6,8 +6,10 @@ import json
 import socket
 import threading
 import time
+from unittest.mock import patch
 
 from vaudeville.server.daemon import handle_request, VaudevilleDaemon
+from vaudeville.server.__main__ import detect_backend
 from vaudeville.core.rules import load_rules
 from conftest import MockBackend
 
@@ -184,3 +186,46 @@ class TestDaemonSocketProtocol:
         assert response["verdict"] == "clean"
         assert backend.calls == []  # backend should never be called
         daemon._stop_event.set()
+
+
+class TestDetectBackend:
+    def test_returns_mlx_on_apple_silicon(self) -> None:
+        with (
+            patch("vaudeville.server.__main__.platform") as mock_platform,
+            patch.dict("sys.modules", {"mlx_lm": __import__("os")}),
+        ):
+            mock_platform.system.return_value = "Darwin"
+            mock_platform.machine.return_value = "arm64"
+            assert detect_backend() == "mlx"
+
+    def test_returns_gguf_on_linux(self) -> None:
+        with (
+            patch("vaudeville.server.__main__.platform") as mock_platform,
+            patch.dict("sys.modules", {"llama_cpp": __import__("os")}),
+        ):
+            mock_platform.system.return_value = "Linux"
+            mock_platform.machine.return_value = "x86_64"
+            assert detect_backend() == "gguf"
+
+    def test_returns_gguf_when_mlx_unavailable(self) -> None:
+        with (
+            patch("vaudeville.server.__main__.platform") as mock_platform,
+            patch.dict(
+                "sys.modules", {"mlx_lm": None, "llama_cpp": __import__("os")}
+            ),
+        ):
+            mock_platform.system.return_value = "Darwin"
+            mock_platform.machine.return_value = "arm64"
+            assert detect_backend() == "gguf"
+
+    def test_raises_when_no_backend_available(self) -> None:
+        with (
+            patch("vaudeville.server.__main__.platform") as mock_platform,
+            patch.dict("sys.modules", {"mlx_lm": None, "llama_cpp": None}),
+        ):
+            mock_platform.system.return_value = "Linux"
+            mock_platform.machine.return_value = "x86_64"
+            import pytest
+
+            with pytest.raises(RuntimeError, match="No inference backend"):
+                detect_backend()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -210,9 +210,7 @@ class TestDetectBackend:
     def test_returns_gguf_when_mlx_unavailable(self) -> None:
         with (
             patch("vaudeville.server.__main__.platform") as mock_platform,
-            patch.dict(
-                "sys.modules", {"mlx_lm": None, "llama_cpp": __import__("os")}
-            ),
+            patch.dict("sys.modules", {"mlx_lm": None, "llama_cpp": __import__("os")}),
         ):
             mock_platform.system.return_value = "Darwin"
             mock_platform.machine.return_value = "arm64"

--- a/vaudeville/core/client.py
+++ b/vaudeville/core/client.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import socket
 
 from .protocol import ClassifyRequest, ClassifyResponse
 
 SOCKET_TEMPLATE = "/tmp/vaudeville-{session_id}.sock"
-CONNECT_TIMEOUT = 4.0  # Stay under PreToolUse 5s limit
-READ_TIMEOUT = 4.0
+CONNECT_TIMEOUT = 1.0  # Localhost socket connect is sub-ms; 1s is generous
+READ_TIMEOUT = 3.0  # Inference takes ~1-2s; 3s is sufficient
 RECV_CHUNK = 4096
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,9 @@ class VaudevilleClient:
             return None
 
     def _send(self, request: ClassifyRequest) -> ClassifyResponse:
+        if not os.path.exists(self._socket_path):
+            raise FileNotFoundError(self._socket_path)
+
         payload = json.dumps(request.to_json_dict()).encode() + b"\n"
 
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:

--- a/vaudeville/server/__main__.py
+++ b/vaudeville/server/__main__.py
@@ -10,23 +10,45 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import platform
 import sys
 from pathlib import Path
 
 from .inference import InferenceBackend
 
 
-def _init_backend(args: argparse.Namespace) -> InferenceBackend:
-    """Create the inference backend from CLI args."""
-    if args.backend == "mlx":
-        from .mlx_backend import MLXBackend
+def detect_backend() -> str:
+    """Auto-detect the best available inference backend for this platform."""
+    if platform.system() == "Darwin" and platform.machine() == "arm64":
+        try:
+            import mlx_lm  # noqa: F401
 
-        return MLXBackend(args.model)
-    elif args.backend == "gguf":
+            return "mlx"
+        except ImportError:
+            pass
+    try:
+        import llama_cpp  # noqa: F401
+
+        return "gguf"
+    except ImportError:
+        pass
+    raise RuntimeError(
+        "No inference backend available. "
+        "Install mlx-lm (Apple Silicon) or llama-cpp-python (CPU)."
+    )
+
+
+def _init_backend(backend_name: str, model: str | None) -> InferenceBackend:
+    """Create the inference backend by name."""
+    if backend_name == "mlx":
+        from .mlx_backend import DEFAULT_MODEL, MLXBackend
+
+        return MLXBackend(model or DEFAULT_MODEL)
+    elif backend_name == "gguf":
         from .gguf_backend import GGUFBackend
 
         return GGUFBackend()
-    logging.error("Unknown backend: %s", args.backend)
+    logging.error("Unknown backend: %s", backend_name)
     sys.exit(1)
 
 
@@ -35,12 +57,15 @@ def main() -> None:
     parser.add_argument("--socket", required=True, help="Unix socket path")
     parser.add_argument("--pid-file", required=True, help="PID file path")
     parser.add_argument(
-        "--backend", default="mlx", choices=["mlx", "gguf"], help="Inference backend"
+        "--backend",
+        default="auto",
+        choices=["mlx", "gguf", "auto"],
+        help="Inference backend (default: auto-detect)",
     )
     parser.add_argument(
         "--model",
-        default="mlx-community/Phi-3-mini-4k-instruct-4bit",
-        help="Model path or Hugging Face ID",
+        default=None,
+        help="Model path or Hugging Face ID (default: backend-specific)",
     )
     args = parser.parse_args()
 
@@ -50,12 +75,14 @@ def main() -> None:
         stream=sys.stderr,
     )
 
+    backend_name = args.backend if args.backend != "auto" else detect_backend()
+
     plugin_root = os.environ.get(
         "CLAUDE_PLUGIN_ROOT",
         str(Path(__file__).parent.parent.parent),
     )
-    logging.info("Loading backend: %s model=%s", args.backend, args.model)
-    backend = _init_backend(args)
+    logging.info("Loading backend: %s model=%s", backend_name, args.model or "default")
+    backend = _init_backend(backend_name, args.model)
     logging.info("Backend ready")
 
     from .daemon import VaudevilleDaemon

--- a/vaudeville/setup.py
+++ b/vaudeville/setup.py
@@ -64,8 +64,7 @@ def main() -> None:
     except ImportError as exc:
         group = "mlx" if backend == "mlx" else "gguf"
         print(
-            f"ERROR: Missing dependency ({exc}). "
-            f"Run: uv sync --group {group}",
+            f"ERROR: Missing dependency ({exc}). Run: uv sync --group {group}",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/vaudeville/setup.py
+++ b/vaudeville/setup.py
@@ -1,38 +1,75 @@
 """Model download and verification for vaudeville.
 
-Usage: uv run python -m vaudeville.setup
+Usage: uv run --group mlx python -m vaudeville.setup   # Apple Silicon
+       uv run --group gguf python -m vaudeville.setup   # CPU (Linux/x86)
 """
 
 from __future__ import annotations
 
-import os
+import platform
 import sys
 
-DEFAULT_MODEL = "mlx-community/Phi-3-mini-4k-instruct-4bit"
-EXPECTED_SIZE_GB = 2.4
+
+def _detect_platform() -> str:
+    """Detect which backend this platform should use."""
+    if platform.system() == "Darwin" and platform.machine() == "arm64":
+        return "mlx"
+    return "gguf"
+
+
+def _setup_mlx() -> None:
+    from mlx_lm import generate, load
+
+    model_id = "mlx-community/Phi-3-mini-4k-instruct-4bit"
+    print(f"Downloading {model_id} (~2.4 GB, Apple Silicon int4)...")
+    model_obj, tokenizer = load(model_id)  # type: ignore[misc]
+    print("Model loaded. Verifying inference...")
+    _ = generate(
+        model_obj, tokenizer, prompt="VERDICT: clean", max_tokens=5, verbose=False
+    )
+    print("Inference verified.")
+
+
+def _setup_gguf() -> None:
+    from huggingface_hub import hf_hub_download
+
+    repo_id = "microsoft/Phi-3-mini-4k-instruct-gguf"
+    filename = "Phi-3-mini-4k-instruct-q4.gguf"
+    print(f"Downloading {repo_id}/{filename} (~2.3 GB, CPU Q4)...")
+    model_path = hf_hub_download(repo_id=repo_id, filename=filename)
+    print(f"Model cached at {model_path}. Verifying inference...")
+
+    from llama_cpp import Llama
+
+    llm = Llama(model_path=model_path, n_ctx=512, n_gpu_layers=0, verbose=False)
+    response = llm.create_chat_completion(
+        messages=[{"role": "user", "content": "VERDICT: clean"}],
+        max_tokens=5,
+        temperature=0.0,
+    )
+    _ = response["choices"][0]["message"]["content"]
+    print("Inference verified.")
 
 
 def main() -> None:
-    model = os.environ.get("VAUDEVILLE_MODEL", DEFAULT_MODEL)
-    print(f"Downloading {model} (~{EXPECTED_SIZE_GB} GB, Apple Silicon int4)...")
-    print("This is a one-time setup step.")
+    backend = _detect_platform()
+    print(f"Detected platform: {platform.system()}/{platform.machine()} → {backend}")
+    print("This is a one-time setup step.\n")
 
     try:
-        from mlx_lm import load
-    except ImportError:
-        print("ERROR: mlx-lm not installed. Run: uv sync", file=sys.stderr)
+        if backend == "mlx":
+            _setup_mlx()
+        else:
+            _setup_gguf()
+    except ImportError as exc:
+        group = "mlx" if backend == "mlx" else "gguf"
+        print(
+            f"ERROR: Missing dependency ({exc}). "
+            f"Run: uv sync --group {group}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
-    print("Fetching model from Hugging Face hub...")
-    model_obj, tokenizer = load(model)  # type: ignore[misc]
-    print("Model loaded successfully.")
-
-    # Verify inference with a short prompt
-    from mlx_lm import generate
-
-    test_prompt = "VERDICT: clean\nREASON: test"
-    _ = generate(model_obj, tokenizer, prompt=test_prompt, max_tokens=5, verbose=False)
-    print("Inference verified.")
     print("\nSetup complete. Vaudeville is ready.")
 
 


### PR DESCRIPTION
## Summary

- Fixes conductor worktree agents hanging on Stop hook by adding 3 layers of fail-open protection: socket-exists fast path in runner.py (~μs vs 8s timeout), `os.path.exists` guard in client.py with reduced timeouts (4s→1s connect), and arch detection in session-start.sh
- Auto-detects inference backend via `detect_backend()` — MLX on Apple Silicon, GGUF (llama-cpp-python) on everything else, with clear error when neither is available
- Makes `setup.py` platform-aware: downloads MLX model on Apple Silicon, GGUF Q4 weights on CPU platforms

## Test plan

- [x] `uv run pytest -v` — 56/56 passing (6 new tests)
- [x] `uv run mypy --strict vaudeville/` — clean
- [ ] Verify conductor agents no longer hang on Stop hook (cairo-v1, lima-v1)
- [ ] Verify `session-start.sh` detects `mlx` on macOS ARM64 and `gguf` on Linux x86_64

🤖 Generated with [Claude Code](https://claude.com/claude-code)