### PR TITLE
feat(daemon): global singleton with version-stamp restart

### DIFF
--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -144,8 +144,7 @@ def main() -> None:
         print("{}")
         sys.exit(0)
 
-    session_id = hook_input.get("session_id", "unknown")
-    client = VaudevilleClient(session_id)
+    client = VaudevilleClient()
 
     for name in rule_names:
         rule = load_rule(name)

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -10,10 +10,14 @@ PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 # Always read stdin (Claude Code sends JSON; not reading causes SIGPIPE)
 INPUT=$(cat)
 
-SOCKET_PATH="/tmp/vaudeville.sock"
-PID_FILE="/tmp/vaudeville.pid"
-LOG_FILE="/tmp/vaudeville.log"
-VERSION_FILE="/tmp/vaudeville.version"
+# Per-UID runtime directory (0700) prevents other users from intercepting socket
+RUNTIME_DIR="/tmp/vaudeville-$(id -u)"
+mkdir -m 0700 "${RUNTIME_DIR}" 2>/dev/null || true
+
+SOCKET_PATH="${RUNTIME_DIR}/vaudeville.sock"
+PID_FILE="${RUNTIME_DIR}/vaudeville.pid"
+LOG_FILE="${RUNTIME_DIR}/vaudeville.log"
+VERSION_FILE="${RUNTIME_DIR}/vaudeville.version"
 
 # Check if model cache exists
 MODEL_CACHE="${HOME}/.cache/huggingface/hub/models--mlx-community--Phi-3-mini-4k-instruct-4bit"

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -1,22 +1,19 @@
 #!/usr/bin/env bash
-# Spawns the vaudeville inference daemon as a detached process.
-# Called on SessionStart. Reads session_id from stdin JSON.
-# Daemon binds to /tmp/vaudeville-{session_id}.sock.
+# Spawns the vaudeville inference daemon as a global singleton.
+# Called on SessionStart. Reads stdin to avoid SIGPIPE.
 # Fails open — if anything goes wrong, session continues normally.
 
 set -euo pipefail
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
-# Read session_id from stdin JSON
+# Always read stdin (Claude Code sends JSON; not reading causes SIGPIPE)
 INPUT=$(cat)
-SESSION_ID=$(echo "$INPUT" | python3 -c \
-  "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" \
-  2>/dev/null || echo "unknown")
 
-SOCKET_PATH="/tmp/vaudeville-${SESSION_ID}.sock"
-PID_FILE="/tmp/vaudeville-${SESSION_ID}.pid"
-LOG_FILE="/tmp/vaudeville-${SESSION_ID}.log"
+SOCKET_PATH="/tmp/vaudeville.sock"
+PID_FILE="/tmp/vaudeville.pid"
+LOG_FILE="/tmp/vaudeville.log"
+VERSION_FILE="/tmp/vaudeville.version"
 
 # Check if model cache exists
 MODEL_CACHE="${HOME}/.cache/huggingface/hub/models--mlx-community--Phi-3-mini-4k-instruct-4bit"
@@ -25,19 +22,40 @@ if [ ! -d "${MODEL_CACHE}" ]; then
   exit 0
 fi
 
-# Check if daemon already running for this session
-# Daemon uses fcntl PID lock (self-healing on crash) — this check is defense-in-depth
+# Compute current version stamp
+CURRENT_VERSION=$(git -C "${PLUGIN_ROOT}" rev-parse HEAD 2>/dev/null || echo "unknown")
+
+# Check if daemon is already running
 if [ -f "${PID_FILE}" ]; then
   PID=$(cat "${PID_FILE}" 2>/dev/null || echo "")
   if [ -n "${PID}" ] && kill -0 "${PID}" 2>/dev/null; then
-    echo "[vaudeville] Daemon already running (PID ${PID})" >&2
-    exit 0
+    # Daemon alive — check version
+    RUNNING_VERSION=$(cat "${VERSION_FILE}" 2>/dev/null || echo "")
+    if [ "${RUNNING_VERSION}" = "${CURRENT_VERSION}" ]; then
+      echo "[vaudeville] Daemon up to date (PID ${PID})" >&2
+      exit 0
+    fi
+    # Version mismatch — restart daemon
+    echo "[vaudeville] Version mismatch — restarting daemon (PID ${PID})" >&2
+    kill "${PID}" 2>/dev/null || true
+    # Wait up to 2s for socket to disappear (20 x 0.1s)
+    for i in $(seq 1 20); do
+      [ ! -S "${SOCKET_PATH}" ] && break
+      sleep 0.1
+    done
+    # Force kill if still alive
+    if kill -0 "${PID}" 2>/dev/null; then
+      kill -9 "${PID}" 2>/dev/null || true
+    fi
+    rm -f "${SOCKET_PATH}" "${PID_FILE}" "${VERSION_FILE}"
+  else
+    # Stale PID — clean up
+    echo "[vaudeville] Stale PID ${PID} — cleaning up" >&2
+    rm -f "${SOCKET_PATH}" "${PID_FILE}" "${VERSION_FILE}"
   fi
-  # Stale PID — clean up
-  rm -f "${PID_FILE}" "${SOCKET_PATH}"
 fi
 
-# Spawn daemon as detached process (nohup + disown mirrors detached:true + unref())
+# Spawn daemon as detached process
 nohup uv run --project "${PLUGIN_ROOT}" python -m vaudeville.server \
   --socket "${SOCKET_PATH}" \
   --pid-file "${PID_FILE}" \

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -31,7 +31,7 @@ if [ -f "${PID_FILE}" ]; then
   if [ -n "${PID}" ] && kill -0 "${PID}" 2>/dev/null; then
     # Daemon alive — check version
     RUNNING_VERSION=$(cat "${VERSION_FILE}" 2>/dev/null || echo "")
-    if [ "${RUNNING_VERSION}" = "${CURRENT_VERSION}" ]; then
+    if [ -z "${RUNNING_VERSION}" ] || [ "${RUNNING_VERSION}" = "${CURRENT_VERSION}" ]; then
       echo "[vaudeville] Daemon up to date (PID ${PID})" >&2
       exit 0
     fi
@@ -47,11 +47,11 @@ if [ -f "${PID_FILE}" ]; then
     if kill -0 "${PID}" 2>/dev/null; then
       kill -9 "${PID}" 2>/dev/null || true
     fi
-    rm -f "${SOCKET_PATH}" "${PID_FILE}" "${VERSION_FILE}"
+    rm -f "${SOCKET_PATH}" "${PID_FILE}" "${VERSION_FILE}" || true
   else
     # Stale PID — clean up
     echo "[vaudeville] Stale PID ${PID} — cleaning up" >&2
-    rm -f "${SOCKET_PATH}" "${PID_FILE}" "${VERSION_FILE}"
+    rm -f "${SOCKET_PATH}" "${PID_FILE}" "${VERSION_FILE}" || true
   fi
 fi
 

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -62,7 +62,7 @@ def _ready_daemon(
     raise RuntimeError(f"Daemon socket {socket_path} not ready within {timeout}s")
 
 
-def _send_request(sock_path: str, payload: bytes) -> dict:
+def _send_request(sock_path: str, payload: bytes) -> dict[str, object]:
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
         sock.settimeout(3.0)
         sock.connect(sock_path)
@@ -73,7 +73,8 @@ def _send_request(sock_path: str, payload: bytes) -> dict:
             if not chunk or b"\n" in data + chunk:
                 data += chunk
                 break
-    return json.loads(data.decode().strip())
+    result: dict[str, object] = json.loads(data.decode().strip())
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -382,7 +383,7 @@ class TestShutdownRace:
             + b"\n"
         )
 
-        results: list[dict] = []
+        results: list[dict[str, object]] = []
         errors: list[Exception] = []
 
         def send() -> None:
@@ -627,7 +628,7 @@ class TestBackendLockContention:
             + b"\n"
         )
 
