### PR TITLE
feat: logprob-based confidence scoring

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ import sys
 
 import pytest
 
+from vaudeville.core.protocol import ClassifyResult
+
 # Ensure vaudeville package is importable from project root
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
@@ -16,14 +18,29 @@ if PROJECT_ROOT not in sys.path:
 class MockBackend:
     """Deterministic backend for tests — returns canned VERDICT/REASON output."""
 
-    def __init__(self, verdict: str = "clean", reason: str = "test reason") -> None:
+    def __init__(
+        self,
+        verdict: str = "clean",
+        reason: str = "test reason",
+        logprobs: dict[str, float] | None = None,
+    ) -> None:
         self.verdict = verdict
         self.reason = reason
+        self.logprobs = logprobs or {}
         self.calls: list[str] = []
 
     def classify(self, prompt: str, max_tokens: int = 50) -> str:  # noqa: ARG002
         self.calls.append(prompt)
         return f"VERDICT: {self.verdict}\nREASON: {self.reason}"
+
+    def classify_with_logprobs(  # noqa: ARG002
+        self, prompt: str, max_tokens: int = 50
+    ) -> ClassifyResult:
+        self.calls.append(prompt)
+        return ClassifyResult(
+            text=f"VERDICT: {self.verdict}\nREASON: {self.reason}",
+            logprobs=self.logprobs,
+        )
 
 
 @pytest.fixture

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,12 @@ import os
 import tempfile
 
 from vaudeville.core.client import VaudevilleClient
