### PR TITLE
fix(daemon): serialize backend access and harden daemon lifecycle

### DIFF
--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -16,8 +16,6 @@ import json
 import os
 import sys
 
-import yaml
-
 PLUGIN_ROOT = os.environ.get(
     "CLAUDE_PLUGIN_ROOT",
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
@@ -64,6 +62,8 @@ def _rules_search_path() -> list[str]:
 
 def load_rule(name: str) -> dict | None:
     """Load a rule YAML file by name, searching layered paths (project wins)."""
+    import yaml
+
     filename = f"{name}.yaml"
     # Walk search path in reverse so highest priority wins
     for rules_dir in reversed(_rules_search_path()):

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -26,6 +26,7 @@ if [ ! -d "${MODEL_CACHE}" ]; then
 fi
 
 # Check if daemon already running for this session
+# Daemon uses fcntl PID lock (self-healing on crash) — this check is defense-in-depth
 if [ -f "${PID_FILE}" ]; then
   PID=$(cat "${PID_FILE}" 2>/dev/null || echo "")
   if [ -n "${PID}" ] && kill -0 "${PID}" 2>/dev/null; then

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import signal
 import socket
 import threading
 import time
@@ -103,23 +105,29 @@ class TestDaemonSocketProtocol:
         import tempfile
 
         # Unix sockets have a 104-char path limit on macOS — use /tmp directly
-        with tempfile.NamedTemporaryFile(suffix=".sock", dir="/tmp", delete=False) as f:
+        with tempfile.NamedTemporaryFile(suffix=".sock", dir=tempfile.gettempdir(), delete=False) as f:
             socket_path = f.name
-        with tempfile.NamedTemporaryFile(suffix=".pid", dir="/tmp", delete=False) as f:
+        with tempfile.NamedTemporaryFile(suffix=".pid", dir=tempfile.gettempdir(), delete=False) as f:
             pid_file = f.name
-        import os
-
         os.unlink(socket_path)  # daemon will re-create it
         backend = MockBackend(verdict="clean", reason="socket test")
-
-        import os
-
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(socket_path, pid_file, plugin_root, backend)
 
         thread = threading.Thread(target=daemon.serve, daemon=True)
         thread.start()
-        time.sleep(0.2)  # Brief pause for socket to bind
+
+        # Wait for daemon socket to be ready
+        for _ in range(20):
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                    probe.settimeout(0.1)
+                    probe.connect(socket_path)
+                    break
+            except (ConnectionRefusedError, FileNotFoundError):
+                time.sleep(0.05)
+        else:
+            raise RuntimeError("Daemon socket not ready after 1s")
 
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
             sock.settimeout(3.0)
@@ -145,3 +153,96 @@ class TestDaemonSocketProtocol:
         response = json.loads(data.decode().strip())
         assert response["verdict"] == "clean"
         daemon._stop_event.set()
+
+
+class TestBackendLockSerialization:
+    def test_concurrent_requests_are_serialized(self) -> None:
+        """Verify that backend.classify() calls don't overlap."""
+        import tempfile
+
+        call_log: list[tuple[float, float]] = []
+        lock = threading.Lock()
+
+        class SlowBackend:
+            def classify(self, prompt: str, max_tokens: int = 50) -> str:  # noqa: ARG002
+                start = time.monotonic()
+                time.sleep(0.05)
+                end = time.monotonic()
+                with lock:
+                    call_log.append((start, end))
+                return "VERDICT: clean\nREASON: ok"
+
+        with tempfile.NamedTemporaryFile(suffix=".sock", dir=tempfile.gettempdir(), delete=False) as f:
+            socket_path = f.name
+        with tempfile.NamedTemporaryFile(suffix=".pid", dir=tempfile.gettempdir(), delete=False) as f:
+            pid_file = f.name
+        os.unlink(socket_path)
+
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        daemon = VaudevilleDaemon(socket_path, pid_file, plugin_root, SlowBackend())
+
+        thread = threading.Thread(target=daemon.serve, daemon=True)
+        thread.start()
+
+        # Wait for ready
+        for _ in range(20):
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                    probe.settimeout(0.1)
+                    probe.connect(socket_path)
+                    break
+            except (ConnectionRefusedError, FileNotFoundError):
+                time.sleep(0.05)
+
+        def send_request() -> None:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.settimeout(3.0)
+                sock.connect(socket_path)
+                payload = (
+                    json.dumps({"rule": "violation-detector", "input": {"text": "test"}}).encode()
+                    + b"\n"
+                )
+                sock.sendall(payload)
+                while True:
+                    chunk = sock.recv(4096)
+                    if not chunk or b"\n" in chunk:
+                        break
+
+        threads = [threading.Thread(target=send_request) for _ in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        daemon._stop_event.set()
+
+        # Verify no overlapping time windows
+        assert len(call_log) == 3
+        sorted_calls = sorted(call_log)
+        for i in range(len(sorted_calls) - 1):
+            assert sorted_calls[i][1] <= sorted_calls[i + 1][0] + 0.01, \
+                f"Calls overlapped: {sorted_calls[i]} and {sorted_calls[i + 1]}"
+
+
+class TestSignalHandlers:
+    def test_sigterm_sets_stop_event(self) -> None:
+        """Verify SIGTERM triggers graceful shutdown via _stop_event."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".sock", dir=tempfile.gettempdir(), delete=False) as f:
+            socket_path = f.name
+        with tempfile.NamedTemporaryFile(suffix=".pid", dir=tempfile.gettempdir(), delete=False) as f:
+            pid_file = f.name
+        os.unlink(socket_path)
+
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        backend = MockBackend()
+        daemon = VaudevilleDaemon(socket_path, pid_file, plugin_root, backend)
+
+        # Install handlers (normally done by serve())
+        daemon._install_signal_handlers()
+        assert not daemon._stop_event.is_set()
+
+        # Send SIGTERM to ourselves
+        os.kill(os.getpid(), signal.SIGTERM)
+        assert daemon._stop_event.is_set()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -105,9 +105,13 @@ class TestDaemonSocketProtocol:
         import tempfile
 
         # Unix sockets have a 104-char path limit on macOS — use /tmp directly
-        with tempfile.NamedTemporaryFile(suffix=".sock", dir=tempfile.gettempdir(), delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            suffix=".sock", dir=tempfile.gettempdir(), delete=False
+        ) as f:
             socket_path = f.name
-        with tempfile.NamedTemporaryFile(suffix=".pid", dir=tempfile.gettempdir(), delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            suffix=".pid", dir=tempfile.gettempdir(), delete=False
+        ) as f:
             pid_file = f.name
         os.unlink(socket_path)  # daemon will re-create it
         backend = MockBackend(verdict="clean", reason="socket test")
@@ -172,9 +176,13 @@ class TestBackendLockSerialization:
                     call_log.append((start, end))
                 return "VERDICT: clean\nREASON: ok"
 
-        with tempfile.NamedTemporaryFile(suffix=".sock", dir=tempfile.gettempdir(), delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            suffix=".sock", dir=tempfile.gettempdir(), delete=False
+        ) as f:
             socket_path = f.name
-        with tempfile.NamedTemporaryFile(suffix=".pid", dir=tempfile.gettempdir(), delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            suffix=".pid", dir=tempfile.gettempdir(), delete=False
+        ) as f:
             pid_file = f.name
         os.unlink(socket_path)
 
@@ -199,7 +207,9 @@ class TestBackendLockSerialization:
                 sock.settimeout(3.0)
                 sock.connect(socket_path)
                 payload = (
-                    json.dumps({"rule": "violation-detector", "input": {"text": "test"}}).encode()
+                    json.dumps(
+                        {"rule": "violation-detector", "input": {"text": "test"}}
+                    ).encode()
                     + b"\n"
                 )
                 sock.sendall(payload)
@@ -220,8 +230,9 @@ class TestBackendLockSerialization:
         assert len(call_log) == 3
         sorted_calls = sorted(call_log)
         for i in range(len(sorted_calls) - 1):
-            assert sorted_calls[i][1] <= sorted_calls[i + 1][0] + 0.01, \
+            assert sorted_calls[i][1] <= sorted_calls[i + 1][0] + 0.01, (
                 f"Calls overlapped: {sorted_calls[i]} and {sorted_calls[i + 1]}"
+            )
 
 
 class TestSignalHandlers:
@@ -229,9 +240,13 @@ class TestSignalHandlers:
         """Verify SIGTERM triggers graceful shutdown via _stop_event."""
         import tempfile
 
-        with tempfile.NamedTemporaryFile(suffix=".sock", dir=tempfile.gettempdir(), delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            suffix=".sock", dir=tempfile.gettempdir(), delete=False
+        ) as f:
             socket_path = f.name
-        with tempfile.NamedTemporaryFile(suffix=".pid", dir=tempfile.gettempdir(), delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            suffix=".pid", dir=tempfile.gettempdir(), delete=False
+        ) as f:
             pid_file = f.name
         os.unlink(socket_path)
 

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -6,13 +6,14 @@ Hot-reloads rules on file change. Self-terminates after idle timeout.
 
 from __future__ import annotations
 
+import fcntl
 import json
 import logging
 import os
+import signal
 import socket
 import threading
 import time
-from pathlib import Path
 
 from ..core.protocol import parse_verdict
 from ..core.rules import Rule, load_rules_layered, rules_search_path
@@ -21,6 +22,8 @@ from .inference import InferenceBackend
 IDLE_TIMEOUT = 30 * 60  # 30 minutes
 RULE_POLL_INTERVAL = 30  # seconds
 RECV_CHUNK = 4096
+THREAD_WARN = 20
+THREAD_KILL = 50
 
 logger = logging.getLogger(__name__)
 
@@ -85,25 +88,55 @@ class VaudevilleDaemon:
         self._backend = backend
         self._rules: dict[str, Rule] = {}
         self._rules_lock = threading.Lock()
+        self._backend_lock = threading.Lock()
         self._last_request = time.monotonic()
         self._stop_event = threading.Event()
+        self._reload_event = threading.Event()
+        self._pid_fd: int | None = None
+
+    def _install_signal_handlers(self) -> None:
+        signal.signal(signal.SIGTERM, self._handle_signal)
+        signal.signal(signal.SIGINT, self._handle_signal)
+        signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+        signal.signal(signal.SIGHUP, self._handle_reload)
+
+    def _handle_signal(self, _signum: int, _frame: object) -> None:
+        self._stop_event.set()
+
+    def _handle_reload(self, _signum: int, _frame: object) -> None:
+        self._reload_event.set()
 
     def serve(self) -> None:
         """Load rules, write PID, bind socket, serve until idle timeout."""
+        if threading.current_thread() is threading.main_thread():
+            self._install_signal_handlers()
+
         with self._rules_lock:
             self._rules = load_rules_layered(self._plugin_root)
         logger.info("[vaudeville] Loaded %d rules", len(self._rules))
 
-        Path(self._pid_file).write_text(str(os.getpid()))
+        pid_fd = os.open(self._pid_file, os.O_WRONLY | os.O_CREAT, 0o644)
+        try:
+            fcntl.flock(pid_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            os.close(pid_fd)
+            logger.info("[vaudeville] Another instance holds PID lock — exiting")
+            return
+        os.ftruncate(pid_fd, 0)
+        os.write(pid_fd, f"{os.getpid()}\n".encode())
+        self._pid_fd = pid_fd
 
         server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        if os.path.exists(self._socket_path):
+        try:
             os.unlink(self._socket_path)
+        except FileNotFoundError:
+            pass
         server_socket.bind(self._socket_path)
         server_socket.listen(16)
         server_socket.settimeout(1.0)
 
         threading.Thread(target=self._watch_rules, daemon=True).start()
+        threading.Thread(target=self._watch_threads, daemon=True).start()
         logger.info("[vaudeville] Listening on %s", self._socket_path)
 
         try:
@@ -114,6 +147,12 @@ class VaudevilleDaemon:
 
     def _accept_loop(self, server_socket: socket.socket) -> None:
         while not self._stop_event.is_set():
+            if self._reload_event.is_set():
+                self._reload_event.clear()
+                new_rules = load_rules_layered(self._plugin_root)
+                with self._rules_lock:
+                    self._rules = new_rules
+                logger.info("[vaudeville] Rules reloaded via SIGHUP (%d rules)", len(new_rules))
             idle = time.monotonic() - self._last_request
             if idle > IDLE_TIMEOUT:
                 logger.info("[vaudeville] Idle timeout — shutting down")
@@ -128,6 +167,7 @@ class VaudevilleDaemon:
 
     def _handle_client(self, conn: socket.socket) -> None:
         try:
+            t0 = time.monotonic()
             data = b""
             while True:
                 chunk = conn.recv(RECV_CHUNK)
@@ -140,8 +180,11 @@ class VaudevilleDaemon:
             with self._rules_lock:
                 current_rules = dict(self._rules)
 
-            response = handle_request(data, current_rules, self._backend)
+            with self._backend_lock:
+                response = handle_request(data, current_rules, self._backend)
             conn.sendall(response)
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            logger.info("[vaudeville] Request handled in %.1fms", elapsed_ms)
             self._last_request = time.monotonic()
         except Exception as exc:
             logger.error("[vaudeville] Client handler error: %s", exc)
@@ -172,7 +215,20 @@ class VaudevilleDaemon:
                 continue
         return max_mtime
 
+    def _watch_threads(self) -> None:
+        while not self._stop_event.is_set():
+            time.sleep(10)
+            count = threading.active_count()
+            if count > THREAD_KILL:
+                logger.error("[vaudeville] Thread count %d exceeds kill threshold — shutting down", count)
+                self._stop_event.set()
+            elif count > THREAD_WARN:
+                logger.warning("[vaudeville] Thread count %d exceeds warning threshold", count)
+
     def _cleanup(self) -> None:
+        if self._pid_fd is not None:
+            os.close(self._pid_fd)
+            self._pid_fd = None
         for path in (self._socket_path, self._pid_file):
             try:
                 os.unlink(path)

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -152,7 +152,9 @@ class VaudevilleDaemon:
                 new_rules = load_rules_layered(self._plugin_root)
                 with self._rules_lock:
                     self._rules = new_rules
-                logger.info("[vaudeville] Rules reloaded via SIGHUP (%d rules)", len(new_rules))
+                logger.info(
+                    "[vaudeville] Rules reloaded via SIGHUP (%d rules)", len(new_rules)
+                )
             idle = time.monotonic() - self._last_request
             if idle > IDLE_TIMEOUT:
                 logger.info("[vaudeville] Idle timeout — shutting down")
@@ -220,10 +222,15 @@ class VaudevilleDaemon:
             time.sleep(10)
             count = threading.active_count()
             if count > THREAD_KILL:
-                logger.error("[vaudeville] Thread count %d exceeds kill threshold — shutting down", count)
+                logger.error(
+                    "[vaudeville] Thread count %d exceeds kill threshold — shutting down",
+                    count,
+                )
                 self._stop_event.set()
             elif count > THREAD_WARN:
-                logger.warning("[vaudeville] Thread count %d exceeds warning threshold", count)
+                logger.warning(
+                    "[vaudeville] Thread count %d exceeds warning threshold", count
+                )
 
     def _cleanup(self) -> None:
         if self._pid_fd is not None:


### PR DESCRIPTION
## Summary

- **P0 — Correctness**: Add `threading.Lock` to serialize MLX backend access (root cause of Metal assertion crashes), install signal handlers (SIGTERM/SIGINT/SIGPIPE) for graceful shutdown, fix TOCTOU race in socket cleanup, defer `import yaml` in `runner.py` so hooks don't crash on system Python without PyYAML
- **P1 — Resilience**: Replace naive PID file write with `fcntl.flock()` exclusive lock (OS releases on crash — self-healing), add SIGHUP handler for manual rule reload
- **P2 — Operational**: Request latency logging via `time.monotonic()`, thread count watchdog (warn >20, kill >50)

## Changed files

| File | Changes |
|------|---------|
| `vaudeville/server/daemon.py` | Backend lock, signal handlers, fcntl PID lock, TOCTOU fix, latency logging, SIGHUP reload, thread watchdog |
| `hooks/runner.py` | Deferred `import yaml` into `load_rule()` |
| `hooks/session-start.sh` | Comment explaining fcntl PID lock interaction |
| `tests/test_daemon.py` | Socket-polling readiness (replaces `time.sleep`), backend serialization test, signal handler test |

## Test plan

- [x] `uv run pytest tests/test_daemon.py -v` — 9/9 pass
- [x] `uv run ruff check .` — clean
- [ ] Manual: start daemon, send concurrent requests, verify no Metal crash
- [ ] Manual: `kill -TERM <pid>` — verify clean shutdown + file cleanup
- [ ] Manual: `kill -HUP <pid>` — verify rule reload log message

🤖 Generated with [Claude Code](https://claude.com/claude-code)