-        responses: list[dict] = []
+        responses: list[dict[str, object]] = []
         errors: list[Exception] = []
         lock = threading.Lock()
 

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -1,0 +1,849 @@
+"""Adversarial tests for the singleton daemon migration.
+
+Attack vectors:
+1. Version stamp race (two session-start.sh racing)
+2. Version file permissions (not writable)
+3. Git not available (_write_version_stamp fallback)
+4. Socket path collision (request arrives during shutdown)
+5. PID file contains garbage (non-numeric content)
+6. Daemon cleanup interrupted (SIGKILL leaves version file)
+7. Backend lock contention (many simultaneous classify calls)
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+from vaudeville.server.daemon import VERSION_FILE, VaudevilleDaemon, handle_request
+from conftest import MockBackend
+
+
+def _make_daemon(
+    socket_path: str,
+    pid_file: str,
+    version_file: str = VERSION_FILE,
+) -> VaudevilleDaemon:
+    plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return VaudevilleDaemon(
+        socket_path, pid_file, plugin_root, MockBackend(), version_file=version_file
+    )
+
+
+def _ready_daemon(
+    socket_path: str,
+    pid_file: str,
+    version_file: str = VERSION_FILE,
+    timeout: float = 2.0,
+) -> tuple[VaudevilleDaemon, threading.Thread]:
+    """Spin up a daemon and block until the socket is ready."""
+    daemon = _make_daemon(socket_path, pid_file, version_file)
+    thread = threading.Thread(target=daemon.serve, daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                probe.settimeout(0.1)
+                probe.connect(socket_path)
+            return daemon, thread
+        except (ConnectionRefusedError, FileNotFoundError, OSError):
+            time.sleep(0.05)
+
+    daemon._stop_event.set()
+    raise RuntimeError(f"Daemon socket {socket_path} not ready within {timeout}s")
+
+
+def _send_request(sock_path: str, payload: bytes) -> dict:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+        sock.settimeout(3.0)
+        sock.connect(sock_path)
+        sock.sendall(payload)
+        data = b""
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk or b"\n" in data + chunk:
+                data += chunk
+                break
+    return json.loads(data.decode().strip())
+
+
+# ---------------------------------------------------------------------------
+# Attack 1: Version stamp race — two instances try to write VERSION_FILE
+# ---------------------------------------------------------------------------
+
+
+class TestVersionStampRace:
+    def test_pid_lock_prevents_second_daemon_from_writing_version(self) -> None:
+        """Second daemon attempt must not overwrite version file of winner."""
+        with (
+            tempfile.NamedTemporaryFile(
+                suffix=".sock", dir=tempfile.gettempdir(), delete=False
+            ) as f1,
+            tempfile.NamedTemporaryFile(
+                suffix=".pid", dir=tempfile.gettempdir(), delete=False
+            ) as fp,
+            tempfile.NamedTemporaryFile(
+                suffix=".version", dir=tempfile.gettempdir(), delete=False
+            ) as fv,
+        ):
+            socket_path = f1.name
+            pid_file = fp.name
+            version_file = fv.name
+        os.unlink(socket_path)
+
+        daemon1, thread1 = _ready_daemon(socket_path, pid_file, version_file)
+
+        try:
+            version_after_winner = open(version_file).read().strip()
+            assert version_after_winner != "", "winner must write a non-empty version"
+
+            # Second daemon with SAME pid_file — should bail after PID lock conflict
+            with tempfile.NamedTemporaryFile(
+                suffix=".sock2", dir=tempfile.gettempdir(), delete=False
+            ) as f2:
+                socket_path2 = f2.name
+            os.unlink(socket_path2)
+
+            plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            daemon2 = VaudevilleDaemon(
+                socket_path2, pid_file, plugin_root, MockBackend(),
+                version_file=version_file,
+            )
+            # serve() should return immediately due to PID lock held by daemon1
+            thread2 = threading.Thread(target=daemon2.serve, daemon=True)
+            thread2.start()
+            thread2.join(timeout=3.0)
+            assert not thread2.is_alive(), "loser daemon should have exited"
+
+            # Version file must still belong to daemon1
+            assert open(version_file).read().strip() == version_after_winner
+        finally:
+            daemon1._stop_event.set()
+            thread1.join(timeout=3)
+
+    def test_version_file_not_present_until_pid_lock_acquired(self) -> None:
+        """_write_version_stamp() is called AFTER the PID lock, not before."""
+        events: list[str] = []
+
+        class TracingBackend:
+            def classify(self, prompt: str, max_tokens: int = 50) -> str:
+                return "VERDICT: clean\nREASON: ok"
+
+        with (
+            tempfile.NamedTemporaryFile(
+                suffix=".sock", dir=tempfile.gettempdir(), delete=False
+            ) as f,
+            tempfile.NamedTemporaryFile(
+                suffix=".pid", dir=tempfile.gettempdir(), delete=False
+            ) as fp,
+            tempfile.NamedTemporaryFile(
+                suffix=".version", dir=tempfile.gettempdir(), delete=False
+            ) as fv,
+        ):
+            socket_path = f.name
+            pid_file = fp.name
+            version_file = fv.name
+        os.unlink(socket_path)
+        os.unlink(version_file)
+
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        daemon = VaudevilleDaemon(
+            socket_path, pid_file, plugin_root, TracingBackend(),
+            version_file=version_file,
+        )
+
+        original_write = daemon._write_version_stamp
+
+        def patched_write() -> None:
+            # At this point PID lock is held; version file must NOT exist yet
+            events.append("write_version_called")
+            original_write()
+
+        daemon._write_version_stamp = patched_write  # type: ignore[method-assign]
+        thread = threading.Thread(target=daemon.serve, daemon=True)
+        thread.start()
+
+        for _ in range(40):
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                    probe.settimeout(0.1)
+                    probe.connect(socket_path)
+                    break
+            except (ConnectionRefusedError, FileNotFoundError, OSError):
+                time.sleep(0.05)
+
+        daemon._stop_event.set()
+        thread.join(timeout=3)
+
+        assert "write_version_called" in events, "_write_version_stamp never called"
+
+
+# ---------------------------------------------------------------------------
+# Attack 2: Version file not writable
+# ---------------------------------------------------------------------------
+
+
+class TestVersionFilePermissions:
+    def test_write_version_stamp_fails_open_on_permission_error(self) -> None:
+        """If VERSION_FILE is not writable, serve() must not crash."""
+        with (
+            tempfile.NamedTemporaryFile(
+                suffix=".sock", dir=tempfile.gettempdir(), delete=False
+            ) as f,
+            tempfile.NamedTemporaryFile(
+                suffix=".pid", dir=tempfile.gettempdir(), delete=False
+            ) as fp,
+        ):
+            socket_path = f.name
+            pid_file = fp.name
+        os.unlink(socket_path)
+
+        # Use a path that will be unwritable (inside a read-only dir we create)
+        with tempfile.TemporaryDirectory() as td:
+            version_file = os.path.join(td, "subdir", "vaudeville.version")
+            # subdir does NOT exist → write will fail
+
+            plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            daemon = VaudevilleDaemon(
+                socket_path, pid_file, plugin_root, MockBackend(),
+                version_file=version_file,
+            )
+
+            # Serve should still bind the socket despite write failure
+            thread = threading.Thread(target=daemon.serve, daemon=True)
+            thread.start()
+
+            socket_ready = False
+            for _ in range(40):
+                try:
+                    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                        probe.settimeout(0.1)
+                        probe.connect(socket_path)
+                    socket_ready = True
+                    break
+                except (ConnectionRefusedError, FileNotFoundError, OSError):
+                    time.sleep(0.05)
+
+            daemon._stop_event.set()
+            thread.join(timeout=3)
+
+            # The daemon crashed instead of serving — this is a BUG
+            assert socket_ready, (
+                "Daemon crashed when VERSION_FILE directory doesn't exist — "
+                "_write_version_stamp must handle write errors gracefully"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Attack 3: git not available
+# ---------------------------------------------------------------------------
+
+
+class TestGitNotAvailable:
+    def test_write_version_stamp_falls_back_to_unknown_when_git_missing(self) -> None:
+        """If git is unavailable, version stamp must be 'unknown', not an error."""
+        with tempfile.NamedTemporaryFile(
+            suffix=".version", dir=tempfile.gettempdir(), delete=False
+        ) as fv:
+            version_file = fv.name
+
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        daemon = VaudevilleDaemon(
+            "/tmp/_test_git_na.sock",
+            "/tmp/_test_git_na.pid",
+            plugin_root,
+            MockBackend(),
+            version_file=version_file,
+        )
+
+        # Simulate git not found by making the subprocess raise OSError
+        with patch("subprocess.run", side_effect=OSError("git not found")):
+            daemon._write_version_stamp()
+
+        content = open(version_file).read().strip()
+        assert content == "unknown", (
+            f"Expected 'unknown' when git is unavailable, got {content!r}"
+        )
+
+    def test_write_version_stamp_falls_back_when_git_nonzero_exit(self) -> None:
+        """Non-zero git exit → stamp is 'unknown'."""
+        with tempfile.NamedTemporaryFile(
+            suffix=".version", dir=tempfile.gettempdir(), delete=False
+        ) as fv:
+            version_file = fv.name
+
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        daemon = VaudevilleDaemon(
+            "/tmp/_test_git_fail.sock",
+            "/tmp/_test_git_fail.pid",
+            plugin_root,
+            MockBackend(),
+            version_file=version_file,
+        )
+
+        fake_result = MagicMock()
+        fake_result.returncode = 128
+        fake_result.stdout = ""
+
+        with patch("subprocess.run", return_value=fake_result):
+            daemon._write_version_stamp()
+
+        content = open(version_file).read().strip()
+        assert content == "unknown", (
+            f"Expected 'unknown' for non-zero git exit, got {content!r}"
+        )
+
+    def test_write_version_stamp_falls_back_on_timeout(self) -> None:
+        """Timed-out git command → stamp is 'unknown', no exception raised."""
+        with tempfile.NamedTemporaryFile(
+            suffix=".version", dir=tempfile.gettempdir(), delete=False
+        ) as fv:
+            version_file = fv.name
+
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        daemon = VaudevilleDaemon(
+            "/tmp/_test_git_timeout.sock",
+            "/tmp/_test_git_timeout.pid",
+            plugin_root,
+            MockBackend(),
+            version_file=version_file,
+        )
+
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5),
+        ):
+            daemon._write_version_stamp()
+
+        content = open(version_file).read().strip()
+        assert content == "unknown", (
+            f"Expected 'unknown' for git timeout, got {content!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Attack 4: Request arrives while daemon is shutting down
+# ---------------------------------------------------------------------------
+
+
+class TestShutdownRace:
+    def test_in_flight_request_gets_response_during_shutdown(self) -> None:
+        """A request dispatched before _stop_event is set must complete."""
+        with (
+            tempfile.NamedTemporaryFile(
+                suffix=".sock", dir=tempfile.gettempdir(), delete=False
+            ) as f,
+            tempfile.NamedTemporaryFile(
+                suffix=".pid", dir=tempfile.gettempdir(), delete=False
+            ) as fp,
+            tempfile.NamedTemporaryFile(
+                suffix=".version", dir=tempfile.gettempdir(), delete=False
+            ) as fv,
+        ):
+            socket_path = f.name
+            pid_file = fp.name
+            version_file = fv.name
+        os.unlink(socket_path)
+
+        # Slow backend so the request is in-flight during shutdown
+        class SlowBackend:
+            def classify(self, prompt: str, max_tokens: int = 50) -> str:
+                time.sleep(0.1)
+                return "VERDICT: clean\nREASON: ok"
+
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        daemon = VaudevilleDaemon(
+            socket_path, pid_file, plugin_root, SlowBackend(),
+            version_file=version_file,
+        )
+        thread = threading.Thread(target=daemon.serve, daemon=True)
+        thread.start()
+
+        for _ in range(40):
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                    probe.settimeout(0.1)
+                    probe.connect(socket_path)
+                    break
+            except (ConnectionRefusedError, FileNotFoundError, OSError):
+                time.sleep(0.05)
+
+        payload = (
+            json.dumps({"rule": "violation-detector", "input": {"text": "test"}}).encode()
+            + b"\n"
+        )
+
+        results: list[dict] = []
+        errors: list[Exception] = []
+
+        def send() -> None:
+            try:
+                results.append(_send_request(socket_path, payload))
+            except Exception as e:
+                errors.append(e)
+
+        req_thread = threading.Thread(target=send)
+        req_thread.start()
+
+        # Signal shutdown immediately after dispatch
+        time.sleep(0.01)
+        daemon._stop_event.set()
+
+        req_thread.join(timeout=5)
+        thread.join(timeout=5)
+
+        # In-flight request must have succeeded — no connection error
+        assert not errors, f"In-flight request raised: {errors}"
+        assert results, "In-flight request produced no response"
+        assert results[0].get("verdict") in ("clean", "violation"), (
+            f"Unexpected verdict: {results[0]}"
+        )
+
+    def test_new_connection_rejected_after_socket_closed(self) -> None:
+        """After daemon stops, the socket must be gone (no stale file)."""
+        with (
+            tempfile.NamedTemporaryFile(
+                suffix=".sock", dir=tempfile.gettempdir(), delete=False
+            ) as f,
+            tempfile.NamedTemporaryFile(
+                suffix=".pid", dir=tempfile.gettempdir(), delete=False
+            ) as fp,
+            tempfile.NamedTemporaryFile(
+                suffix=".version", dir=tempfile.gettempdir(), delete=False
+            ) as fv,
+        ):
+            socket_path = f.name
+            pid_file = fp.name
+            version_file = fv.name
+        os.unlink(socket_path)
+
+        daemon, thread = _ready_daemon(socket_path, pid_file, version_file)
+        daemon._stop_event.set()
+        thread.join(timeout=5)
+
+        # _cleanup() must remove the socket file
+        assert not os.path.exists(socket_path), (
+            "Socket file not removed on shutdown — stale socket left behind"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Attack 5: PID file contains garbage
+# ---------------------------------------------------------------------------
+
+
+class TestPidFileGarbage:
+    def test_serve_exits_when_pid_file_locked_by_another(self) -> None:
+        """If another process already holds the PID lock, serve() must exit silently."""
+        with (
+            tempfile.NamedTemporaryFile(
+                suffix=".sock", dir=tempfile.gettempdir(), delete=False
+            ) as f,
+            tempfile.NamedTemporaryFile(
+                suffix=".pid", dir=tempfile.gettempdir(), delete=False
+            ) as fp,
+            tempfile.NamedTemporaryFile(
+                suffix=".version", dir=tempfile.gettempdir(), delete=False
+            ) as fv,
+        ):
+            socket_path = f.name
+            pid_file = fp.name
+            version_file = fv.name
+        os.unlink(socket_path)
+
+        # Pre-lock the PID file with LOCK_EX so daemon can't acquire it
+        lock_fd = os.open(pid_file, os.O_WRONLY | os.O_CREAT, 0o644)
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+        try:
+            plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            daemon = VaudevilleDaemon(
+                socket_path, pid_file, plugin_root, MockBackend(),
+                version_file=version_file,
+            )
+            thread = threading.Thread(target=daemon.serve, daemon=True)
+            thread.start()
+            thread.join(timeout=3.0)
+            assert not thread.is_alive(), (
+                "Daemon should exit when PID file is already locked"
+            )
+            # Socket must NOT have been created
+            assert not os.path.exists(socket_path), (
+                "Daemon bound socket even though PID lock was held by another process"
+            )
+        finally:
+            os.close(lock_fd)
+
+    def test_pid_file_with_garbage_content_still_allows_serve(self) -> None:
+        """PID file with non-numeric content must not crash daemon startup."""
+        with (
+            tempfile.NamedTemporaryFile(
+                suffix=".sock", dir=tempfile.gettempdir(), delete=False
+            ) as f,
+            tempfile.NamedTemporaryFile(
+                suffix=".pid", dir=tempfile.gettempdir(), delete=False, mode="w"
+            ) as fp,
+            tempfile.NamedTemporaryFile(
+                suffix=".version", dir=tempfile.gettempdir(), delete=False
+            ) as fv,
+        ):
+            socket_path = f.name
+            pid_file = fp.name
+            version_file = fv.name
+            fp.write("not-a-pid\x00\xff garbage\n")
+        os.unlink(socket_path)
+
+        # The daemon re-opens and relocks the PID file; garbage content shouldn't matter
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        daemon = VaudevilleDaemon(
+            socket_path, pid_file, plugin_root, MockBackend(),
+            version_file=version_file,
+        )
+        thread = threading.Thread(target=daemon.serve, daemon=True)
+        thread.start()
+
+        socket_ready = False
+        for _ in range(40):
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                    probe.settimeout(0.1)
+                    probe.connect(socket_path)
+                socket_ready = True
+                break
+            except (ConnectionRefusedError, FileNotFoundError, OSError):
+                time.sleep(0.05)
+
+        daemon._stop_event.set()
+        thread.join(timeout=3)
+
+        assert socket_ready, (
+            "Daemon failed to start when PID file contained garbage content"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Attack 6: Cleanup interrupted — version file left behind after SIGKILL
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupInterrupted:
+    def test_cleanup_is_idempotent_for_already_removed_files(self) -> None:
+        """_cleanup() must not raise if socket/pid/version files are already gone."""
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        daemon = VaudevilleDaemon(
+            "/tmp/_nonexistent_test.sock",
+            "/tmp/_nonexistent_test.pid",
+            plugin_root,
+            MockBackend(),
+            version_file="/tmp/_nonexistent_test.version",
+        )
+        # No files exist — must not raise
+        daemon._cleanup()
+        daemon._cleanup()  # second call also must not raise
+
+    def test_stale_version_file_does_not_prevent_new_daemon(self) -> None:
+        """A leftover VERSION_FILE from a crashed daemon must be overwritten."""
+        with (
+            tempfile.NamedTemporaryFile(
+                suffix=".sock", dir=tempfile.gettempdir(), delete=False
+            ) as f,
+            tempfile.NamedTemporaryFile(
+                suffix=".pid", dir=tempfile.gettempdir(), delete=False
+            ) as fp,
+            tempfile.NamedTemporaryFile(
+                suffix=".version", dir=tempfile.gettempdir(), delete=False, mode="w"
+            ) as fv,
+        ):
+            socket_path = f.name
+            pid_file = fp.name
+            version_file = fv.name
+            fv.write("stale-git-hash-from-dead-daemon\n")
+        os.unlink(socket_path)
+
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        daemon = VaudevilleDaemon(
+            socket_path, pid_file, plugin_root, MockBackend(),
+            version_file=version_file,
+        )
+        thread = threading.Thread(target=daemon.serve, daemon=True)
+        thread.start()
+
+        for _ in range(40):
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                    probe.settimeout(0.1)
+                    probe.connect(socket_path)
+                    break
+            except (ConnectionRefusedError, FileNotFoundError, OSError):
+                time.sleep(0.05)
+
+        try:
+            content = open(version_file).read().strip()
+            assert content != "stale-git-hash-from-dead-daemon", (
+                "New daemon must overwrite stale version file, not keep old value"
+            )
+        finally:
+            daemon._stop_event.set()
+            thread.join(timeout=3)
+
+
+# ---------------------------------------------------------------------------
+# Attack 7: Backend lock contention — many simultaneous classify calls
+# ---------------------------------------------------------------------------
+
+
+class TestBackendLockContention:
+    def test_no_deadlock_under_high_concurrency(self) -> None:
+        """10 simultaneous requests must all complete without deadlocking."""
+        with (
+            tempfile.NamedTemporaryFile(
+                suffix=".sock", dir=tempfile.gettempdir(), delete=False
+            ) as f,
+            tempfile.NamedTemporaryFile(
+                suffix=".pid", dir=tempfile.gettempdir(), delete=False
+            ) as fp,
+            tempfile.NamedTemporaryFile(
+                suffix=".version", dir=tempfile.gettempdir(), delete=False
+            ) as fv,
+        ):
+            socket_path = f.name
+            pid_file = fp.name
+            version_file = fv.name
+        os.unlink(socket_path)
+
+        daemon, thread = _ready_daemon(socket_path, pid_file, version_file)
+
+        payload = (
+            json.dumps({"rule": "violation-detector", "input": {"text": "test text"}}).encode()
+            + b"\n"
+        )
+
+        responses: list[dict] = []
+        errors: list[Exception] = []
+        lock = threading.Lock()
+
+        def send() -> None:
+            try:
+                resp = _send_request(socket_path, payload)
+                with lock:
+                    responses.append(resp)
+            except Exception as e:
+                with lock:
+                    errors.append(e)
+
+        workers = [threading.Thread(target=send) for _ in range(10)]
+        for w in workers:
+            w.start()
+        for w in workers:
+            w.join(timeout=10)
+
+        daemon._stop_event.set()
+        thread.join(timeout=5)
+
+        assert not errors, f"Concurrent requests raised errors: {errors}"
+        assert len(responses) == 10, (
+            f"Expected 10 responses, got {len(responses)}"
+        )
+
+    def test_backend_lock_held_for_duration_of_classify(self) -> None:
+        """Backend calls must not overlap (lock must serialize them end-to-end)."""
+        with (
+            tempfile.NamedTemporaryFile(
+                suffix=".sock", dir=tempfile.gettempdir(), delete=False
+            ) as f,
+            tempfile.NamedTemporaryFile(
+                suffix=".pid", dir=tempfile.gettempdir(), delete=False
+            ) as fp,
+            tempfile.NamedTemporaryFile(
+                suffix=".version", dir=tempfile.gettempdir(), delete=False
+            ) as fv,
+        ):
+            socket_path = f.name
+            pid_file = fp.name
+            version_file = fv.name
+        os.unlink(socket_path)
+
+        call_intervals: list[tuple[float, float]] = []
+        ci_lock = threading.Lock()
+
+        class TimingBackend:
+            def classify(self, prompt: str, max_tokens: int = 50) -> str:
+                t0 = time.monotonic()
+                time.sleep(0.03)
+                t1 = time.monotonic()
+                with ci_lock:
+                    call_intervals.append((t0, t1))
+                return "VERDICT: clean\nREASON: ok"
+
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        daemon = VaudevilleDaemon(
+            socket_path, pid_file, plugin_root, TimingBackend(),
+            version_file=version_file,
+        )
+        thread = threading.Thread(target=daemon.serve, daemon=True)
+        thread.start()
+
+        for _ in range(40):
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                    probe.settimeout(0.1)
+                    probe.connect(socket_path)
+                    break
+            except (ConnectionRefusedError, FileNotFoundError, OSError):
+                time.sleep(0.05)
+
+        payload = (
+            json.dumps({"rule": "violation-detector", "input": {"text": "test"}}).encode()
+            + b"\n"
+        )
+
+        workers = [
+            threading.Thread(target=_send_request, args=(socket_path, payload))
+            for _ in range(5)
+        ]
+        for w in workers:
+            w.start()
+        for w in workers:
+            w.join(timeout=10)
+
+        daemon._stop_event.set()
+        thread.join(timeout=5)
+
+        assert len(call_intervals) == 5, f"Expected 5 calls, got {len(call_intervals)}"
+        sorted_intervals = sorted(call_intervals)
+        for i in range(len(sorted_intervals) - 1):
+            end_i = sorted_intervals[i][1]
+            start_next = sorted_intervals[i + 1][0]
+            assert end_i <= start_next + 0.01, (
+                f"Backend calls overlapped: [{sorted_intervals[i]}] and "
+                f"[{sorted_intervals[i + 1]}] — _backend_lock not protecting correctly"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Attack: handle_request with extreme/invalid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestHandleRequestEdgeCases:
+    def test_empty_bytes(self) -> None:
+        """Empty payload must return clean (fail-open)."""
+        from vaudeville.core.rules import load_rules
+        import os
+
+        rules_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "rules"
+        )
+        rules = load_rules(rules_dir)
+        backend = MockBackend()
+        response = json.loads(handle_request(b"", rules, backend))
+        assert response["verdict"] == "clean"
+
+    def test_null_bytes_in_payload(self) -> None:
+        """Null bytes in payload must not crash the handler."""
+        from vaudeville.core.rules import load_rules
+
+        rules_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "rules"
+        )
+        rules = load_rules(rules_dir)
+        backend = MockBackend()
+        response = json.loads(handle_request(b"\x00\x01\x02\x03\n", rules, backend))
+        assert response["verdict"] == "clean"
+
+    def test_oversized_payload(self) -> None:
+        """10MB payload must not cause an unhandled exception."""
+        from vaudeville.core.rules import load_rules
+
+        rules_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "rules"
+        )
+        rules = load_rules(rules_dir)
+        backend = MockBackend()
+        giant_text = "x" * (10 * 1024 * 1024)
+        payload = (
+            json.dumps({"rule": "violation-detector", "input": {"text": giant_text}}).encode()
+            + b"\n"
+        )
+        response = json.loads(handle_request(payload, rules, backend))
+        # Must not crash — verdict is backend-dependent
+        assert "verdict" in response
+
+    def test_missing_rule_key(self) -> None:
+        """Payload without 'rule' key defaults to clean."""
+        from vaudeville.core.rules import load_rules
+
+        rules_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "rules"
+        )
+        rules = load_rules(rules_dir)
+        backend = MockBackend()
+        payload = json.dumps({"input": {"text": "test"}}).encode() + b"\n"
+        response = json.loads(handle_request(payload, rules, backend))
+        assert response["verdict"] == "clean"
+
+    def test_rule_value_is_none(self) -> None:
+        """JSON null for 'rule' must not crash — treat as unknown rule."""
+        from vaudeville.core.rules import load_rules
+
+        rules_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "rules"
+        )
+        rules = load_rules(rules_dir)
+        backend = MockBackend()
+        payload = json.dumps({"rule": None, "input": {"text": "test"}}).encode() + b"\n"
+        response = json.loads(handle_request(payload, rules, backend))
+        # None key → dict.get returns None → "Unknown rule"
+        assert response["verdict"] == "clean"
+
+    def test_backend_exception_returns_clean(self) -> None:
+        """If backend raises, response must be clean (fail-open), not an exception."""
+        from vaudeville.core.rules import load_rules
+
+        rules_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "rules"
+        )
+        rules = load_rules(rules_dir)
+
+        class ExplodingBackend:
+            def classify(self, prompt: str, max_tokens: int = 50) -> str:
+                raise RuntimeError("GPU on fire")
+
+        payload = (
+            json.dumps({"rule": "violation-detector", "input": {"text": "test"}}).encode()
+            + b"\n"
+        )
+        response = json.loads(handle_request(payload, rules, ExplodingBackend()))
+        assert response["verdict"] == "clean", (
+            "Backend exception must return clean (fail-open)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Attack: _cleanup() doesn't remove pid_file if pid_fd is None (never locked)
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupWithoutPidLock:
+    def test_cleanup_skips_pid_close_if_never_locked(self) -> None:
+        """_cleanup() with pid_fd=None must not raise AttributeError or OSError."""
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        daemon = VaudevilleDaemon(
+            "/tmp/_skip_test.sock",
+            "/tmp/_skip_test.pid",
+            plugin_root,
+            MockBackend(),
+            version_file="/tmp/_skip_test.version",
+        )
+        assert daemon._pid_fd is None
+        # Must not raise
+        daemon._cleanup()

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -22,7 +22,8 @@ import threading
 import time
 from unittest.mock import MagicMock, patch
 
-from vaudeville.server.daemon import VERSION_FILE, VaudevilleDaemon, handle_request
+from vaudeville.core.paths import VERSION_FILE
+from vaudeville.server.daemon import VaudevilleDaemon, handle_request
 from conftest import MockBackend
 
 

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -116,7 +116,10 @@ class TestVersionStampRace:
 
             plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
             daemon2 = VaudevilleDaemon(
-                socket_path2, pid_file, plugin_root, MockBackend(),
+                socket_path2,
+                pid_file,
+                plugin_root,
+                MockBackend(),
                 version_file=version_file,
             )
             # serve() should return immediately due to PID lock held by daemon1
@@ -158,7 +161,10 @@ class TestVersionStampRace:
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            socket_path, pid_file, plugin_root, TracingBackend(),
+            socket_path,
+            pid_file,
+            plugin_root,
+            TracingBackend(),
             version_file=version_file,
         )
 
@@ -215,7 +221,10 @@ class TestVersionFilePermissions:
 
             plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
             daemon = VaudevilleDaemon(
-                socket_path, pid_file, plugin_root, MockBackend(),
+                socket_path,
+                pid_file,
+                plugin_root,
+                MockBackend(),
                 version_file=version_file,
             )
 
@@ -363,7 +372,10 @@ class TestShutdownRace:
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            socket_path, pid_file, plugin_root, SlowBackend(),
+            socket_path,
+            pid_file,
+            plugin_root,
+            SlowBackend(),
             version_file=version_file,
         )
         thread = threading.Thread(target=daemon.serve, daemon=True)
@@ -379,7 +391,9 @@ class TestShutdownRace:
                 time.sleep(0.05)
 
         payload = (
-            json.dumps({"rule": "violation-detector", "input": {"text": "test"}}).encode()
+            json.dumps(
+                {"rule": "violation-detector", "input": {"text": "test"}}
+            ).encode()
             + b"\n"
         )
 
@@ -468,7 +482,10 @@ class TestPidFileGarbage:
         try:
             plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
             daemon = VaudevilleDaemon(
-                socket_path, pid_file, plugin_root, MockBackend(),
+                socket_path,
+                pid_file,
+                plugin_root,
+                MockBackend(),
                 version_file=version_file,
             )
             thread = threading.Thread(target=daemon.serve, daemon=True)
@@ -506,7 +523,10 @@ class TestPidFileGarbage:
         # The daemon re-opens and relocks the PID file; garbage content shouldn't matter
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            socket_path, pid_file, plugin_root, MockBackend(),
+            socket_path,
+            pid_file,
+            plugin_root,
+            MockBackend(),
             version_file=version_file,
         )
         thread = threading.Thread(target=daemon.serve, daemon=True)
@@ -572,7 +592,10 @@ class TestCleanupInterrupted:
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            socket_path, pid_file, plugin_root, MockBackend(),
+            socket_path,
+            pid_file,
+            plugin_root,
+            MockBackend(),
             version_file=version_file,
         )
         thread = threading.Thread(target=daemon.serve, daemon=True)
@@ -624,7 +647,9 @@ class TestBackendLockContention:
         daemon, thread = _ready_daemon(socket_path, pid_file, version_file)
 
         payload = (
-            json.dumps({"rule": "violation-detector", "input": {"text": "test text"}}).encode()
+            json.dumps(
+                {"rule": "violation-detector", "input": {"text": "test text"}}
+            ).encode()
             + b"\n"
         )
 
@@ -651,9 +676,7 @@ class TestBackendLockContention:
         thread.join(timeout=5)
 
         assert not errors, f"Concurrent requests raised errors: {errors}"
-        assert len(responses) == 10, (
-            f"Expected 10 responses, got {len(responses)}"
-        )
+        assert len(responses) == 10, f"Expected 10 responses, got {len(responses)}"
 
     def test_backend_lock_held_for_duration_of_classify(self) -> None:
         """Backend calls must not overlap (lock must serialize them end-to-end)."""
@@ -687,7 +710,10 @@ class TestBackendLockContention:
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            socket_path, pid_file, plugin_root, TimingBackend(),
+            socket_path,
+            pid_file,
+            plugin_root,
+            TimingBackend(),
             version_file=version_file,
         )
         thread = threading.Thread(target=daemon.serve, daemon=True)
@@ -703,7 +729,9 @@ class TestBackendLockContention:
                 time.sleep(0.05)
 
         payload = (
-            json.dumps({"rule": "violation-detector", "input": {"text": "test"}}).encode()
+            json.dumps(
+                {"rule": "violation-detector", "input": {"text": "test"}}
+            ).encode()
             + b"\n"
         )
 
@@ -772,7 +800,9 @@ class TestHandleRequestEdgeCases:
         backend = MockBackend()
         giant_text = "x" * (10 * 1024 * 1024)
         payload = (
-            json.dumps({"rule": "violation-detector", "input": {"text": giant_text}}).encode()
+            json.dumps(
+                {"rule": "violation-detector", "input": {"text": giant_text}}
+            ).encode()
             + b"\n"
         )
         response = json.loads(handle_request(payload, rules, backend))
@@ -820,7 +850,9 @@ class TestHandleRequestEdgeCases:
                 raise RuntimeError("GPU on fire")
 
         payload = (
-            json.dumps({"rule": "violation-detector", "input": {"text": "test"}}).encode()
+            json.dumps(
+                {"rule": "violation-detector", "input": {"text": "test"}}
+            ).encode()
             + b"\n"
         )
         response = json.loads(handle_request(payload, rules, ExplodingBackend()))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -111,7 +111,7 @@ class TestLoadRules:
 
 class TestFailOpen:
     def test_client_returns_none_for_missing_socket(self) -> None:
-        client = VaudevilleClient("nonexistent-session-id-xyz")
+        client = VaudevilleClient()
         result = client.classify("violation-detector", {"text": "test"})
         assert result is None
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -116,7 +116,13 @@ class TestDaemonSocketProtocol:
         os.unlink(socket_path)  # daemon will re-create it
         backend = MockBackend(verdict="clean", reason="socket test")
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        daemon = VaudevilleDaemon(socket_path, pid_file, plugin_root, backend)
+        with tempfile.NamedTemporaryFile(
+            suffix=".version", dir=tempfile.gettempdir(), delete=True
+        ) as vf:
+            version_file = vf.name
+        daemon = VaudevilleDaemon(
+            socket_path, pid_file, plugin_root, backend, version_file=version_file
+        )
 
         thread = threading.Thread(target=daemon.serve, daemon=True)
         thread.start()
@@ -187,7 +193,13 @@ class TestBackendLockSerialization:
         os.unlink(socket_path)
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        daemon = VaudevilleDaemon(socket_path, pid_file, plugin_root, SlowBackend())
+        with tempfile.NamedTemporaryFile(
+            suffix=".version", dir=tempfile.gettempdir(), delete=True
+        ) as vf:
+            version_file = vf.name
+        daemon = VaudevilleDaemon(
+            socket_path, pid_file, plugin_root, SlowBackend(), version_file=version_file
+        )
 
         thread = threading.Thread(target=daemon.serve, daemon=True)
         thread.start()
@@ -261,3 +273,94 @@ class TestSignalHandlers:
         # Send SIGTERM to ourselves
         os.kill(os.getpid(), signal.SIGTERM)
         assert daemon._stop_event.is_set()
+
+
+class TestVersionStamp:
+    def _make_daemon(
+        self,
+        socket_path: str,
+        pid_file: str,
+        version_file: str,
+    ) -> "VaudevilleDaemon":
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        return VaudevilleDaemon(
+            socket_path, pid_file, plugin_root, MockBackend(), version_file=version_file
+        )
+
+    def test_version_file_written_after_serve(self) -> None:
+        """serve() writes the version file once the PID lock is acquired."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".sock", dir=tempfile.gettempdir(), delete=False
+        ) as f:
+            socket_path = f.name
+        with tempfile.NamedTemporaryFile(
+            suffix=".pid", dir=tempfile.gettempdir(), delete=False
+        ) as f:
+            pid_file = f.name
+        with tempfile.NamedTemporaryFile(
+            suffix=".version", dir=tempfile.gettempdir(), delete=False
+        ) as f:
+            version_file = f.name
+        os.unlink(socket_path)
+
+        daemon = self._make_daemon(socket_path, pid_file, version_file)
+        thread = threading.Thread(target=daemon.serve, daemon=True)
+        thread.start()
+
+        for _ in range(40):
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                    probe.settimeout(0.1)
+                    probe.connect(socket_path)
+                    break
+            except (ConnectionRefusedError, FileNotFoundError):
+                time.sleep(0.05)
+        else:
+            daemon._stop_event.set()
+            raise RuntimeError("Daemon socket never became ready")
+
+        try:
+            assert os.path.exists(version_file), "version file not written"
+            content = open(version_file).read().strip()
+            assert content != "", "version file is empty"
+        finally:
+            daemon._stop_event.set()
+            thread.join(timeout=3)
+
+    def test_version_file_cleaned_on_shutdown(self) -> None:
+        """_cleanup() removes the version file after the daemon stops."""
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".sock", dir=tempfile.gettempdir(), delete=False
+        ) as f:
+            socket_path = f.name
+        with tempfile.NamedTemporaryFile(
+            suffix=".pid", dir=tempfile.gettempdir(), delete=False
+        ) as f:
+            pid_file = f.name
+        with tempfile.NamedTemporaryFile(
+            suffix=".version", dir=tempfile.gettempdir(), delete=False
+        ) as f:
+            version_file = f.name
+        os.unlink(socket_path)
+
+        daemon = self._make_daemon(socket_path, pid_file, version_file)
+        thread = threading.Thread(target=daemon.serve, daemon=True)
+        thread.start()
+
+        for _ in range(40):
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                    probe.settimeout(0.1)
+                    probe.connect(socket_path)
+                    break
+            except (ConnectionRefusedError, FileNotFoundError):
+                time.sleep(0.05)
+
+        daemon._stop_event.set()
+        thread.join(timeout=5)
+
+        assert not os.path.exists(version_file), "version file not removed on cleanup"

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -369,7 +369,6 @@ class TestRunnerNoSessionId:
             f"VaudevilleClient must be called with no keyword args, got: {kwargs}"
         )
 