-from vaudeville.core.protocol import ClassifyRequest, parse_verdict
+from vaudeville.core.protocol import (
+    ClassifyRequest,
+    ClassifyResponse,
+    compute_confidence,
+    parse_verdict,
+)
 from vaudeville.core.rules import (
     Rule,
     _sanitize_input,
@@ -389,3 +394,48 @@ class TestLoadRulesLayered:
             rules = load_rules_layered(plugin_root, project_root=project_dir)
             assert rules["violation-detector"].action == "warn"
             assert "override" in rules["violation-detector"].prompt
+
+
+# --- compute_confidence ---
+
+
+class TestComputeConfidence:
+    def test_high_confidence_violation(self) -> None:
+        logprobs = {"violation": -0.1, "clean": -3.0}
+        conf = compute_confidence(logprobs, "violation")
+        assert conf > 0.9
+
+    def test_high_confidence_clean(self) -> None:
+        logprobs = {"violation": -3.0, "clean": -0.1}
+        conf = compute_confidence(logprobs, "clean")
+        assert conf > 0.9
+
+    def test_empty_logprobs_returns_one(self) -> None:
+        assert compute_confidence({}, "violation") == 1.0
+
+    def test_no_matching_tokens_returns_one(self) -> None:
+        logprobs = {"hello": -1.0, "world": -2.0}
+        assert compute_confidence(logprobs, "violation") == 1.0
+
+    def test_prefix_matching(self) -> None:
+        logprobs = {"v": -0.5, "c": -1.5}
+        conf = compute_confidence(logprobs, "violation")
+        assert 0.5 < conf < 1.0
+
+    def test_case_insensitive(self) -> None:
+        logprobs = {"VIOLATION": -0.2, "CLEAN": -2.0}
+        conf = compute_confidence(logprobs, "violation")
+        assert conf > 0.8
+
+
+# --- ClassifyResponse.confidence ---
+
+
+class TestClassifyResponseConfidence:
+    def test_defaults_to_one(self) -> None:
+        resp = ClassifyResponse(verdict="clean", reason="ok")
+        assert resp.confidence == 1.0
+
+    def test_custom_confidence(self) -> None:
+        resp = ClassifyResponse(verdict="violation", reason="bad", confidence=0.75)
+        assert resp.confidence == 0.75

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -407,6 +407,93 @@ class TestVersionStamp:
         assert not os.path.exists(version_file), "version file not removed on cleanup"
 
 
+class TestConfidenceScoring:
+    def test_response_includes_confidence(self, rules_dir: str) -> None:
+        rules = load_rules(rules_dir)
+        backend = MockBackend(
+            verdict="violation",
+            reason="test",
+            logprobs={"violation": -0.2, "clean": -2.5},
+        )
+        data = (
+            json.dumps(
+                {
+                    "rule": "violation-detector",
+                    "input": {"text": "test"},
+                }
+            ).encode()
+            + b"\n"
+        )
+        response = json.loads(handle_request(data, rules, backend))
+        assert "confidence" in response
+        assert 0.0 <= response["confidence"] <= 1.0
+
+    def test_threshold_downgrades_low_confidence_violation(
+        self, rules_dir: str
+    ) -> None:
+        rules = load_rules(rules_dir)
+        # Set a high threshold on the rule
+        rules["violation-detector"].threshold = 0.95
+        backend = MockBackend(
+            verdict="violation",
+            reason="low confidence",
+            logprobs={"violation": -0.8, "clean": -1.0},
+        )
+        data = (
+            json.dumps(
+                {
+                    "rule": "violation-detector",
+                    "input": {"text": "borderline"},
+                }
+            ).encode()
+            + b"\n"
+        )
+        response = json.loads(handle_request(data, rules, backend))
+        # Confidence ~0.55 is below threshold 0.95 → downgraded to clean
+        assert response["verdict"] == "clean"
+
+    def test_threshold_keeps_high_confidence_violation(self, rules_dir: str) -> None:
+        rules = load_rules(rules_dir)
+        rules["violation-detector"].threshold = 0.5
+        backend = MockBackend(
+            verdict="violation",
+            reason="high confidence",
+            logprobs={"violation": -0.1, "clean": -3.0},
+        )
+        data = (
+            json.dumps(
+                {
+                    "rule": "violation-detector",
+                    "input": {"text": "clearly bad"},
+                }
+            ).encode()
+            + b"\n"
+        )
+        response = json.loads(handle_request(data, rules, backend))
+        assert response["verdict"] == "violation"
+
+    def test_fallback_when_backend_lacks_logprobs(self, rules_dir: str) -> None:
+        """Backend without classify_with_logprobs falls back gracefully."""
+        rules = load_rules(rules_dir)
+
+        class PlainBackend:
+            def classify(self, prompt: str, max_tokens: int = 50) -> str:  # noqa: ARG002
+                return "VERDICT: clean\nREASON: ok"
+
+        data = (
+            json.dumps(
+                {
+                    "rule": "violation-detector",
+                    "input": {"text": "test"},
+                }
+            ).encode()
+            + b"\n"
+        )
+        response = json.loads(handle_request(data, rules, PlainBackend()))
+        assert response["verdict"] == "clean"
+        assert response["confidence"] == 1.0
+
+
 class TestDetectBackend:
     def test_returns_mlx_on_apple_silicon(self) -> None:
         with (

--- a/tests/test_prompt_tuning.py
+++ b/tests/test_prompt_tuning.py
@@ -6,6 +6,7 @@ import io
 import json
 import os
 import sys
+import types
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -201,7 +202,7 @@ class TestInterleavedExamples:
 class TestConcurrentDispatch:
     """Tests for the concurrent rule dispatch in hooks/runner.py."""
 
-    def _get_runner(self):
+    def _get_runner(self) -> types.ModuleType:
         """Import runner module fresh."""
         import importlib
 
@@ -268,7 +269,7 @@ class TestConcurrentDispatch:
     def test_multi_rule_concurrent_first_violation_wins(self) -> None:
         runner = self._get_runner()
 
-        def mock_classify(rule_name, _input_data):
+        def mock_classify(rule_name: str, _input_data: object) -> MagicMock:
             if rule_name == "violation-detector":
                 return MagicMock(verdict="violation", reason="hedging", action="block")
             return MagicMock(verdict="clean", reason="ok", action="block")
@@ -389,7 +390,7 @@ class TestConcurrentDispatch:
 
 
 class TestRunnerHelpers:
-    def _get_runner(self):
+    def _get_runner(self) -> types.ModuleType:
         import importlib
 
         hooks_dir = os.path.join(

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -71,7 +71,7 @@ class TestEvaluateRule:
         rules = load_rules(rules_dir)
         backend = MockBackend(verdict="violation")
         cases = [EvalCase(text="test", label="violation")] * 5
-        results = evaluate_rule("violation-detector", cases, rules, backend)
+        results, _ = evaluate_rule("violation-detector", cases, rules, backend)
         assert results.accuracy == 1.0
         assert results.tp == 5
 
@@ -79,7 +79,7 @@ class TestEvaluateRule:
         rules = load_rules(rules_dir)
         backend = MockBackend(verdict="violation")
         cases = [EvalCase(text="test", label="clean")] * 5
-        results = evaluate_rule("violation-detector", cases, rules, backend)
+        results, _ = evaluate_rule("violation-detector", cases, rules, backend)
         assert results.fp == 5
         assert results.accuracy == 0.0
 
@@ -93,7 +93,7 @@ class TestEvaluateRule:
         rules = load_rules(rules_dir)
         backend = MockBackend(verdict="violation")
         cases = [EvalCase(text="clean text", label="clean")]
-        results = evaluate_rule("violation-detector", cases, rules, backend)
+        results, _ = evaluate_rule("violation-detector", cases, rules, backend)
         assert results.misclassified is not None
         assert len(results.misclassified) == 1
         assert results.misclassified[0]["actual"] == "clean"

--- a/vaudeville/core/client.py
+++ b/vaudeville/core/client.py
@@ -64,4 +64,5 @@ class VaudevilleClient:
             verdict=response.get("verdict", "clean"),
             reason=response.get("reason", ""),
             action=response.get("action", "block"),
+            confidence=float(response.get("confidence", 1.0)),
         )

--- a/vaudeville/core/protocol.py
+++ b/vaudeville/core/protocol.py
@@ -5,7 +5,8 @@ Stdlib-only — safe to import in hook scripts.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import math
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -18,10 +19,19 @@ class ClassifyRequest:
 
 
 @dataclass
+class ClassifyResult:
+    """Raw inference output: generated text paired with first-token logprobs."""
+
+    text: str
+    logprobs: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
 class ClassifyResponse:
     verdict: str  # "violation" | "clean"
     reason: str
     action: str = "block"  # "block" | "warn" | "log"
+    confidence: float = 1.0  # P(predicted_class), 0.0–1.0
 
 
 def parse_verdict(raw: str) -> ClassifyResponse:
@@ -55,3 +65,42 @@ def parse_verdict(raw: str) -> ClassifyResponse:
         reason = raw.strip()[:200]
 
     return ClassifyResponse(verdict=verdict, reason=reason)
+
+
+_VIOLATION_PREFIXES = ("violation", "viol", "vi", "v")
+_CLEAN_PREFIXES = ("clean", "cl", "c")
+
+
+def compute_confidence(logprobs: dict[str, float], verdict: str) -> float:
+    """Compute confidence from first-token logprobs.
+
+    Finds the best logprob for violation-class and clean-class tokens,
+    applies softmax, and returns P(predicted_class). Returns 1.0 (fail-open)
+    when logprobs are empty or no matching tokens are found.
+    """
+    if not logprobs:
+        return 1.0
+
+    best_violation = -math.inf
+    best_clean = -math.inf
+
+    for token, lp in logprobs.items():
+        normalized = token.strip().lower()
+        if any(normalized.startswith(p) for p in _VIOLATION_PREFIXES):
+            best_violation = max(best_violation, lp)
+        elif any(normalized.startswith(p) for p in _CLEAN_PREFIXES):
+            best_clean = max(best_clean, lp)
+
+    if best_violation == -math.inf or best_clean == -math.inf:
+        return 1.0
+
+    # Softmax of two values: P(x) = exp(x) / (exp(x) + exp(y))
+    # Use log-sum-exp trick for numerical stability
+    max_lp = max(best_violation, best_clean)
+    exp_v = math.exp(best_violation - max_lp)
+    exp_c = math.exp(best_clean - max_lp)
+    total = exp_v + exp_c
+
+    if verdict == "violation":
+        return exp_v / total
+    return exp_c / total

--- a/vaudeville/core/rules.py
+++ b/vaudeville/core/rules.py
@@ -84,6 +84,7 @@ class Rule:
     context: list[dict[str, str]]
     action: str
     message: str
+    threshold: float = 0.0
 
     def format_prompt(self, text: str, context: str = "") -> str:
         safe_text = _sanitize_input(back_truncate(text))
@@ -177,4 +178,5 @@ def _parse_rule(data: dict[str, Any]) -> Rule:
         context=[c for c in data.get("context", []) if isinstance(c, dict)],
         action=str(data.get("action", "block")),
         message=str(data.get("message", "{reason}")),
+        threshold=float(data.get("threshold", 0.0)),
     )

--- a/vaudeville/eval.py
+++ b/vaudeville/eval.py
@@ -19,6 +19,7 @@ import yaml
 from .core.protocol import ClassifyResult, compute_confidence, parse_verdict
 from .core.rules import Rule, load_rules_layered
 from .server import InferenceBackend
+from .server.inference import LogprobBackend
 
 
 def _find_project_root() -> str | None:
@@ -128,11 +129,10 @@ def _load_test_file(path: str) -> tuple[list[EvalCase], str]:
 
 def _run_inference(backend: InferenceBackend, prompt: str) -> ClassifyResult:
     """Run inference with logprobs, falling back to plain classify."""
-    try:
+    if isinstance(backend, LogprobBackend):
         return backend.classify_with_logprobs(prompt, max_tokens=50)
-    except AttributeError:
-        text = backend.classify(prompt, max_tokens=50)
-        return ClassifyResult(text=text)
+    text = backend.classify(prompt, max_tokens=50)
+    return ClassifyResult(text=text)
 
 
 def _classify_case(

--- a/vaudeville/eval.py
+++ b/vaudeville/eval.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 
 import yaml
 
-from .core.protocol import parse_verdict
+from .core.protocol import ClassifyResult, compute_confidence, parse_verdict
 from .core.rules import Rule, load_rules_layered
 from .server import InferenceBackend
 
@@ -46,6 +46,14 @@ class EvalCase:
 
 
 @dataclass
+class CaseResult:
+    text: str
+    label: str
+    predicted: str
+    confidence: float
+
+
+@dataclass
 class EvalResults:
     rule: str
     tp: int = 0
@@ -53,10 +61,13 @@ class EvalResults:
     tn: int = 0
     fn: int = 0
     misclassified: list[dict[str, str]] | None = None
+    confidences: list[float] | None = None
 
     def __post_init__(self) -> None:
         if self.misclassified is None:
             self.misclassified = []
+        if self.confidences is None:
+            self.confidences = []
 
     @property
     def total(self) -> int:
@@ -115,19 +126,32 @@ def _load_test_file(path: str) -> tuple[list[EvalCase], str]:
     return cases, rule_name
 
 
+def _run_inference(backend: InferenceBackend, prompt: str) -> ClassifyResult:
+    """Run inference with logprobs, falling back to plain classify."""
+    try:
+        return backend.classify_with_logprobs(prompt, max_tokens=50)
+    except AttributeError:
+        text = backend.classify(prompt, max_tokens=50)
+        return ClassifyResult(text=text)
+
+
 def _classify_case(
     case: EvalCase,
     rule: Rule,
     backend: InferenceBackend,
     results: EvalResults,
-) -> str:
-    """Classify a single case and update results. Returns predicted label."""
+) -> CaseResult:
+    """Classify a single case and update results. Returns CaseResult."""
     prompt = rule.format_prompt(case.text)
-    raw = backend.classify(prompt, max_tokens=50)
-    response = parse_verdict(raw)
+    result = _run_inference(backend, prompt)
+    response = parse_verdict(result.text)
     predicted = response.verdict
+    confidence = compute_confidence(result.logprobs, predicted)
 
     assert results.misclassified is not None
+    assert results.confidences is not None
+    results.confidences.append(confidence)
+
     if case.label == "violation" and predicted == "violation":
         results.tp += 1
     elif case.label == "clean" and predicted == "clean":
@@ -151,7 +175,12 @@ def _classify_case(
             }
         )
 
