### PR TITLE
fix: SLM inference bugs + coverage quality gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# Vaudeville
+
+SLM-powered hook enforcement plugin for Claude Code. Uses Phi-3-mini (3.8B, int4) to classify AI responses against quality rules.
+
+## Build & Test
+
+```bash
+just check        # lint + typecheck + test
+just coverage     # tests with line coverage report (fails under 80%)
+just test         # tests only
+just lint         # ruff check + format check
+just typecheck    # mypy strict
+just fmt          # auto-format
+just eval         # run eval harness against bundled rules
+```
+
+## Quality Gates
+
+- `just check` must pass before committing
+- `just coverage` for coverage verification
+
+### Coverage Policy
+
+- **New code must have 90%+ line coverage.** No exceptions. If you add a function, test it.
+- **Boy Scout Rule**: when touching code adjacent to your change (same file or closely coupled module), add tests for uncovered lines you encounter. Leave coverage better than you found it.
+- Overall project floor is 70% (enforced by `just coverage`). Ratchet this up as coverage improves. The 90% rule applies per-change, not retroactively to legacy code.
+- Hardware-dependent modules (MLX/GGUF backends, setup.py, `__main__.py`) are excluded from coverage metrics.
+
+## Architecture
+
+Vertical slices under `vaudeville/`:
+- `core/` — protocol, client, rules (stdlib-only, safe for hook scripts)
+- `server/` — daemon, inference backends (MLX, GGUF)
+- `eval.py` — eval harness for rule accuracy testing
+
+Hook entry point: `hooks/runner.py` (thin, stdlib-only, fail-open)
+
+## Key Patterns
+
+- **Fail-open everywhere**: daemon down → allow, inference error → allow, unknown rule → allow
+- **Back-truncation**: input text is truncated to last 1500 tokens (violations cluster at end)
+- **Prompt injection defense**: VERDICT:/REASON: markers are neutralized with zero-width spaces before interpolation
+- **Deterministic inference**: both backends use temp=0.0

--- a/justfile
+++ b/justfile
@@ -1,0 +1,33 @@
+# Vaudeville development tasks
+
+# Run all quality checks
+check: lint typecheck test
+
+# Run tests
+test:
+    uv run python -m pytest tests/ -q
+
+# Run tests with coverage report
+coverage:
+    uv run --with pytest-cov python -m pytest tests/ -q \
+        --cov=vaudeville --cov-report=term-missing \
+        --cov-fail-under=70 \
+        --cov-config=pyproject.toml
+
+# Lint and format check
+lint:
+    uv run ruff check .
+    uv run ruff format --check .
+
+# Type check
+typecheck:
+    uv run mypy vaudeville/
+
+# Format code
+fmt:
+    uv run ruff format .
+    uv run ruff check --fix .
+
+# Run eval harness
+eval *ARGS:
+    uv run python -m vaudeville.eval {{ARGS}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,15 @@ warn_unused_ignores = false
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 
+[tool.coverage.run]
+source = ["vaudeville"]
+omit = [
+    "vaudeville/server/mlx_backend.py",
+    "vaudeville/server/gguf_backend.py",
+    "vaudeville/setup.py",
+    "vaudeville/server/__main__.py",
+]
+
 [dependency-groups]
 dev = [
     "mypy>=1.19.1",

--- a/vaudeville/core/rules.py
+++ b/vaudeville/core/rules.py
@@ -20,6 +20,25 @@ from typing import Any
 import yaml
 
 
+MAX_INPUT_TOKENS = 1500
+CHARS_PER_TOKEN = 4  # conservative English approximation
+
+
+def _sanitize_input(text: str) -> str:
+    """Neutralize verdict/reason markers that could spoof parse_verdict()."""
+    return text.replace("VERDICT:", "VERDICT\u200b:").replace(
+        "REASON:", "REASON\u200b:"
+    )
+
+
+def back_truncate(text: str, max_tokens: int = MAX_INPUT_TOKENS) -> str:
+    """Keep the last max_tokens tokens (approx). Violations cluster at the end."""
+    max_chars = max_tokens * CHARS_PER_TOKEN
+    if len(text) <= max_chars:
+        return text
+    return text[-max_chars:]
+
+
 def _resolve_field(data: dict[str, object], path: str) -> object:
     """Resolve a dot-notation path like 'tool_input.body' from a nested dict."""
     current: object = data
@@ -61,7 +80,8 @@ class Rule:
     message: str
 
     def format_prompt(self, text: str, context: str = "") -> str:
-        return self.prompt.replace("{text}", text).replace("{context}", context)
+        sanitized = _sanitize_input(text)
+        return self.prompt.replace("{text}", sanitized).replace("{context}", context)
 
     def resolve_context(
         self,

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -16,7 +16,7 @@ import time
 from pathlib import Path
 
 from ..core.protocol import parse_verdict
-from ..core.rules import Rule, load_rules_layered, rules_search_path
+from ..core.rules import Rule, back_truncate, load_rules_layered, rules_search_path
 from .inference import InferenceBackend
 
 IDLE_TIMEOUT = 30 * 60  # 30 minutes
@@ -58,7 +58,7 @@ def handle_request(
         if rule is None:
             return _response("clean", f"Unknown rule: {rule_name}")
 
-        text = str(input_data.get("text", ""))
+        text = back_truncate(str(input_data.get("text", "")))
         plugin_root = os.environ.get(
             "CLAUDE_PLUGIN_ROOT",
             os.path.dirname(

--- a/vaudeville/server/mlx_backend.py
+++ b/vaudeville/server/mlx_backend.py
@@ -25,6 +25,7 @@ class MLXBackend:
             self._tokenizer,
             prompt=formatted,
             max_tokens=max_tokens,
+            temp=0.0,
             verbose=False,
         )
         return result


### PR DESCRIPTION
## Summary

- Fix non-deterministic MLX inference by adding `temp=0.0` to `mlx_lm.generate()`
- Defend against prompt injection by sanitizing `VERDICT:`/`REASON:` markers in input text with zero-width spaces before interpolation
- Back-truncate input to last 1500 tokens (violations cluster at end of responses)
- Add justfile with `coverage` recipe using pytest-cov (`--cov-fail-under=70`, hardware-dependent modules excluded)
- Add CLAUDE.md with 90%+ line coverage policy for new code and boy scout rule for adjacent areas

## Test plan

- [x] All 56 existing tests pass
- [x] `just check` passes (lint + typecheck + test)
- [x] `just coverage` passes at 70% floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)