-
     def test_runner_source_does_not_extract_session_id(self) -> None:
         """runner.py must not contain session_id extraction after the singleton change."""
         hooks_dir = os.path.join(

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -1,0 +1,383 @@
+"""Tests for singleton daemon contract: global socket, version stamp lifecycle."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import socket
+import sys
+import tempfile
+import threading
+import time
+from typing import Any
+
+from vaudeville.server.daemon import VaudevilleDaemon
+
+
+# ---------------------------------------------------------------------------
+# client.py contract
+# ---------------------------------------------------------------------------
+
+
+class TestClientSocketPath:
+    def test_SOCKET_PATH_constant_exists_in_module(self) -> None:
+        """client.py must export SOCKET_PATH, not SOCKET_TEMPLATE."""
+        import vaudeville.core.client as client_module
+
+        assert hasattr(client_module, "SOCKET_PATH"), (
+            "SOCKET_PATH constant is missing from vaudeville.core.client"
+        )
+
+    def test_SOCKET_TEMPLATE_removed_from_module(self) -> None:
+        """SOCKET_TEMPLATE must be gone — it's been replaced by SOCKET_PATH."""
+        import vaudeville.core.client as client_module
+
+        assert not hasattr(client_module, "SOCKET_TEMPLATE"), (
+            "SOCKET_TEMPLATE should be removed; SOCKET_PATH replaces it"
+        )
+
+    def test_SOCKET_PATH_value_is_tmp_vaudeville_sock(self) -> None:
+        """Fixed path must be /tmp/vaudeville.sock."""
+        from vaudeville.core.client import SOCKET_PATH
+
+        assert SOCKET_PATH == "/tmp/vaudeville.sock", (
+            f"SOCKET_PATH is {SOCKET_PATH!r}, expected '/tmp/vaudeville.sock'"
+        )
+
+    def test_SOCKET_PATH_is_a_string(self) -> None:
+        from vaudeville.core.client import SOCKET_PATH
+
+        assert isinstance(SOCKET_PATH, str)
+
+    def test_SOCKET_PATH_has_no_format_placeholder(self) -> None:
+        """Must not contain {session_id} or any other {} placeholder."""
+        from vaudeville.core.client import SOCKET_PATH
+
+        assert "{" not in SOCKET_PATH and "}" not in SOCKET_PATH, (
+            f"SOCKET_PATH must be a fixed path, not a template: {SOCKET_PATH!r}"
+        )
+
+
+class TestVaudevilleClientNoArgs:
+    def test_constructor_accepts_no_arguments(self) -> None:
+        """VaudevilleClient() must work with zero arguments."""
+        from vaudeville.core.client import VaudevilleClient
+
+        client = VaudevilleClient()
+        assert client is not None
+
+    def test_constructor_rejects_positional_session_id(self) -> None:
+        """Old VaudevilleClient(session_id) signature must no longer exist."""
+        import inspect
+
+        from vaudeville.core.client import VaudevilleClient
+
+        sig = inspect.signature(VaudevilleClient.__init__)
+        params = [
+            p
+            for p in sig.parameters.values()
+            if p.name not in ("self",)
+            and p.default is inspect.Parameter.empty
+            and p.kind
+            not in (
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            )
+        ]
+        assert len(params) == 0, (
+            f"VaudevilleClient.__init__ has required parameters: "
+            f"{[p.name for p in params]}"
+        )
+
+    def test_client_uses_fixed_socket_path_internally(self) -> None:
+        """Client must connect to /tmp/vaudeville.sock, not a session path."""
+        from vaudeville.core.client import SOCKET_PATH, VaudevilleClient
+
+        client = VaudevilleClient()
+        # The internal socket path should match the module-level constant
+        assert client._socket_path == SOCKET_PATH
+
+    def test_client_classify_fails_open_on_missing_socket(self) -> None:
+        """Fail-open semantics must still hold with no-arg constructor."""
+        from vaudeville.core.client import VaudevilleClient
+
+        client = VaudevilleClient()
+        result = client.classify("violation-detector", {"text": "test"})
+        assert result is None, (
+            "classify() must return None when daemon is unavailable (fail-open)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# daemon.py contract
+# ---------------------------------------------------------------------------
+
+
+class TestDaemonConstants:
+    def test_IDLE_TIMEOUT_equals_3600(self) -> None:
+        """Idle timeout must be 1 hour (3600 seconds)."""
+        from vaudeville.server.daemon import IDLE_TIMEOUT
+
+        assert IDLE_TIMEOUT == 3600, (
+            f"IDLE_TIMEOUT is {IDLE_TIMEOUT}, expected 3600 (1 hour)"
+        )
+
+    def test_VERSION_FILE_constant_exists(self) -> None:
+        """daemon.py must export VERSION_FILE constant."""
+        import vaudeville.server.daemon as daemon_module
+
+        assert hasattr(daemon_module, "VERSION_FILE"), (
+            "VERSION_FILE constant is missing from vaudeville.server.daemon"
+        )
+
+    def test_VERSION_FILE_value_is_tmp_vaudeville_version(self) -> None:
+        """VERSION_FILE must be /tmp/vaudeville.version."""
+        from vaudeville.server.daemon import VERSION_FILE
+
+        assert VERSION_FILE == "/tmp/vaudeville.version", (
+            f"VERSION_FILE is {VERSION_FILE!r}, expected '/tmp/vaudeville.version'"
+        )
+
+    def test_VERSION_FILE_is_a_string(self) -> None:
+        from vaudeville.server.daemon import VERSION_FILE
+
+        assert isinstance(VERSION_FILE, str)
+
+
+class TestVersionStamp:
+    """Version stamp file is written during serve() and removed during cleanup."""
+
+    def _make_daemon(
+        self,
+        socket_path: str,
+        pid_file: str,
+    ) -> VaudevilleDaemon:
+        from conftest import MockBackend
+
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        return VaudevilleDaemon(socket_path, pid_file, plugin_root, MockBackend())
+
+    def test_version_file_written_after_pid_lock(self) -> None:
+        """serve() must write VERSION_FILE once the PID lock is acquired."""
+        from vaudeville.server.daemon import VERSION_FILE
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".sock", dir=tempfile.gettempdir(), delete=False
+        ) as f:
+            socket_path = f.name
+        with tempfile.NamedTemporaryFile(
+            suffix=".pid", dir=tempfile.gettempdir(), delete=False
+        ) as f:
+            pid_file = f.name
+        os.unlink(socket_path)
+
+        # Clean slate — remove version file if leftover from a previous run
+        try:
+            os.unlink(VERSION_FILE)
+        except FileNotFoundError:
+            pass
+
+        daemon = self._make_daemon(socket_path, pid_file)
+        thread = threading.Thread(target=daemon.serve, daemon=True)
+        thread.start()
+
+        # Wait for socket to appear (daemon is serving)
+        for _ in range(40):
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                    probe.settimeout(0.1)
+                    probe.connect(socket_path)
+                    break
+            except (ConnectionRefusedError, FileNotFoundError):
+                time.sleep(0.05)
+        else:
+            daemon._stop_event.set()
+            raise RuntimeError("Daemon socket never became ready")
+
+        try:
+            assert os.path.exists(VERSION_FILE), (
+                f"VERSION_FILE {VERSION_FILE!r} was not written during serve()"
+            )
+        finally:
+            daemon._stop_event.set()
+            thread.join(timeout=3)
+
+    def test_version_file_contains_nonempty_content(self) -> None:
+        """VERSION_FILE must not be empty — it should contain a git HEAD hash."""
+        from vaudeville.server.daemon import VERSION_FILE
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".sock", dir=tempfile.gettempdir(), delete=False
+        ) as f:
+            socket_path = f.name
+        with tempfile.NamedTemporaryFile(
+            suffix=".pid", dir=tempfile.gettempdir(), delete=False
+        ) as f:
+            pid_file = f.name
+        os.unlink(socket_path)
+
+        try:
+            os.unlink(VERSION_FILE)
+        except FileNotFoundError:
+            pass
+
+        daemon = self._make_daemon(socket_path, pid_file)
+        thread = threading.Thread(target=daemon.serve, daemon=True)
+        thread.start()
+
+        for _ in range(40):
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                    probe.settimeout(0.1)
+                    probe.connect(socket_path)
+                    break
+            except (ConnectionRefusedError, FileNotFoundError):
+                time.sleep(0.05)
+
+        try:
+            if os.path.exists(VERSION_FILE):
+                content = open(VERSION_FILE).read().strip()
+                assert content != "", "VERSION_FILE exists but is empty"
+        finally:
+            daemon._stop_event.set()
+            thread.join(timeout=3)
+
+    def test_version_file_removed_on_cleanup(self) -> None:
+        """_cleanup() must remove VERSION_FILE alongside socket and PID."""
+        from vaudeville.server.daemon import VERSION_FILE
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".sock", dir=tempfile.gettempdir(), delete=False
+        ) as f:
+            socket_path = f.name
+        with tempfile.NamedTemporaryFile(
+            suffix=".pid", dir=tempfile.gettempdir(), delete=False
+        ) as f:
+            pid_file = f.name
+        os.unlink(socket_path)
+
+        try:
+            os.unlink(VERSION_FILE)
+        except FileNotFoundError:
+            pass
+
+        daemon = self._make_daemon(socket_path, pid_file)
+        thread = threading.Thread(target=daemon.serve, daemon=True)
+        thread.start()
+
+        # Wait for serving
+        for _ in range(40):
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as probe:
+                    probe.settimeout(0.1)
+                    probe.connect(socket_path)
+                    break
+            except (ConnectionRefusedError, FileNotFoundError):
+                time.sleep(0.05)
+
+        # Stop daemon and wait for cleanup
+        daemon._stop_event.set()
+        thread.join(timeout=5)
+
+        assert not os.path.exists(VERSION_FILE), (
+            f"VERSION_FILE {VERSION_FILE!r} was not removed during _cleanup()"
+        )
+
+    def test_cleanup_removes_version_file_even_if_missing(self) -> None:
+        """_cleanup() must not raise if VERSION_FILE does not exist."""
+        from vaudeville.server.daemon import VaudevilleDaemon
+        from conftest import MockBackend
+
+        plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        daemon = VaudevilleDaemon(
+            "/tmp/_test_cleanup.sock",
+            "/tmp/_test_cleanup.pid",
+            plugin_root,
+            MockBackend(),
+        )
+
+        # Ensure file absent
+        from vaudeville.server.daemon import VERSION_FILE
+
+        try:
+            os.unlink(VERSION_FILE)
+        except FileNotFoundError:
+            pass
+
+        # Must not raise
+        daemon._cleanup()
+
+
+# ---------------------------------------------------------------------------
+# runner.py contract — no session_id extraction
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerNoSessionId:
+    def test_runner_constructs_client_without_session_id(self) -> None:
+        """runner.main() must call VaudevilleClient() with no positional args."""
+        import io
+        from unittest.mock import MagicMock, patch
+
+        hook_input = json.dumps(
+            {
+                "session_id": "should-be-ignored",
+                "last_assistant_message": "A" * 200,
+            }
+        )
+
+        mock_client = MagicMock()
+        mock_client.classify.return_value = None
+
+        captured_calls: list[Any] = []
+
+        def fake_constructor(*args: object, **kwargs: object) -> MagicMock:
+            captured_calls.append((args, kwargs))
+            return mock_client
+
+        hooks_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "hooks"
+        )
+
+        with (
+            patch("sys.stdin", io.StringIO(hook_input)),
+            patch("sys.stdout", io.StringIO()),
+            patch("sys.argv", ["runner.py", "violation-detector"]),
+            patch(
+                "vaudeville.core.client.VaudevilleClient", side_effect=fake_constructor
+            ),
+        ):
+            if hooks_dir not in sys.path:
+                sys.path.insert(0, hooks_dir)
+            try:
+                runner = importlib.import_module("runner")
+                importlib.reload(runner)
+                runner.main()
+            except SystemExit:
+                pass
+            finally:
+                if hooks_dir in sys.path:
+                    sys.path.remove(hooks_dir)
+
+        assert len(captured_calls) == 1, "VaudevilleClient should be constructed once"
+        args, kwargs = captured_calls[0]
+        assert args == (), (
+            f"VaudevilleClient must be called with no positional args, got: {args}"
+        )
+        assert kwargs == {}, (
+            f"VaudevilleClient must be called with no keyword args, got: {kwargs}"
+        )
+
+
+    def test_runner_source_does_not_extract_session_id(self) -> None:
+        """runner.py must not contain session_id extraction after the singleton change."""
+        hooks_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "hooks"
+        )
+        runner_src = open(os.path.join(hooks_dir, "runner.py")).read()
+
+        # Old pattern: session_id = hook_input.get("session_id", ...)
+        assert "session_id" not in runner_src, (
+            "runner.py still references session_id — remove it for the singleton client"
+        )

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -37,22 +37,23 @@ class TestClientSocketPath:
             "SOCKET_TEMPLATE should be removed; SOCKET_PATH replaces it"
         )
 
