### PR TITLE
fix(plugin): arch-aware install, uv-based hooks, and setup command

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -26,13 +26,20 @@ echo "uv $(uv --version)"
 
 ```bash
 arch=$(uname -m)
-if [ "$arch" = "arm64" ]; then
-  echo "Apple Silicon detected — syncing mlx backend..."
-  uv sync --project "${CLAUDE_PLUGIN_ROOT}" --group dev --group mlx
-else
-  echo "x86_64 detected — syncing gguf backend..."
-  uv sync --project "${CLAUDE_PLUGIN_ROOT}" --group dev --group gguf
-fi
+case "$arch" in
+  arm64|aarch64)
+    echo "ARM64 detected — syncing mlx backend..."
+    uv sync --project "${CLAUDE_PLUGIN_ROOT}" --group dev --group mlx
+    ;;
+  x86_64|amd64)
+    echo "x86_64 detected — syncing gguf backend..."
+    uv sync --project "${CLAUDE_PLUGIN_ROOT}" --group dev --group gguf
+    ;;
+  *)
+    echo "Unknown architecture '$arch' — defaulting to gguf backend..."
+    uv sync --project "${CLAUDE_PLUGIN_ROOT}" --group dev --group gguf
+    ;;
+esac
 ```
 
 3. **Download the model** (~2.4 GB, one-time):

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,0 +1,50 @@
+---
+description: Install prerequisites and download the SLM model for vaudeville
+allowed-tools:
+  - Bash
+---
+
+# Vaudeville Setup
+
+Run the full setup sequence: install `uv` if missing, sync Python dependencies, and download the inference model.
+
+## Steps
+
+1. **Check for `uv`** — if not found, install it via the official installer:
+
+```bash
+if ! command -v uv &>/dev/null; then
+  echo "Installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # Reload PATH so uv is available immediately
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+echo "uv $(uv --version)"
+```
+
+2. **Sync dependencies** — install the correct backend for this architecture:
+
+```bash
+arch=$(uname -m)
+if [ "$arch" = "arm64" ]; then
+  echo "Apple Silicon detected — syncing mlx backend..."
+  uv sync --project "${CLAUDE_PLUGIN_ROOT}" --group dev --group mlx
+else
+  echo "x86_64 detected — syncing gguf backend..."
+  uv sync --project "${CLAUDE_PLUGIN_ROOT}" --group dev --group gguf
+fi
+```
+
+3. **Download the model** (~2.4 GB, one-time):
+
+```bash
+uv run --project "${CLAUDE_PLUGIN_ROOT}" python -m vaudeville.setup
+```
+
+4. **Verify the daemon starts** — restart the session or run the session-start hook manually:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh" < /dev/null
+```
+
+Report success or failure to the user after each step. If any step fails, stop and diagnose before continuing.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/runner.py violation-detector dismissal-detector",
+            "command": "uv run --project ${CLAUDE_PLUGIN_ROOT} python ${CLAUDE_PLUGIN_ROOT}/hooks/runner.py violation-detector dismissal-detector",
             "timeout": 30,
             "statusMessage": "Evaluating response quality..."
           }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/runner.py deferral-detector",
+            "command": "uv run --project ${CLAUDE_PLUGIN_ROOT} python ${CLAUDE_PLUGIN_ROOT}/hooks/runner.py deferral-detector",
             "timeout": 10,
             "statusMessage": "Checking PR reply for deferral..."
           }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --project ${CLAUDE_PLUGIN_ROOT} python ${CLAUDE_PLUGIN_ROOT}/hooks/runner.py violation-detector dismissal-detector",
+            "command": "uv run --project \"${CLAUDE_PLUGIN_ROOT}\" python \"${CLAUDE_PLUGIN_ROOT}/hooks/runner.py\" violation-detector dismissal-detector",
             "timeout": 30,
             "statusMessage": "Evaluating response quality..."
           }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --project ${CLAUDE_PLUGIN_ROOT} python ${CLAUDE_PLUGIN_ROOT}/hooks/runner.py deferral-detector",
+            "command": "uv run --project \"${CLAUDE_PLUGIN_ROOT}\" python \"${CLAUDE_PLUGIN_ROOT}/hooks/runner.py\" deferral-detector",
             "timeout": 10,
             "statusMessage": "Checking PR reply for deferral..."
           }

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -28,7 +28,7 @@ VERSION_FILE="${RUNTIME_DIR}/vaudeville.version"
 # Write socket path to session env so subsequent hooks skip re-derivation
 export_socket_path() {
   if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-    echo "export VAUDEVILLE_SOCKET=${SOCKET_PATH}" >> "${CLAUDE_ENV_FILE}"
+    printf 'export VAUDEVILLE_SOCKET=%q\n' "${SOCKET_PATH}" >> "${CLAUDE_ENV_FILE}"
   fi
 }
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -10,6 +10,12 @@ PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 # Always read stdin (Claude Code sends JSON; not reading causes SIGPIPE)
 INPUT=$(cat)
 
+# uv is required for dependency management
+if ! command -v uv &>/dev/null; then
+  echo "[vaudeville] uv not found. Run /vaudeville:setup to install prerequisites." >&2
+  exit 0
+fi
+
 # Per-UID runtime directory (0700) prevents other users from intercepting socket
 RUNTIME_DIR="/tmp/vaudeville-$(id -u)"
 mkdir -m 0700 "${RUNTIME_DIR}" 2>/dev/null || true
@@ -19,10 +25,17 @@ PID_FILE="${RUNTIME_DIR}/vaudeville.pid"
 LOG_FILE="${RUNTIME_DIR}/vaudeville.log"
 VERSION_FILE="${RUNTIME_DIR}/vaudeville.version"
 
+# Write socket path to session env so subsequent hooks skip re-derivation
+export_socket_path() {
+  if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    echo "export VAUDEVILLE_SOCKET=${SOCKET_PATH}" >> "${CLAUDE_ENV_FILE}"
+  fi
+}
+
 # Check if model cache exists
 MODEL_CACHE="${HOME}/.cache/huggingface/hub/models--mlx-community--Phi-3-mini-4k-instruct-4bit"
 if [ ! -d "${MODEL_CACHE}" ]; then
-  echo "[vaudeville] Model not downloaded. Run: cd ${PLUGIN_ROOT} && uv run python -m vaudeville.setup" >&2
+  echo "[vaudeville] Model not downloaded. Run /vaudeville:setup to download it." >&2
   exit 0
 fi
 
@@ -37,6 +50,7 @@ if [ -f "${PID_FILE}" ]; then
     RUNNING_VERSION=$(cat "${VERSION_FILE}" 2>/dev/null || echo "")
     if [ -z "${RUNNING_VERSION}" ] || [ "${RUNNING_VERSION}" = "${CURRENT_VERSION}" ]; then
       echo "[vaudeville] Daemon up to date (PID ${PID})" >&2
+      export_socket_path
       exit 0
     fi
     # Version mismatch — restart daemon
@@ -68,4 +82,5 @@ DAEMON_PID=$!
 disown "${DAEMON_PID}"
 
 echo "[vaudeville] Daemon spawned (PID ${DAEMON_PID}, socket ${SOCKET_PATH})" >&2
+export_socket_path
 exit 0

--- a/justfile
+++ b/justfile
@@ -1,0 +1,73 @@
+set dotenv-load := true
+
+# Show available commands
+@default:
+    just --list
+
+# Install dependencies (sync with pyproject.toml, arch-aware backend)
+install:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    arch=$(uname -m)
+    if [ "$arch" = "arm64" ]; then
+        echo "Apple Silicon detected — installing with mlx backend"
+        uv sync --group dev --group mlx
+    else
+        echo "x86_64 detected — installing with gguf backend"
+        uv sync --group dev --group gguf
+    fi
+
+# Run the full test suite
+test *args:
+    uv run pytest {{args}}
+
+# Run tests with coverage report
+test-coverage *args:
+    uv run pytest --cov=vaudeville --cov-report=term-missing {{args}}
+
+# Run all quality checks (format, lint, type)
+check: fmt-check lint type-check
+    @echo "All checks passed ✓"
+
+# Run ruff linter
+lint:
+    uv run ruff check .
+
+# Format code with ruff
+fmt:
+    uv run ruff format .
+
+# Verify format compliance (used in CI)
+fmt-check:
+    uv run ruff format --check .
+
+# Run mypy type checker (strict mode)
+type-check:
+    uv run mypy --strict vaudeville/ tests/
+
+# Download the MLX model for inference (one-time setup, ~2.4 GB)
+setup:
+    uv sync --group mlx
+    uv run python -m vaudeville.setup
+
+# Run the eval harness on all rules
+eval:
+    uv run python -m vaudeville.eval
+
+# Run eval with cross-validation
+eval-cv:
+    uv run python -m vaudeville.eval --cross-validate
+
+# Run eval for a specific rule (e.g., `just eval-rule violation-detector`)
+eval-rule rule:
+    uv run python -m vaudeville.eval --rule {{rule}}
+
+# Clean build and test artifacts
+clean:
+    rm -rf .pytest_cache .mypy_cache .ruff_cache
+    find . -type d -name __pycache__ -exec rm -rf {} + || true
+    find . -type f -name "*.pyc" -delete || true
+
+# Run a development shell with dependencies
+dev:
+    uv run python -c "import sys; print(f'Python {sys.version}')" && bash

--- a/justfile
+++ b/justfile
@@ -9,13 +9,20 @@ install:
     #!/usr/bin/env bash
     set -euo pipefail
     arch=$(uname -m)
-    if [ "$arch" = "arm64" ]; then
-        echo "Apple Silicon detected — installing with mlx backend"
-        uv sync --group dev --group mlx
-    else
-        echo "x86_64 detected — installing with gguf backend"
-        uv sync --group dev --group gguf
-    fi
+    case "$arch" in
+        arm64|aarch64)
+            echo "ARM64 detected — installing with mlx backend"
+            uv sync --group dev --group mlx
+            ;;
+        x86_64|amd64)
+            echo "x86_64 detected — installing with gguf backend"
+            uv sync --group dev --group gguf
+            ;;
+        *)
+            echo "Warning: unknown architecture '$arch' — defaulting to gguf backend" >&2
+            uv sync --group dev --group gguf
+            ;;
+    esac
 
 # Run the full test suite
 test *args:
@@ -45,9 +52,21 @@ fmt-check:
 type-check:
     uv run mypy --strict vaudeville/ tests/
 
-# Download the MLX model for inference (one-time setup, ~2.4 GB)
+# Download the inference model (one-time setup, ~2.4 GB, arch-aware backend)
 setup:
-    uv sync --group mlx
+    #!/usr/bin/env bash
+    set -euo pipefail
+    arch=$(uname -m)
+    case "$arch" in
+        arm64|aarch64)
+            echo "ARM64 detected — syncing mlx backend"
+            uv sync --group mlx
+            ;;
+        *)
+            echo "Non-ARM detected — syncing gguf backend"
+            uv sync --group gguf
+            ;;
+    esac
     uv run python -m vaudeville.setup
 
 # Run the eval harness on all rules

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -111,10 +111,11 @@ class TestLoadRules:
 
 class TestFailOpen:
     def test_client_returns_none_for_missing_socket(self) -> None:
-        client = VaudevilleClient()
-        client._socket_path = "/tmp/vaudeville-nonexistent.sock"
-        result = client.classify("violation-detector", {"text": "test"})
-        assert result is None
+        with tempfile.TemporaryDirectory() as td:
+            client = VaudevilleClient()
+            client._socket_path = os.path.join(td, "nonexistent.sock")
+            result = client.classify("violation-detector", {"text": "test"})
+            assert result is None
 
     def test_runner_allows_when_daemon_unavailable(self) -> None:
         """runner.main() exits 0 when client returns None for all rules."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -112,6 +112,7 @@ class TestLoadRules:
 class TestFailOpen:
     def test_client_returns_none_for_missing_socket(self) -> None:
         client = VaudevilleClient()
+        client._socket_path = "/tmp/vaudeville-nonexistent.sock"
         result = client.classify("violation-detector", {"text": "test"})
         assert result is None
 

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -104,12 +104,13 @@ class TestVaudevilleClientNoArgs:
         """Fail-open semantics must still hold with no-arg constructor."""
         from vaudeville.core.client import VaudevilleClient
 
-        client = VaudevilleClient()
-        client._socket_path = "/tmp/vaudeville-nonexistent.sock"
-        result = client.classify("violation-detector", {"text": "test"})
-        assert result is None, (
-            "classify() must return None when daemon is unavailable (fail-open)"
-        )
+        with tempfile.TemporaryDirectory() as td:
+            client = VaudevilleClient()
+            client._socket_path = os.path.join(td, "nonexistent.sock")
+            result = client.classify("violation-detector", {"text": "test"})
+            assert result is None, (
+                "classify() must return None when daemon is unavailable (fail-open)"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -105,6 +105,7 @@ class TestVaudevilleClientNoArgs:
         from vaudeville.core.client import VaudevilleClient
 
         client = VaudevilleClient()
+        client._socket_path = "/tmp/vaudeville-nonexistent.sock"
         result = client.classify("violation-detector", {"text": "test"})
         assert result is None, (
             "classify() must return None when daemon is unavailable (fail-open)"

--- a/vaudeville/core/paths.py
+++ b/vaudeville/core/paths.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 import os
 
 RUNTIME_DIR = f"/tmp/vaudeville-{os.getuid()}"
-SOCKET_PATH = os.path.join(RUNTIME_DIR, "vaudeville.sock")
+SOCKET_PATH = os.environ.get(
+    "VAUDEVILLE_SOCKET", os.path.join(RUNTIME_DIR, "vaudeville.sock")
+)
 PID_FILE = os.path.join(RUNTIME_DIR, "vaudeville.pid")
 LOG_FILE = os.path.join(RUNTIME_DIR, "vaudeville.log")
 VERSION_FILE = os.path.join(RUNTIME_DIR, "vaudeville.version")

--- a/vaudeville/core/paths.py
+++ b/vaudeville/core/paths.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import os
 
 RUNTIME_DIR = f"/tmp/vaudeville-{os.getuid()}"
-SOCKET_PATH = os.environ.get(
-    "VAUDEVILLE_SOCKET", os.path.join(RUNTIME_DIR, "vaudeville.sock")
+# VAUDEVILLE_SOCKET may be set by SessionStart via CLAUDE_ENV_FILE to avoid
+# re-deriving the path in each hook. Treat empty string as unset.
+SOCKET_PATH = os.environ.get("VAUDEVILLE_SOCKET") or os.path.join(
+    RUNTIME_DIR, "vaudeville.sock"
 )
 PID_FILE = os.path.join(RUNTIME_DIR, "vaudeville.pid")
 LOG_FILE = os.path.join(RUNTIME_DIR, "vaudeville.log")


### PR DESCRIPTION
## Summary

- **Arch-aware install**: `just install` detects arm64 vs x86_64 and syncs the correct backend (mlx or gguf), fixing the llama-cpp-python build failure on Apple Silicon
- **Fix yaml import**: Stop/PostToolUse hooks now use `uv run --project` instead of bare `python3`, so PyYAML is available in installed plugin copies
- **Socket path via env**: SessionStart writes `VAUDEVILLE_SOCKET` to `$CLAUDE_ENV_FILE`, subsequent hooks read it from env instead of re-deriving
- **Setup command**: New `/vaudeville:setup` slash command handles first-time setup (uv install, dep sync, model download) with user-visible feedback
- **Test fix**: Fail-open tests use a nonexistent socket path so they don't hit a running daemon

## Test plan

- [x] `just check` passes (format + lint + type-check)
- [x] `just test` passes (93 tests)
- [x] `just install` works on Apple Silicon (syncs mlx group only)
- [x] Daemon responds to classify requests after session start
- [x] Plugin audit against Claude Code best practices — no issues found

🤖 Generated with [Claude Code](https://claude.com/claude-code)