### PR TITLE
feat: auto-discover rules by event type

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --project \"${CLAUDE_PLUGIN_ROOT}\" python \"${CLAUDE_PLUGIN_ROOT}/hooks/runner.py\" violation-detector dismissal-detector",
+            "command": "uv run --project \"${CLAUDE_PLUGIN_ROOT}\" python \"${CLAUDE_PLUGIN_ROOT}/hooks/runner.py\" --event Stop",
             "timeout": 30,
             "statusMessage": "Evaluating response quality..."
           }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run --project \"${CLAUDE_PLUGIN_ROOT}\" python \"${CLAUDE_PLUGIN_ROOT}/hooks/runner.py\" deferral-detector",
+            "command": "uv run --project \"${CLAUDE_PLUGIN_ROOT}\" python \"${CLAUDE_PLUGIN_ROOT}/hooks/runner.py\" --event PostToolUse",
             "timeout": 10,
             "statusMessage": "Checking PR reply for deferral..."
           }

--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
-"""Generic hook runner — evaluates rules by name against hook input.
+"""Generic hook runner — evaluates rules against hook input.
 
-Usage: python3 runner.py <rule-name> [rule-name ...]
+Usage:
+  python3 runner.py --event Stop          # auto-discover rules for event
+  python3 runner.py <rule-name> [...]     # explicit rule names (legacy)
 