-    return predicted
+    return CaseResult(
+        text=case.text,
+        label=case.label,
+        predicted=predicted,
+        confidence=confidence,
+    )
 
 
 def evaluate_rule(
@@ -159,15 +188,16 @@ def evaluate_rule(
     cases: list[EvalCase],
     rules: dict[str, Rule],
     backend: InferenceBackend,
-) -> EvalResults:
+) -> tuple[EvalResults, list[CaseResult]]:
     rule = rules.get(rule_name)
     if not isinstance(rule, Rule):
         raise ValueError(f"Rule not found: {rule_name}")
 
     results = EvalResults(rule=rule_name, misclassified=[])
+    case_results: list[CaseResult] = []
     for case in cases:
-        _classify_case(case, rule, backend, results)
-    return results
+        case_results.append(_classify_case(case, rule, backend, results))
+    return results, case_results
 
 
 def cross_validate_rule(
@@ -186,21 +216,24 @@ def cross_validate_rule(
 
     for i, case in enumerate(cases):
         fold = EvalResults(rule=rule_name, misclassified=[])
-        predicted = _classify_case(case, rule, backend, fold)
+        case_result = _classify_case(case, rule, backend, fold)
 
         aggregate.tp += fold.tp
         aggregate.fp += fold.fp
         aggregate.tn += fold.tn
         aggregate.fn += fold.fn
         assert aggregate.misclassified is not None
+        assert aggregate.confidences is not None
         assert fold.misclassified is not None
+        assert fold.confidences is not None
         aggregate.misclassified.extend(fold.misclassified)
+        aggregate.confidences.extend(fold.confidences)
 
-        status = "OK" if predicted == case.label else "FAIL"
-        acc = "100%" if predicted == case.label else "0%"
+        status = "OK" if case_result.predicted == case.label else "FAIL"
+        acc = "100%" if case_result.predicted == case.label else "0%"
         print(
             f"  Fold {i + 1}/{n} [{status}] acc={acc}"
-            f" expected={case.label} got={predicted}: {case.text[:50]}"
+            f" expected={case.label} got={case_result.predicted}: {case.text[:50]}"
         )
 
     return aggregate
@@ -218,6 +251,13 @@ def print_results(results: EvalResults) -> bool:
     print(f"Recall:    {results.recall * 100:.1f}%")
     print(f"F1:        {results.f1 * 100:.1f}%")
     print(f"Confusion: TP={results.tp} FP={results.fp} TN={results.tn} FN={results.fn}")
+
+    if results.confidences:
+        confs = results.confidences
+        print(
+            f"Confidence: mean={sum(confs) / len(confs):.3f}"
+            f" min={min(confs):.3f} max={max(confs):.3f}"
+        )
 
     if results.misclassified:
         print("\nMisclassifications:")
@@ -254,10 +294,54 @@ def _run_evaluations(
             print(f"  Leave-one-out cross-validation ({len(cases)} folds):")
             results = cross_validate_rule(rule_name, cases, rules, backend)
         else:
-            results = evaluate_rule(rule_name, cases, rules, backend)
+            results, _ = evaluate_rule(rule_name, cases, rules, backend)
         if not print_results(results):
             overall_pass = False
     return overall_pass
+
+
+def _threshold_sweep(
+    test_suites: dict[str, list[EvalCase]],
+    rules: dict[str, Rule],
+    backend: InferenceBackend,
+) -> None:
+    """Sweep thresholds and print confusion matrix per threshold."""
+    for rule_name, cases in sorted(test_suites.items()):
+        if rule_name not in rules:
+            continue
+        _, case_results = evaluate_rule(rule_name, cases, rules, backend)
+        print(f"\n--- Threshold sweep: {rule_name} ---")
+        print(f"{'Thresh':>7} {'Acc':>6} {'Prec':>6} {'Rec':>6} {'F1':>6}")
+        best_f1 = 0.0
+        best_thresh = 0.0
+        step = 5
+        for pct in range(30, 95, step):
+            thresh = pct / 100.0
+            r = EvalResults(rule=rule_name)
+            for cr in case_results:
+                predicted = cr.predicted
+                if predicted == "violation" and cr.confidence < thresh:
+                    predicted = "clean"
+                if cr.label == "violation" and predicted == "violation":
+                    r.tp += 1
+                elif cr.label == "clean" and predicted == "clean":
+                    r.tn += 1
+                elif cr.label == "clean" and predicted == "violation":
+                    r.fp += 1
+                else:
+                    r.fn += 1
+            marker = ""
+            if r.f1 > best_f1 and r.precision >= 0.95:
+                best_f1 = r.f1
+                best_thresh = thresh
+                marker = " <-- best"
+            print(
+                f"  {thresh:.2f}  {r.accuracy * 100:5.1f}%"
+                f" {r.precision * 100:5.1f}% {r.recall * 100:5.1f}%"
+                f" {r.f1 * 100:5.1f}%{marker}"
+            )
+        if best_thresh > 0:
+            print(f"Best threshold: {best_thresh:.2f} (F1={best_f1 * 100:.1f}%)")
 
 
 def main() -> None:
@@ -271,6 +355,11 @@ def main() -> None:
     parser.add_argument(
         "--test-file",
         help="Extra test file to include (YAML format)",
+    )
+    parser.add_argument(
+        "--threshold-sweep",
+        action="store_true",
+        help="Sweep thresholds 0.30-0.90 and print confusion matrix per threshold",
     )
     parser.add_argument(
         "--backend", default="mlx", choices=["mlx"], help="Inference backend"
@@ -309,6 +398,10 @@ def main() -> None:
             sys.exit(1)
 
     passed = _run_evaluations(args, rules, test_suites, backend)
+
+    if args.threshold_sweep:
+        _threshold_sweep(test_suites, rules, backend)
+
     print("\n" + ("ALL RULES PASS" if passed else "SOME RULES FAILED"))
     sys.exit(0 if passed else 1)
 

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -17,7 +17,7 @@ import threading
 import time
 
 from ..core.paths import VERSION_FILE, ensure_runtime_dir
-from ..core.protocol import parse_verdict
+from ..core.protocol import ClassifyResult, compute_confidence, parse_verdict
 from ..core.rules import Rule, load_rules_layered, rules_search_path
 from .inference import InferenceBackend
 
@@ -48,6 +48,15 @@ def _find_project_root() -> str | None:
     return None
 
 
+def _run_inference(backend: InferenceBackend, prompt: str) -> ClassifyResult:
+    """Run inference with logprobs, falling back to plain classify."""
+    try:
+        return backend.classify_with_logprobs(prompt, max_tokens=50)
+    except AttributeError:
+        text = backend.classify(prompt, max_tokens=50)
+        return ClassifyResult(text=text)
+
+
 def handle_request(
     data: bytes,
     rules: dict[str, Rule],
@@ -72,22 +81,37 @@ def handle_request(
         )
         context = rule.resolve_context(input_data, plugin_root)
         prompt = rule.format_prompt(text, context)
-        raw_output = backend.classify(prompt, max_tokens=50)
-        response = parse_verdict(raw_output)
-        return _response(response.verdict, response.reason, rule.action)
+        result = _run_inference(backend, prompt)
+        response = parse_verdict(result.text)
+        confidence = compute_confidence(result.logprobs, response.verdict)
+        logger.debug("[vaudeville] confidence=%.3f for rule=%s", confidence, rule_name)
+
+        verdict = response.verdict
+        if verdict == "violation" and confidence < rule.threshold:
+            logger.info(
+                "[vaudeville] Downgrading violation (confidence=%.3f < threshold=%.3f)",
+                confidence,
+                rule.threshold,
+            )
+            verdict = "clean"
+
+        return _response(verdict, response.reason, rule.action, confidence)
 
     except Exception as exc:
         logger.error("[vaudeville] Request error: %s", exc)
         return _response("clean", "Inference error — fail open")
 
 
-def _response(verdict: str, reason: str, action: str = "block") -> bytes:
+def _response(
+    verdict: str, reason: str, action: str = "block", confidence: float = 1.0
+) -> bytes:
     return (
         json.dumps(
             {
                 "verdict": verdict,
                 "reason": reason,
                 "action": action,
+                "confidence": confidence,
             }
         ).encode()
         + b"\n"

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -19,7 +19,7 @@ import time
 from ..core.paths import VERSION_FILE, ensure_runtime_dir
 from ..core.protocol import ClassifyResult, compute_confidence, parse_verdict
 from ..core.rules import Rule, load_rules_layered, rules_search_path
-from .inference import InferenceBackend
+from .inference import InferenceBackend, LogprobBackend
 
 IDLE_TIMEOUT = 60 * 60  # 60 minutes
 RULE_POLL_INTERVAL = 30  # seconds
@@ -50,11 +50,10 @@ def _find_project_root() -> str | None:
 
 def _run_inference(backend: InferenceBackend, prompt: str) -> ClassifyResult:
     """Run inference with logprobs, falling back to plain classify."""
-    try:
+    if isinstance(backend, LogprobBackend):
         return backend.classify_with_logprobs(prompt, max_tokens=50)
-    except AttributeError:
-        text = backend.classify(prompt, max_tokens=50)
-        return ClassifyResult(text=text)
+    text = backend.classify(prompt, max_tokens=50)
+    return ClassifyResult(text=text)
 
 
 def handle_request(

--- a/vaudeville/server/gguf_backend.py
+++ b/vaudeville/server/gguf_backend.py
@@ -62,13 +62,26 @@ class GGUFBackend:
         return ClassifyResult(text=text, logprobs=logprobs)
 
     def _extract_first_token_logprobs(self, response: Any) -> dict[str, float]:
-        """Extract first-token logprobs from OpenAI-format response."""
+        """Extract logprobs from the label-token position in the response.
+
+        Scans token positions until finding one whose top logprobs contain
+        violation/clean-prefixed tokens (skipping "VERDICT", ":", etc.).
+        """
+        from ..core.protocol import compute_confidence
+
         try:
             content = response["choices"][0]["logprobs"]["content"]
             if not content:
                 return {}
-            top = content[0]["top_logprobs"]
-            return {entry["token"]: entry["logprob"] for entry in top}
+            for position in content:
+                top = {
+                    entry["token"]: entry["logprob"]
+                    for entry in position["top_logprobs"]
+                }
+                # compute_confidence returns 1.0 when no label tokens found
+                if compute_confidence(top, "violation") != 1.0:
+                    return top
+            return {}
         except (KeyError, IndexError, TypeError) as exc:
             logger.warning("[vaudeville] Logprob extraction failed: %s", exc)
             return {}

--- a/vaudeville/server/gguf_backend.py
+++ b/vaudeville/server/gguf_backend.py
@@ -5,8 +5,16 @@ Loads Phi-3-mini Q4 GGUF via llama-cpp-python. No GPU required.
 
 from __future__ import annotations
 
+import logging
+from typing import Any
+
+from ..core.protocol import ClassifyResult
+
 DEFAULT_REPO = "microsoft/Phi-3-mini-4k-instruct-gguf"
 DEFAULT_FILE = "Phi-3-mini-4k-instruct-q4.gguf"
+TOP_LOGPROBS = 10
+
+logger = logging.getLogger(__name__)
 
 
 class GGUFBackend:
@@ -37,3 +45,30 @@ class GGUFBackend:
         )
         result: str = response["choices"][0]["message"]["content"]
         return result
+
+    def classify_with_logprobs(
+        self, prompt: str, max_tokens: int = 50
+    ) -> ClassifyResult:
+        """Run inference and return output with first-token logprobs."""
+        response: Any = self._llm.create_chat_completion(
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=max_tokens,
+            temperature=0.0,
+            logprobs=True,
+            top_logprobs=TOP_LOGPROBS,
+        )
+        text: str = response["choices"][0]["message"]["content"]
+        logprobs = self._extract_first_token_logprobs(response)
+        return ClassifyResult(text=text, logprobs=logprobs)
+
+    def _extract_first_token_logprobs(self, response: Any) -> dict[str, float]:
+        """Extract first-token logprobs from OpenAI-format response."""
+        try:
+            content = response["choices"][0]["logprobs"]["content"]
+            if not content:
+                return {}
+            top = content[0]["top_logprobs"]
+            return {entry["token"]: entry["logprob"] for entry in top}
+        except (KeyError, IndexError, TypeError) as exc:
+            logger.warning("[vaudeville] Logprob extraction failed: %s", exc)
+            return {}

--- a/vaudeville/server/inference.py
+++ b/vaudeville/server/inference.py
@@ -8,8 +8,14 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from ..core.protocol import ClassifyResult
+
 
 class InferenceBackend(Protocol):
     def classify(self, prompt: str, max_tokens: int) -> str:
         """Run inference and return raw model output."""
+        ...
+
+    def classify_with_logprobs(self, prompt: str, max_tokens: int) -> ClassifyResult:
+        """Run inference and return output with first-token logprobs."""
         ...

--- a/vaudeville/server/inference.py
+++ b/vaudeville/server/inference.py
@@ -6,15 +6,21 @@ no changes to rules or hooks required.
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 from ..core.protocol import ClassifyResult
 
 
+@runtime_checkable
 class InferenceBackend(Protocol):
     def classify(self, prompt: str, max_tokens: int) -> str:
         """Run inference and return raw model output."""
         ...
+
+
+@runtime_checkable
+class LogprobBackend(InferenceBackend, Protocol):
+    """Backend that also supports logprob extraction."""
 
     def classify_with_logprobs(self, prompt: str, max_tokens: int) -> ClassifyResult:
         """Run inference and return output with first-token logprobs."""

--- a/vaudeville/server/mlx_backend.py
+++ b/vaudeville/server/mlx_backend.py
@@ -5,17 +5,25 @@ Loads Phi-3-mini int4 via mlx_lm. Model is cached by Hugging Face hub.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
+from ..core.protocol import ClassifyResult
+
 DEFAULT_MODEL = "mlx-community/Phi-3-mini-4k-instruct-4bit"
+TOP_K_LOGPROBS = 10
+
+logger = logging.getLogger(__name__)
 
 
 class MLXBackend:
     def __init__(self, model_path: str = DEFAULT_MODEL) -> None:
         from mlx_lm import load, generate
+        from mlx_lm.utils import generate_step
 
         self._model, self._tokenizer = load(model_path)
         self._generate = generate
+        self._generate_step = generate_step
 
     def classify(self, prompt: str, max_tokens: int = 50) -> str:
         """Run inference on prompt, return raw text output."""
@@ -29,6 +37,59 @@ class MLXBackend:
             verbose=False,
         )
         return result
+
+    def classify_with_logprobs(
+        self, prompt: str, max_tokens: int = 50
+    ) -> ClassifyResult:
+        """Run inference and return output with first-token logprobs."""
+        import mlx.core as mx
+
+        formatted = self._apply_chat_template(prompt)
+        tokenizer: Any = self._tokenizer
+        prompt_tokens = mx.array(tokenizer.encode(formatted))
+
+        tokens: list[int] = []
+        first_logprobs: dict[str, float] = {}
+
+        for i, (token, logprobs_arr) in enumerate(
+            self._generate_step(prompt_tokens, self._model, temp=0.0)
+        ):
+            token_id = token.item()
+            tokens.append(token_id)
+
+            if i == 0:
+                first_logprobs = self._extract_top_logprobs(logprobs_arr, tokenizer)
+
+            if i + 1 >= max_tokens:
+                break
+            eos = getattr(tokenizer, "eos_token_id", None)
+            if eos is not None and token_id == eos:
+                break
+
+        text: str = tokenizer.decode(tokens)
+        return ClassifyResult(text=text, logprobs=first_logprobs)
+
+    def _extract_top_logprobs(
+        self, logprobs_arr: Any, tokenizer: Any
+    ) -> dict[str, float]:
+        """Extract top-K token logprobs from the full vocab distribution."""
+        import mlx.core as mx
+
+        try:
+            mx.eval(logprobs_arr)
+            top_indices = mx.argpartition(logprobs_arr, kth=-TOP_K_LOGPROBS)[
+                -TOP_K_LOGPROBS:
+            ]
+            mx.eval(top_indices)
+
+            result: dict[str, float] = {}
+            for idx in top_indices.tolist():
+                token_str: str = tokenizer.decode([idx])
+                result[token_str] = logprobs_arr[idx].item()
+            return result
+        except Exception as exc:
+            logger.warning("[vaudeville] Logprob extraction failed: %s", exc)
+            return {}
 
     def _apply_chat_template(self, prompt: str) -> str:
         """Format prompt using the model's chat template."""

--- a/vaudeville/server/mlx_backend.py
+++ b/vaudeville/server/mlx_backend.py
@@ -41,10 +41,15 @@ class MLXBackend:
     def classify_with_logprobs(
         self, prompt: str, max_tokens: int = 50
     ) -> ClassifyResult:
-        """Run inference and return output with first-token logprobs."""
+        """Run inference and return output with first-token logprobs.
+
+        Pre-fills "VERDICT:" so the first generated token IS the class label
+        ("violation"/"clean"), giving meaningful logprob distributions.
+        """
         import mlx.core as mx
 
-        formatted = self._apply_chat_template(prompt)
+        # Append anchor after chat template so model's first token = class label
+        formatted = self._apply_chat_template(prompt) + "VERDICT:"
         tokenizer: Any = self._tokenizer
         prompt_tokens = mx.array(tokenizer.encode(formatted))
 
@@ -66,7 +71,8 @@ class MLXBackend:
             if eos is not None and token_id == eos:
                 break
 
-        text: str = tokenizer.decode(tokens)
+        # Prepend the anchor back so parse_verdict can parse the full output
+        text: str = "VERDICT:" + tokenizer.decode(tokens)
         return ClassifyResult(text=text, logprobs=first_logprobs)
 
     def _extract_top_logprobs(


### PR DESCRIPTION
## Summary

- Extract first-token log probabilities from both MLX and GGUF backends to compute a confidence score (0.0–1.0) representing P(predicted_class)
- Add per-rule `threshold` field in YAML — violations below threshold are downgraded to clean, reducing false positives
- Confidence propagates through the full pipeline: backend → protocol → daemon → client → eval
- Eval harness gains `--threshold-sweep` mode showing precision/recall/F1 at each threshold level

## How it works

Instead of treating the SLM verdict as binary, we now look at **how confident** the model was. The first token's logprob distribution tells us P(violation) vs P(clean). A 51% lean toward "violation" is basically a coin flip — with threshold tuning, you can require e.g. 70% confidence before blocking.

## Test plan

- [x] 71 tests pass (10 new: confidence computation, threshold downgrade, fallback)
- [x] `ruff check` clean
- [x] `ruff format --check` clean  
- [x] `mypy --strict` clean (pre-existing issues only)
- [ ] Manual: set `threshold: 0.7` on a rule, verify low-confidence violations pass through
- [ ] Manual: run `--threshold-sweep` with real model to find optimal thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)