### PR TITLE
fix: defer yaml/rules imports in runner for bare python3 fail-open

### DIFF
--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -25,8 +25,12 @@ PLUGIN_ROOT = os.environ.get(
 if PLUGIN_ROOT not in sys.path:
     sys.path.insert(0, PLUGIN_ROOT)
 
-from vaudeville.core import VaudevilleClient, rules_search_path  # noqa: E402
-from vaudeville.core.client import SOCKET_TEMPLATE  # noqa: E402
+try:
+    from vaudeville.core.client import SOCKET_TEMPLATE, VaudevilleClient  # noqa: E402
+except ImportError as _exc:
+    print(f"[vaudeville] cannot import client ({_exc}) — fail open", file=sys.stderr)
+    print("{}")
+    sys.exit(0)
 
 MIN_TEXT_LENGTH = 100
 
@@ -49,7 +53,9 @@ def _find_project_root() -> str | None:
 
 def load_rule(name: str) -> dict | None:
     """Load a rule YAML file by name, searching layered paths (project wins)."""
-    import yaml
+    import yaml  # deferred — only needed when daemon socket exists
+
+    from vaudeville.core.rules import rules_search_path  # noqa: E402
 
     filename = f"{name}.yaml"
     project_root = _find_project_root()
@@ -141,7 +147,7 @@ def _run() -> None:
 
     session_id = hook_input.get("session_id", "unknown")
 
-    # Fast path: if daemon socket doesn't exist, skip immediately (~μs vs 8s timeout)
+    # Fast path: if daemon socket doesn't exist, skip (~μs vs timeout)
     socket_path = SOCKET_TEMPLATE.format(session_id=session_id)
     if not os.path.exists(socket_path):
         print("{}")
@@ -172,4 +178,9 @@ def _run() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as exc:
+        print(f"[vaudeville] runner crashed ({exc}) — fail open", file=sys.stderr)
+        print("{}")
+        sys.exit(0)


### PR DESCRIPTION
## Summary

- Fixes conductor worktree agents still hanging despite PR #6: `from vaudeville.core import rules_search_path` at module level triggers the yaml import chain, crashing on bare `python3` without PyYAML
- Defers both `yaml` and `rules_search_path` imports into `load_rule()` — they only execute after the socket-exists fast path confirms the daemon is running
- Wraps the `vaudeville.core.client` import in try/except for defense-in-depth

## Root cause

```
hooks/runner.py line 28:
  from vaudeville.core import VaudevilleClient, rules_search_path
    → vaudeville/core/__init__.py re-exports from .rules
      → vaudeville/core/rules.py: import yaml  ← ModuleNotFoundError
```

The `main()` fail-open wrapper never runs because the crash is at import time.

## Test plan

- [x] `uv run pytest -v` — 56/56 passing
- [x] `uv run ruff check . && ruff format --check .` — clean
- [x] `uv run mypy --strict vaudeville/` — clean
- [ ] Verify `python3 hooks/runner.py violation-detector < test-input.json` exits 0 without PyYAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)