-Reads Claude Code hook JSON from stdin, extracts text per each rule's
-`context.field` dotted path, classifies via daemon socket, and returns
-the first blocking verdict (or passes if all clean).
+Reads Claude Code hook JSON from stdin, loads rules (layered: bundled ->
+~/.vaudeville/rules/ -> project/.vaudeville/rules/), classifies via daemon
+socket, and returns the first blocking verdict (or passes if all clean).
 
 Fails open: if daemon is unavailable or input is missing, allows the hook.
 """
@@ -133,10 +135,28 @@ def main() -> None:
         sys.exit(0)
 
 
+def _load_rules_for_event(event: str) -> list:
+    """Auto-discover all rules matching an event via layered resolution."""
+    from vaudeville.core.rules import load_rules_layered  # noqa: E402
+
+    project_root = _find_project_root()
+    all_rules = load_rules_layered(PLUGIN_ROOT, project_root)
+    return [r for r in all_rules.values() if r.event == event]
+
+
 def _run() -> None:
-    rule_names = sys.argv[1:]
-    if not rule_names:
-        print("[vaudeville] runner: no rules specified", file=sys.stderr)
+    args = sys.argv[1:]
+
+    # Parse --event flag for auto-discovery mode
+    event = None
+    rule_names: list[str] = []
+    if len(args) >= 2 and args[0] == "--event":
+        event = args[1]
+    else:
+        rule_names = args
+
+    if not event and not rule_names:
+        print("[vaudeville] runner: no rules or --event specified", file=sys.stderr)
         print("{}")
         sys.exit(0)
 
@@ -148,6 +168,41 @@ def _run() -> None:
 
     client = VaudevilleClient()
 
+    if event:
+        _run_event_rules(event, hook_input, client)
+    else:
+        _run_named_rules(rule_names, hook_input, client)
+
+
+def _run_event_rules(event: str, hook_input: dict, client: VaudevilleClient) -> None:
+    """Evaluate all rules matching the given event."""
+    rules = _load_rules_for_event(event)
+    for rule in rules:
+        text = extract_field(hook_input, rule.context[0]["field"]) if rule.context else ""
+        if not text or len(text) < MIN_TEXT_LENGTH:
+            continue
+
+        result = client.classify(rule.name, {"text": text})
+        if result is None:
+            continue
+
+        if result.verdict == "violation":
+            response = verdict_to_hook_response(
+                {"name": rule.name, "message": rule.message},
+                result.reason,
+                rule.action,
+            )
+            print(json.dumps(response))
+            sys.exit(0)
+
+    print("{}")
+    sys.exit(0)
+
+
+def _run_named_rules(
+    rule_names: list[str], hook_input: dict, client: VaudevilleClient
+) -> None:
+    """Evaluate explicitly named rules (legacy mode)."""
     # Build classify tasks for all valid rules
     tasks: list[tuple[str, dict]] = []
     for name in rule_names:

--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -141,7 +141,8 @@ def _load_rules_for_event(event: str) -> list:
 
     project_root = _find_project_root()
     all_rules = load_rules_layered(PLUGIN_ROOT, project_root)
-    return [r for r in all_rules.values() if r.event == event]
+    matching = [r for r in all_rules.values() if r.event == event]
+    return sorted(matching, key=lambda r: r.name)
 
 
 def _run() -> None:
@@ -178,7 +179,7 @@ def _run_event_rules(event: str, hook_input: dict, client: VaudevilleClient) -> 
     """Evaluate all rules matching the given event."""
     rules = _load_rules_for_event(event)
     for rule in rules:
-        text = extract_field(hook_input, rule.context[0]["field"]) if rule.context else ""
+        text = extract_text(hook_input, {"context": rule.context})
         if not text or len(text) < MIN_TEXT_LENGTH:
             continue
 
@@ -190,7 +191,7 @@ def _run_event_rules(event: str, hook_input: dict, client: VaudevilleClient) -> 
             response = verdict_to_hook_response(
                 {"name": rule.name, "message": rule.message},
                 result.reason,
-                rule.action,
+                result.action,
             )
             print(json.dumps(response))
             sys.exit(0)

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -27,6 +27,13 @@ fi
 # Always read stdin (Claude Code sends JSON; not reading causes SIGPIPE)
 INPUT=$(cat)
 
+# Read session_id from stdin JSON
+SESSION_ID=$(echo "$INPUT" | python3 -c \
+  "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" \
+  2>/dev/null || echo "unknown")
+# Sanitize — session_id comes from stdin JSON, strip path-traversal chars
+SESSION_ID=$(echo "$SESSION_ID" | tr -cd 'a-zA-Z0-9_-')
+
 # uv is required for dependency management
 if ! command -v uv &>/dev/null; then
   echo "[vaudeville] uv not found. Run /vaudeville:setup to install prerequisites." >&2

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -84,7 +84,7 @@ if [ -f "${PID_FILE}" ]; then
     echo "[vaudeville] Version mismatch — restarting daemon (PID ${PID})" >&2
     kill "${PID}" 2>/dev/null || true
     # Wait up to 2s for socket to disappear (20 x 0.1s)
-    for i in $(seq 1 20); do
+    for _ in $(seq 1 20); do
       [ ! -S "${SOCKET_PATH}" ] && break
       sleep 0.1
     done

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -33,6 +33,10 @@ SESSION_ID=$(echo "$INPUT" | python3 -c \
   2>/dev/null || echo "unknown")
 # Sanitize — session_id comes from stdin JSON, strip path-traversal chars
 SESSION_ID=$(echo "$SESSION_ID" | tr -cd 'a-zA-Z0-9_-')
+# Guard against empty string after sanitization (would cause path collisions)
+if [ -z "${SESSION_ID}" ]; then
+  SESSION_ID="unknown"
+fi
 
 # uv is required for dependency management
 if ! command -v uv &>/dev/null; then

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -25,18 +25,7 @@ else
 fi
 
 # Always read stdin (Claude Code sends JSON; not reading causes SIGPIPE)
-INPUT=$(cat)
-
-# Read session_id from stdin JSON
-SESSION_ID=$(echo "$INPUT" | python3 -c \
-  "import sys,json; print(json.load(sys.stdin).get('session_id','unknown'))" \
-  2>/dev/null || echo "unknown")
-# Sanitize — session_id comes from stdin JSON, strip path-traversal chars
-SESSION_ID=$(echo "$SESSION_ID" | tr -cd 'a-zA-Z0-9_-')
-# Guard against empty string after sanitization (would cause path collisions)
-if [ -z "${SESSION_ID}" ]; then
-  SESSION_ID="unknown"
-fi
+cat > /dev/null
 
 # uv is required for dependency management
 if ! command -v uv &>/dev/null; then

--- a/tests/test_prompt_tuning.py
+++ b/tests/test_prompt_tuning.py
@@ -490,3 +490,246 @@ class TestRunnerHelpers:
                 runner._run()
             assert exc_info.value.code == 0
         assert json.loads(stdout.getvalue()) == {}
+
+
+# --- Event-based rule discovery ---
+
+
+class TestEventDiscovery:
+    """Tests for --event flag auto-discovery in hooks/runner.py."""
+
+    def _get_runner(self):
+        import importlib
+
+        hooks_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "hooks",
+        )
+        if hooks_dir not in sys.path:
+            sys.path.insert(0, hooks_dir)
+        runner = importlib.import_module("runner")
+        importlib.reload(runner)
+        return runner
+
+    def _make_hook_input(self, text: str = "A" * 200) -> str:
+        return json.dumps(
+            {
+                "session_id": "test-session",
+                "last_assistant_message": text,
+                "tool_input": {"body": text},
+            }
+        )
+
+    def test_load_rules_for_event_filters_by_event(self) -> None:
+        runner = self._get_runner()
+        from vaudeville.core.rules import Rule
+
+        mock_rules = {
+            "stop-rule": Rule(
+                name="stop-rule",
+                event="Stop",
+                prompt="{text}",
+                context=[{"field": "last_assistant_message"}],
+                action="block",
+                message="{reason}",
+            ),
+            "post-rule": Rule(
+                name="post-rule",
+                event="PostToolUse",
+                prompt="{text}",
+                context=[{"field": "tool_input.body"}],
+                action="block",
+                message="{reason}",
+            ),
+        }
+
+        with patch("vaudeville.core.rules.load_rules_layered", return_value=mock_rules):
+            stop_rules = runner._load_rules_for_event("Stop")
+            assert len(stop_rules) == 1
+            assert stop_rules[0].name == "stop-rule"
+
+            post_rules = runner._load_rules_for_event("PostToolUse")
+            assert len(post_rules) == 1
+            assert post_rules[0].name == "post-rule"
+
+            none_rules = runner._load_rules_for_event("SessionStart")
+            assert len(none_rules) == 0
+
+    def test_event_flag_routes_to_event_runner(self) -> None:
+        """--event Stop should call _run_event_rules, not _run_named_rules."""
+        runner = self._get_runner()
+        mock_client = MagicMock()
+
+        with (
+            patch("sys.stdin", io.StringIO(self._make_hook_input())),
+            patch("sys.argv", ["runner.py", "--event", "Stop"]),
+            patch.object(runner, "VaudevilleClient", return_value=mock_client),
+            patch.object(runner, "_run_event_rules") as mock_event,
+        ):
+            mock_event.side_effect = SystemExit(0)
+            with pytest.raises(SystemExit):
+                runner._run()
+            mock_event.assert_called_once()
+            assert mock_event.call_args[0][0] == "Stop"
+
+    def test_event_violation_blocks(self) -> None:
+        runner = self._get_runner()
+        from vaudeville.core.rules import Rule
+
+        mock_rules = [
+            Rule(
+                name="violation-detector",
+                event="Stop",
+                prompt="{text}",
+                context=[{"field": "last_assistant_message"}],
+                action="block",
+                message="{reason}",
+            ),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.classify.return_value = MagicMock(
+            verdict="violation", reason="hedging detected", action="block"
+        )
+
+        stdout = io.StringIO()
+        with (
+            patch("sys.stdin", io.StringIO(self._make_hook_input())),
+            patch("sys.stdout", stdout),
+            patch("sys.argv", ["runner.py", "--event", "Stop"]),
+            patch.object(runner, "VaudevilleClient", return_value=mock_client),
+            patch.object(runner, "_load_rules_for_event", return_value=mock_rules),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                runner._run()
+            assert exc_info.value.code == 0
+        result = json.loads(stdout.getvalue())
+        assert result["decision"] == "block"
+
+    def test_event_all_clean_passes(self) -> None:
+        runner = self._get_runner()
+        from vaudeville.core.rules import Rule
+
+        mock_rules = [
+            Rule(
+                name="violation-detector",
+                event="Stop",
+                prompt="{text}",
+                context=[{"field": "last_assistant_message"}],
+                action="block",
+                message="{reason}",
+            ),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.classify.return_value = MagicMock(
+            verdict="clean", reason="ok", action="block"
+        )
+
+        stdout = io.StringIO()
+        with (
+            patch("sys.stdin", io.StringIO(self._make_hook_input())),
+            patch("sys.stdout", stdout),
+            patch("sys.argv", ["runner.py", "--event", "Stop"]),
+            patch.object(runner, "VaudevilleClient", return_value=mock_client),
+            patch.object(runner, "_load_rules_for_event", return_value=mock_rules),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                runner._run()
+            assert exc_info.value.code == 0
+        assert json.loads(stdout.getvalue()) == {}
+
+    def test_event_no_matching_rules_passes(self) -> None:
+        runner = self._get_runner()
+        mock_client = MagicMock()
+
+        stdout = io.StringIO()
+        with (
+            patch("sys.stdin", io.StringIO(self._make_hook_input())),
+            patch("sys.stdout", stdout),
+            patch("sys.argv", ["runner.py", "--event", "SessionStart"]),
+            patch.object(runner, "VaudevilleClient", return_value=mock_client),
+            patch.object(runner, "_load_rules_for_event", return_value=[]),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                runner._run()
+            assert exc_info.value.code == 0
+        assert json.loads(stdout.getvalue()) == {}
+        mock_client.classify.assert_not_called()
+
+    def test_event_daemon_unavailable_passes(self) -> None:
+        runner = self._get_runner()
+        from vaudeville.core.rules import Rule
+
+        mock_rules = [
+            Rule(
+                name="violation-detector",
+                event="Stop",
+                prompt="{text}",
+                context=[{"field": "last_assistant_message"}],
+                action="block",
+                message="{reason}",
+            ),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.classify.return_value = None
+
+        stdout = io.StringIO()
+        with (
+            patch("sys.stdin", io.StringIO(self._make_hook_input())),
+            patch("sys.stdout", stdout),
+            patch("sys.argv", ["runner.py", "--event", "Stop"]),
+            patch.object(runner, "VaudevilleClient", return_value=mock_client),
+            patch.object(runner, "_load_rules_for_event", return_value=mock_rules),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                runner._run()
+            assert exc_info.value.code == 0
+        assert json.loads(stdout.getvalue()) == {}
+
+    def test_event_short_text_skipped(self) -> None:
+        runner = self._get_runner()
+        from vaudeville.core.rules import Rule
+
+        mock_rules = [
+            Rule(
+                name="violation-detector",
+                event="Stop",
+                prompt="{text}",
+                context=[{"field": "last_assistant_message"}],
+                action="block",
+                message="{reason}",
+            ),
+        ]
+
+        mock_client = MagicMock()
+
+        stdout = io.StringIO()
+        with (
+            patch("sys.stdin", io.StringIO(self._make_hook_input("short"))),
+            patch("sys.stdout", stdout),
+            patch("sys.argv", ["runner.py", "--event", "Stop"]),
+            patch.object(runner, "VaudevilleClient", return_value=mock_client),
+            patch.object(runner, "_load_rules_for_event", return_value=mock_rules),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                runner._run()
+            assert exc_info.value.code == 0
+        assert json.loads(stdout.getvalue()) == {}
+        mock_client.classify.assert_not_called()
+
+    def test_no_args_no_event_passes(self) -> None:
+        """Neither --event nor rule names → exits cleanly."""
+        runner = self._get_runner()
+
+        stdout = io.StringIO()
+        with (
+            patch("sys.stdin", io.StringIO(self._make_hook_input())),
+            patch("sys.stdout", stdout),
+            patch("sys.argv", ["runner.py"]),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                runner._run()
+            assert exc_info.value.code == 0
+        assert json.loads(stdout.getvalue()) == {}

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -95,18 +95,25 @@ def _response(verdict: str, reason: str, action: str = "block") -> bytes:
 
 
 def _read_message(conn: socket.socket) -> bytes:
-    """Read a newline-terminated message from a socket connection."""
-    data = b""
+    """Read a newline-terminated message from a socket connection.
+
+    Returns bytes up to and including the first newline.
+    Returns empty bytes if the connection closes or the payload exceeds MAX_REQUEST_SIZE.
+    """
+    buf = bytearray()
     while True:
         chunk = conn.recv(RECV_CHUNK)
         if not chunk:
             break
-        data += chunk
-        if b"\n" in data:
-            break
-        if len(data) > MAX_REQUEST_SIZE:
-            break
-    return data
+        buf.extend(chunk)
+        if b"\n" in buf:
+            return bytes(buf.split(b"\n", 1)[0])
+        if len(buf) > MAX_REQUEST_SIZE:
+            logger.warning(
+                "[vaudeville] Request exceeded %d bytes — dropping", MAX_REQUEST_SIZE
+            )
+            return b""
+    return bytes(buf)
 
 
 def _scan_dir_mtime(rules_dir: str) -> float:

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -97,8 +97,10 @@ def _response(verdict: str, reason: str, action: str = "block") -> bytes:
 def _read_message(conn: socket.socket) -> bytes:
     """Read a newline-terminated message from a socket connection.
 
