### PR TITLE
feat: shift eval gate from accuracy to precision/recall

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -101,12 +101,27 @@ class TestEvaluateRule:
 
 
 class TestPrintResults:
-    def test_passes_at_90_percent(self) -> None:
-        r = EvalResults(rule="test-rule", tp=9, tn=9, fp=1, fn=1)
-        passed = print_results(r)
-        assert passed is True
+    def test_passes_high_precision_adequate_recall(self) -> None:
+        # precision=100%, recall=82.6%
+        r = EvalResults(rule="test-rule", tp=19, fp=0, tn=10, fn=4)
+        assert print_results(r) is True
 
-    def test_fails_below_90_percent(self) -> None:
-        r = EvalResults(rule="test-rule", tp=7, tn=7, fp=3, fn=3)
-        passed = print_results(r)
-        assert passed is False
+    def test_fails_low_precision(self) -> None:
+        # precision=80%, recall=80%
+        r = EvalResults(rule="test-rule", tp=8, fp=2, tn=8, fn=2)
+        assert print_results(r) is False
+
+    def test_fails_low_recall(self) -> None:
+        # precision=100%, recall=70%
+        r = EvalResults(rule="test-rule", tp=7, fp=0, tn=10, fn=3)
+        assert print_results(r) is False
+
+    def test_passes_at_exact_thresholds(self) -> None:
+        # precision=95% (20/21), recall=80% (20/25)
+        r = EvalResults(rule="test-rule", tp=20, fp=1, tn=10, fn=5)
+        assert print_results(r) is True
+
+    def test_fails_both_below(self) -> None:
+        # precision=75%, recall=60%
+        r = EvalResults(rule="test-rule", tp=6, fp=2, tn=8, fn=4)
+        assert print_results(r) is False

--- a/vaudeville/eval.py
+++ b/vaudeville/eval.py
@@ -219,7 +219,9 @@ def print_results(results: EvalResults) -> bool:
         return "" if ok else " << BELOW THRESHOLD"
 
     print(f"\n=== {results.rule} [{status}] ===")
-    print(f"Accuracy:  {results.accuracy * 100:.1f}% ({results.tp + results.tn}/{results.total})")
+    print(
+        f"Accuracy:  {results.accuracy * 100:.1f}% ({results.tp + results.tn}/{results.total})"
+    )
     print(f"Precision: {prec_pct:.1f}% (>= 95%){_marker(prec_ok)}")
     print(f"Recall:    {rec_pct:.1f}% (>= 80%){_marker(rec_ok)}")
     print(f"F1:        {results.f1 * 100:.1f}%")

--- a/vaudeville/eval.py
+++ b/vaudeville/eval.py
@@ -207,15 +207,21 @@ def cross_validate_rule(
 
 
 def print_results(results: EvalResults) -> bool:
-    """Print metrics, return True if accuracy >= 90%."""
-    pct = results.accuracy * 100
-    passed = pct >= 90.0
+    """Print metrics, return True if precision >= 95% and recall >= 80%."""
+    prec_pct = results.precision * 100
+    rec_pct = results.recall * 100
+    prec_ok = prec_pct >= 95.0
+    rec_ok = rec_pct >= 80.0
+    passed = prec_ok and rec_ok
     status = "PASS" if passed else "FAIL"
 
+    def _marker(ok: bool) -> str:
+        return "" if ok else " << BELOW THRESHOLD"
+
     print(f"\n=== {results.rule} [{status}] ===")
-    print(f"Accuracy:  {pct:.1f}% ({results.tp + results.tn}/{results.total})")
-    print(f"Precision: {results.precision * 100:.1f}%")
-    print(f"Recall:    {results.recall * 100:.1f}%")
+    print(f"Accuracy:  {results.accuracy * 100:.1f}% ({results.tp + results.tn}/{results.total})")
+    print(f"Precision: {prec_pct:.1f}% (>= 95%){_marker(prec_ok)}")
+    print(f"Recall:    {rec_pct:.1f}% (>= 80%){_marker(rec_ok)}")
     print(f"F1:        {results.f1 * 100:.1f}%")
     print(f"Confusion: TP={results.tp} FP={results.fp} TN={results.tn} FN={results.fn}")
 


### PR DESCRIPTION
## Summary

- Replaces the single `accuracy >= 90%` eval pass threshold with dual gates: `precision >= 95%` and `recall >= 80%`
- Prioritizes avoiding false positives (blocking valid work) over catching every violation, per the SLM hook authoring guide
- Adds `<< BELOW THRESHOLD` markers to eval output for quick failure scanning
- Expands test coverage from 2 to 5 cases covering high precision, low precision, low recall, exact boundaries, and both-below scenarios

## Test plan

- [x] All 59 tests pass (`uv run pytest -v`)
- [x] Boundary case verified: precision=95.24%, recall=80% passes; precision=95%, recall=79.2% fails


🤖 Generated with [Claude Code](https://claude.com/claude-code)