-    def test_SOCKET_PATH_value_is_tmp_vaudeville_sock(self) -> None:
-        """Fixed path must be /tmp/vaudeville.sock."""
-        from vaudeville.core.client import SOCKET_PATH
+    def test_SOCKET_PATH_is_per_uid(self) -> None:
+        """Socket must live in a per-UID runtime directory."""
+        from vaudeville.core.paths import SOCKET_PATH
 
-        assert SOCKET_PATH == "/tmp/vaudeville.sock", (
-            f"SOCKET_PATH is {SOCKET_PATH!r}, expected '/tmp/vaudeville.sock'"
+        expected = f"/tmp/vaudeville-{os.getuid()}/vaudeville.sock"
+        assert SOCKET_PATH == expected, (
+            f"SOCKET_PATH is {SOCKET_PATH!r}, expected {expected!r}"
         )
 
     def test_SOCKET_PATH_is_a_string(self) -> None:
-        from vaudeville.core.client import SOCKET_PATH
+        from vaudeville.core.paths import SOCKET_PATH
 
         assert isinstance(SOCKET_PATH, str)
 
     def test_SOCKET_PATH_has_no_format_placeholder(self) -> None:
         """Must not contain {session_id} or any other {} placeholder."""
-        from vaudeville.core.client import SOCKET_PATH
+        from vaudeville.core.paths import SOCKET_PATH
 
         assert "{" not in SOCKET_PATH and "}" not in SOCKET_PATH, (
             f"SOCKET_PATH must be a fixed path, not a template: {SOCKET_PATH!r}"
@@ -92,7 +93,8 @@ class TestVaudevilleClientNoArgs:
 
     def test_client_uses_fixed_socket_path_internally(self) -> None:
         """Client must connect to /tmp/vaudeville.sock, not a session path."""
-        from vaudeville.core.client import SOCKET_PATH, VaudevilleClient
+        from vaudeville.core.client import VaudevilleClient
+        from vaudeville.core.paths import SOCKET_PATH
 
         client = VaudevilleClient()
         # The internal socket path should match the module-level constant
@@ -131,16 +133,17 @@ class TestDaemonConstants:
             "VERSION_FILE constant is missing from vaudeville.server.daemon"
         )
 
-    def test_VERSION_FILE_value_is_tmp_vaudeville_version(self) -> None:
-        """VERSION_FILE must be /tmp/vaudeville.version."""
-        from vaudeville.server.daemon import VERSION_FILE
+    def test_VERSION_FILE_is_per_uid(self) -> None:
+        """VERSION_FILE must live in a per-UID runtime directory."""
+        from vaudeville.core.paths import VERSION_FILE
 
-        assert VERSION_FILE == "/tmp/vaudeville.version", (
-            f"VERSION_FILE is {VERSION_FILE!r}, expected '/tmp/vaudeville.version'"
+        expected = f"/tmp/vaudeville-{os.getuid()}/vaudeville.version"
+        assert VERSION_FILE == expected, (
+            f"VERSION_FILE is {VERSION_FILE!r}, expected {expected!r}"
         )
 
     def test_VERSION_FILE_is_a_string(self) -> None:
-        from vaudeville.server.daemon import VERSION_FILE
+        from vaudeville.core.paths import VERSION_FILE
 
         assert isinstance(VERSION_FILE, str)
 
@@ -160,7 +163,7 @@ class TestVersionStamp:
 
     def test_version_file_written_after_pid_lock(self) -> None:
         """serve() must write VERSION_FILE once the PID lock is acquired."""
-        from vaudeville.server.daemon import VERSION_FILE
+        from vaudeville.core.paths import VERSION_FILE
 
         with tempfile.NamedTemporaryFile(
             suffix=".sock", dir=tempfile.gettempdir(), delete=False
@@ -205,7 +208,7 @@ class TestVersionStamp:
 
     def test_version_file_contains_nonempty_content(self) -> None:
         """VERSION_FILE must not be empty — it should contain a git HEAD hash."""
-        from vaudeville.server.daemon import VERSION_FILE
+        from vaudeville.core.paths import VERSION_FILE
 
         with tempfile.NamedTemporaryFile(
             suffix=".sock", dir=tempfile.gettempdir(), delete=False
@@ -245,7 +248,7 @@ class TestVersionStamp:
 
     def test_version_file_removed_on_cleanup(self) -> None:
         """_cleanup() must remove VERSION_FILE alongside socket and PID."""
-        from vaudeville.server.daemon import VERSION_FILE
+        from vaudeville.core.paths import VERSION_FILE
 
         with tempfile.NamedTemporaryFile(
             suffix=".sock", dir=tempfile.gettempdir(), delete=False
@@ -298,7 +301,7 @@ class TestVersionStamp:
         )
 
         # Ensure file absent
-        from vaudeville.server.daemon import VERSION_FILE
+        from vaudeville.core.paths import VERSION_FILE
 
         try:
             os.unlink(VERSION_FILE)

--- a/vaudeville/core/client.py
+++ b/vaudeville/core/client.py
@@ -9,9 +9,9 @@ import json
 import logging
 import socket
 
+from .paths import SOCKET_PATH
 from .protocol import ClassifyRequest, ClassifyResponse
 
-SOCKET_PATH = "/tmp/vaudeville.sock"
 CONNECT_TIMEOUT = 4.0  # Stay under PreToolUse 5s limit
 READ_TIMEOUT = 4.0
 RECV_CHUNK = 4096

--- a/vaudeville/core/client.py
+++ b/vaudeville/core/client.py
@@ -11,7 +11,7 @@ import socket
 
 from .protocol import ClassifyRequest, ClassifyResponse
 
-SOCKET_TEMPLATE = "/tmp/vaudeville-{session_id}.sock"
+SOCKET_PATH = "/tmp/vaudeville.sock"
 CONNECT_TIMEOUT = 4.0  # Stay under PreToolUse 5s limit
 READ_TIMEOUT = 4.0
 RECV_CHUNK = 4096
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 
 
 class VaudevilleClient:
-    def __init__(self, session_id: str) -> None:
-        self._socket_path = SOCKET_TEMPLATE.format(session_id=session_id)
+    def __init__(self) -> None:
+        self._socket_path = SOCKET_PATH
 
     def classify(
         self, rule: str, input_data: dict[str, object]

--- a/vaudeville/core/paths.py
+++ b/vaudeville/core/paths.py
@@ -1,0 +1,20 @@
+"""Runtime paths for vaudeville daemon and client.
+
+Per-UID directory in /tmp with 0700 permissions prevents other local
+users from intercepting the Unix socket or tampering with state files.
+"""
+
+from __future__ import annotations
+
+import os
+
+RUNTIME_DIR = f"/tmp/vaudeville-{os.getuid()}"
+SOCKET_PATH = os.path.join(RUNTIME_DIR, "vaudeville.sock")
+PID_FILE = os.path.join(RUNTIME_DIR, "vaudeville.pid")
+LOG_FILE = os.path.join(RUNTIME_DIR, "vaudeville.log")
+VERSION_FILE = os.path.join(RUNTIME_DIR, "vaudeville.version")
+
+
+def ensure_runtime_dir() -> None:
+    """Create runtime directory with restrictive permissions if absent."""
+    os.makedirs(RUNTIME_DIR, mode=0o700, exist_ok=True)

--- a/vaudeville/server/__main__.py
+++ b/vaudeville/server/__main__.py
@@ -2,7 +2,7 @@
 
 Usage: uv run python -m vaudeville.server [--socket PATH] [--pid-file PATH]
 
-Defaults to /tmp/vaudeville.sock and /tmp/vaudeville.pid (singleton daemon).
+Defaults to per-UID runtime directory (singleton daemon).
 """
 
 from __future__ import annotations
@@ -13,17 +13,14 @@ import os
 import sys
 from pathlib import Path
 
+from ..core.paths import PID_FILE, SOCKET_PATH
 from .inference import InferenceBackend
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Vaudeville inference daemon")
-    parser.add_argument(
-        "--socket", default="/tmp/vaudeville.sock", help="Unix socket path"
-    )
-    parser.add_argument(
-        "--pid-file", default="/tmp/vaudeville.pid", help="PID file path"
-    )
+    parser.add_argument("--socket", default=SOCKET_PATH, help="Unix socket path")
+    parser.add_argument("--pid-file", default=PID_FILE, help="PID file path")
     parser.add_argument(
         "--backend", default="mlx", choices=["mlx", "gguf"], help="Inference backend"
     )

--- a/vaudeville/server/__main__.py
+++ b/vaudeville/server/__main__.py
@@ -1,8 +1,8 @@
 """Entry point for the vaudeville daemon.
 
-Usage: uv run python -m vaudeville.server \\
-    --socket /tmp/vaudeville-{session_id}.sock \\
-    --pid-file /tmp/vaudeville-{session_id}.pid
+Usage: uv run python -m vaudeville.server [--socket PATH] [--pid-file PATH]
+
+Defaults to /tmp/vaudeville.sock and /tmp/vaudeville.pid (singleton daemon).
 """
 
 from __future__ import annotations
@@ -18,8 +18,12 @@ from .inference import InferenceBackend
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Vaudeville inference daemon")
-    parser.add_argument("--socket", required=True, help="Unix socket path")
-    parser.add_argument("--pid-file", required=True, help="PID file path")
+    parser.add_argument(
+        "--socket", default="/tmp/vaudeville.sock", help="Unix socket path"
+    )
+    parser.add_argument(
+        "--pid-file", default="/tmp/vaudeville.pid", help="PID file path"
+    )
     parser.add_argument(
         "--backend", default="mlx", choices=["mlx", "gguf"], help="Inference backend"
     )
@@ -46,13 +50,10 @@ def main() -> None:
         from .mlx_backend import MLXBackend
 
         backend = MLXBackend(args.model)
-    elif args.backend == "gguf":
+    else:
         from .gguf_backend import GGUFBackend
 
         backend = GGUFBackend()
-    else:
-        logging.error("Unknown backend: %s", args.backend)
-        sys.exit(1)
 
     logging.info("Backend ready")
 

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -12,6 +12,7 @@ import logging
 import os
 import signal
 import socket
+import subprocess
 import threading
 import time
 
@@ -19,9 +20,12 @@ from ..core.protocol import parse_verdict
 from ..core.rules import Rule, load_rules_layered, rules_search_path
 from .inference import InferenceBackend
 
-IDLE_TIMEOUT = 30 * 60  # 30 minutes
+IDLE_TIMEOUT = 60 * 60  # 60 minutes
+VERSION_FILE = "/tmp/vaudeville.version"
 RULE_POLL_INTERVAL = 30  # seconds
 RECV_CHUNK = 4096
+MAX_REQUEST_SIZE = 1 * 1024 * 1024  # 1 MB
+CLIENT_TIMEOUT = 10.0  # seconds
 THREAD_WARN = 20
 THREAD_KILL = 50
 
@@ -81,11 +85,13 @@ class VaudevilleDaemon:
         pid_file: str,
         plugin_root: str,
         backend: InferenceBackend,
+        version_file: str = VERSION_FILE,
     ) -> None:
         self._socket_path = socket_path
         self._pid_file = pid_file
         self._plugin_root = plugin_root
         self._backend = backend
+        self._version_file = version_file
         self._rules: dict[str, Rule] = {}
         self._rules_lock = threading.Lock()
         self._backend_lock = threading.Lock()
@@ -125,6 +131,8 @@ class VaudevilleDaemon:
         os.ftruncate(pid_fd, 0)
         os.write(pid_fd, f"{os.getpid()}\n".encode())
         self._pid_fd = pid_fd
+
+        self._write_version_stamp()
 
         server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
@@ -169,6 +177,7 @@ class VaudevilleDaemon:
 
     def _handle_client(self, conn: socket.socket) -> None:
         try:
+            conn.settimeout(CLIENT_TIMEOUT)
             t0 = time.monotonic()
             data = b""
             while True:
@@ -176,6 +185,8 @@ class VaudevilleDaemon:
                 if not chunk:
                     break
                 data += chunk
+                if len(data) > MAX_REQUEST_SIZE:
+                    break
                 if b"\n" in data:
                     break
 
@@ -232,11 +243,29 @@ class VaudevilleDaemon:
                     "[vaudeville] Thread count %d exceeds warning threshold", count
                 )
 
+    def _write_version_stamp(self) -> None:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=self._plugin_root,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            stamp = result.stdout.strip() if result.returncode == 0 else "unknown"
+        except (OSError, subprocess.TimeoutExpired):
+            stamp = "unknown"
+        try:
+            with open(self._version_file, "w") as f:
+                f.write(stamp + "\n")
+        except OSError:
+            logger.warning("[vaudeville] Could not write version stamp")
+
     def _cleanup(self) -> None:
         if self._pid_fd is not None:
             os.close(self._pid_fd)
             self._pid_fd = None
-        for path in (self._socket_path, self._pid_file):
+        for path in (self._socket_path, self._pid_file, self._version_file):
             try:
                 os.unlink(path)
             except FileNotFoundError:

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -137,7 +137,7 @@ class VaudevilleDaemon:
         server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
             os.unlink(self._socket_path)
-        except FileNotFoundError:
+        except (FileNotFoundError, PermissionError):
             pass
         server_socket.bind(self._socket_path)
         server_socket.listen(16)

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -16,12 +16,12 @@ import subprocess
 import threading
 import time
 
+from ..core.paths import VERSION_FILE, ensure_runtime_dir
 from ..core.protocol import parse_verdict
 from ..core.rules import Rule, load_rules_layered, rules_search_path
 from .inference import InferenceBackend
 
 IDLE_TIMEOUT = 60 * 60  # 60 minutes
-VERSION_FILE = "/tmp/vaudeville.version"
 RULE_POLL_INTERVAL = 30  # seconds
 RECV_CHUNK = 4096
 MAX_REQUEST_SIZE = 1 * 1024 * 1024  # 1 MB
@@ -114,6 +114,7 @@ class VaudevilleDaemon:
 
     def serve(self) -> None:
         """Load rules, write PID, bind socket, serve until idle timeout."""
+        ensure_runtime_dir()
         if threading.current_thread() is threading.main_thread():
             self._install_signal_handlers()
 

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -179,12 +179,12 @@ class VaudevilleDaemon:
         try:
             conn.settimeout(CLIENT_TIMEOUT)
             t0 = time.monotonic()
-            data = b""
+            data = bytearray()
             while True:
                 chunk = conn.recv(RECV_CHUNK)
                 if not chunk:
                     break
-                data += chunk
+                data.extend(chunk)
                 if len(data) > MAX_REQUEST_SIZE:
                     break
                 if b"\n" in data:
@@ -194,7 +194,7 @@ class VaudevilleDaemon:
                 current_rules = dict(self._rules)
 
             with self._backend_lock:
-                response = handle_request(data, current_rules, self._backend)
+                response = handle_request(bytes(data), current_rules, self._backend)
             conn.sendall(response)
             elapsed_ms = (time.monotonic() - t0) * 1000
             logger.info("[vaudeville] Request handled in %.1fms", elapsed_ms)


### PR DESCRIPTION
## Summary

- **Global singleton daemon** — replaces per-session architecture (one daemon per Claude Code session, each loading ~2.4GB Phi-3-mini) with a shared instance at `/tmp/vaudeville.sock`. Saves N×2.4GB of unified memory since the daemon is fully stateless between requests.
- **Version-stamp restart** — daemon writes `git rev-parse HEAD` to `/tmp/vaudeville.version` after PID lock. On SessionStart, the hook compares stamps and restarts on mismatch (SIGTERM → 2s poll → force-kill → respawn).
- **Safety hardening** — adds 10s client read timeout and 1MB request size cap to prevent connection exhaustion and OOM on the shared singleton.

## Files Changed

| File | Change |
|------|--------|
| `vaudeville/core/client.py` | `SOCKET_PATH` replaces `SOCKET_TEMPLATE`, no-arg constructor |
| `hooks/runner.py` | Drop `session_id` extraction |
| `hooks/session-start.sh` | Fixed paths, version stamp compare, restart loop |
| `vaudeville/server/daemon.py` | 1h idle timeout, version stamp lifecycle, read timeout + size cap |
| `vaudeville/server/__main__.py` | Default to global socket/pid paths |
| `tests/test_singleton.py` | Contract tests for singleton API |
| `tests/test_adversarial.py` | Adversarial tests (races, permissions, contention) |

## Test plan

- [x] All 93 tests pass (`uv run pytest tests/ -v`)
- [x] Ruff clean (`uv run ruff check`)
- [ ] Manual: kill existing daemons, start session → daemon at `/tmp/vaudeville.sock`
- [ ] Manual: start second session → no new daemon spawned
- [ ] Manual: change version stamp → new session restarts daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)