-    Returns bytes up to and including the first newline.
-    Returns empty bytes if the connection closes or the payload exceeds MAX_REQUEST_SIZE.
+    Returns the bytes up to (but not including) the first newline.
+    If the connection closes before a newline is received, returns all buffered
+    bytes read so far (which may be empty). Returns empty bytes if the payload
+    exceeds MAX_REQUEST_SIZE.
     """
     buf = bytearray()
     while True:

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -94,6 +94,21 @@ def _response(verdict: str, reason: str, action: str = "block") -> bytes:
     )
 
 
+def _read_message(conn: socket.socket) -> bytes:
+    """Read a newline-terminated message from a socket connection."""
+    data = b""
+    while True:
+        chunk = conn.recv(RECV_CHUNK)
+        if not chunk:
+            break
+        data += chunk
+        if b"\n" in data:
+            break
+        if len(data) > MAX_REQUEST_SIZE:
+            break
+    return data
+
+
 def _scan_dir_mtime(rules_dir: str) -> float:
     """Return the max mtime of YAML files in a single rules directory."""
     max_mtime = 0.0
@@ -210,16 +225,7 @@ class VaudevilleDaemon:
         try:
             conn.settimeout(CLIENT_TIMEOUT)
             t0 = time.monotonic()
-            data = bytearray()
-            while True:
-                chunk = conn.recv(RECV_CHUNK)
-                if not chunk:
-                    break
-                data.extend(chunk)
-                if len(data) > MAX_REQUEST_SIZE:
-                    break
-                if b"\n" in data:
-                    break
+            data = _read_message(conn)
 
             with self._rules_lock:
                 current_rules = dict(self._rules)


### PR DESCRIPTION
## Summary
- Adds `--event` flag to `runner.py` that auto-discovers rules via `load_rules_layered()` instead of requiring hardcoded rule names in argv
- Updates `hooks.json` to use `--event Stop` and `--event PostToolUse` instead of explicit rule names
- Projects can now drop YAML rules in `.vaudeville/rules/` with an `event:` field and they activate automatically — no plugin config changes needed
- Legacy explicit-name invocation (`runner.py rule-name`) still works

## Test plan
- [ ] Verify `--event Stop` discovers `violation-detector` and `dismissal-detector`
- [ ] Verify `--event PostToolUse` discovers `deferral-detector`
- [ ] Add a custom rule to `.vaudeville/rules/` in a test project and confirm it auto-activates
- [ ] Verify legacy `runner.py rule-name` invocation still works
- [ ] Verify fail-open when no daemon socket exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)