### PR TITLE
feat: add verdict logging and vaudeville tail CLI

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,133 @@
+"""Tests for the vaudeville CLI entry point."""
+
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+class TestFindLogFiles:
+    def test_returns_logs_with_live_daemon(self, tmp_path: Path) -> None:
+        log = tmp_path / "vaudeville-abc123.log"
+        pid = tmp_path / "vaudeville-abc123.pid"
+        log.write_text("some log")
+        pid.write_text(str(os.getpid()))  # current process is alive
+
+        with patch("vaudeville.__main__.glob.glob", return_value=[str(log)]):
+            from vaudeville.__main__ import _find_log_files
+
+            # Patch the pid path derivation to use tmp_path
+            with patch(
+                "vaudeville.__main__.Path.read_text",
+                return_value=str(os.getpid()),
+            ):
+                result = _find_log_files()
+
+        assert result == [str(log)]
+
+    def test_skips_logs_with_dead_daemon(self, tmp_path: Path) -> None:
+        log = tmp_path / "vaudeville-dead.log"
+        log.write_text("some log")
+
+        with patch("vaudeville.__main__.glob.glob", return_value=[str(log)]):
+            from vaudeville.__main__ import _find_log_files
+
+            # PID file missing → FileNotFoundError → skip
+            result = _find_log_files()
+
+        assert result == []
+
+    def test_skips_stale_pid(self, tmp_path: Path) -> None:
+        log = tmp_path / "vaudeville-stale.log"
+        log.write_text("some log")
+
+        with patch("vaudeville.__main__.glob.glob", return_value=[str(log)]):
+            with patch(
+                "vaudeville.__main__.Path.read_text",
+                return_value="99999999",
+            ):
+                with patch(
+                    "vaudeville.__main__.os.kill",
+                    side_effect=ProcessLookupError,
+                ):
+                    from vaudeville.__main__ import _find_log_files
+
+                    result = _find_log_files()
+
+        assert result == []
+
+
+class TestCmdTail:
+    def _make_args(
+        self, session: str | None = None, all: bool = False
+    ) -> Namespace:
+        return Namespace(session=session, all=all)
+
+    def test_no_active_daemons_exits(self) -> None:
+        with patch("vaudeville.__main__._find_log_files", return_value=[]):
+            from vaudeville.__main__ import cmd_tail
+
+            with pytest.raises(SystemExit, match="1"):
+                cmd_tail(self._make_args())
+
+    def test_single_session_tails(self) -> None:
+        with patch(
+            "vaudeville.__main__._find_log_files",
+            return_value=["/tmp/vaudeville-abc.log"],
+        ):
+            with patch("vaudeville.__main__.subprocess.run") as mock_run:
+                from vaudeville.__main__ import cmd_tail
+
+                cmd_tail(self._make_args())
+
+        mock_run.assert_called_once_with(
+            ["tail", "-f", "/tmp/vaudeville-abc.log"]
+        )
+
+    def test_multiple_sessions_without_all_exits(self) -> None:
+        logs = ["/tmp/vaudeville-a.log", "/tmp/vaudeville-b.log"]
+        with patch("vaudeville.__main__._find_log_files", return_value=logs):
+            from vaudeville.__main__ import cmd_tail
+
+            with pytest.raises(SystemExit, match="1"):
+                cmd_tail(self._make_args())
+
+    def test_multiple_sessions_with_all_tails_all(self) -> None:
+        logs = ["/tmp/vaudeville-a.log", "/tmp/vaudeville-b.log"]
+        with patch("vaudeville.__main__._find_log_files", return_value=logs):
+            with patch("vaudeville.__main__.subprocess.run") as mock_run:
+                from vaudeville.__main__ import cmd_tail
+
+                cmd_tail(self._make_args(all=True))
+
+        mock_run.assert_called_once_with(["tail", "-f"] + logs)
+
+    def test_session_flag_overrides_discovery(self) -> None:
+        logs = ["/tmp/vaudeville-a.log", "/tmp/vaudeville-b.log"]
+        with patch("vaudeville.__main__._find_log_files", return_value=logs):
+            with patch("vaudeville.__main__.os.path.exists", return_value=True):
+                with patch(
+                    "vaudeville.__main__.subprocess.run"
+                ) as mock_run:
+                    from vaudeville.__main__ import cmd_tail
+
+                    cmd_tail(self._make_args(session="b"))
+
+        mock_run.assert_called_once_with(
+            ["tail", "-f", "/tmp/vaudeville-b.log"]
+        )
+
+    def test_session_flag_missing_log_exits(self) -> None:
+        with patch(
+            "vaudeville.__main__._find_log_files",
+            return_value=["/tmp/vaudeville-a.log"],
+        ):
+            with patch("vaudeville.__main__.os.path.exists", return_value=False):
+                from vaudeville.__main__ import cmd_tail
+
+                with pytest.raises(SystemExit, match="1"):
+                    cmd_tail(self._make_args(session="missing"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,9 +62,7 @@ class TestFindLogFiles:
 
 
 class TestCmdTail:
-    def _make_args(
-        self, session: str | None = None, all: bool = False
-    ) -> Namespace:
+    def _make_args(self, session: str | None = None, all: bool = False) -> Namespace:
         return Namespace(session=session, all=all)
 
     def test_no_active_daemons_exits(self) -> None:
@@ -84,9 +82,7 @@ class TestCmdTail:
 
                 cmd_tail(self._make_args())
 
-        mock_run.assert_called_once_with(
-            ["tail", "-f", "/tmp/vaudeville-abc.log"]
-        )
+        mock_run.assert_called_once_with(["tail", "-f", "/tmp/vaudeville-abc.log"])
 
     def test_multiple_sessions_without_all_exits(self) -> None:
         logs = ["/tmp/vaudeville-a.log", "/tmp/vaudeville-b.log"]
@@ -110,16 +106,12 @@ class TestCmdTail:
         logs = ["/tmp/vaudeville-a.log", "/tmp/vaudeville-b.log"]
         with patch("vaudeville.__main__._find_log_files", return_value=logs):
             with patch("vaudeville.__main__.os.path.exists", return_value=True):
-                with patch(
-                    "vaudeville.__main__.subprocess.run"
-                ) as mock_run:
+                with patch("vaudeville.__main__.subprocess.run") as mock_run:
                     from vaudeville.__main__ import cmd_tail
 
                     cmd_tail(self._make_args(session="b"))
 
-        mock_run.assert_called_once_with(
-            ["tail", "-f", "/tmp/vaudeville-b.log"]
-        )
+        mock_run.assert_called_once_with(["tail", "-f", "/tmp/vaudeville-b.log"])
 
     def test_session_flag_missing_log_exits(self) -> None:
         with patch(

--- a/vaudeville/__main__.py
+++ b/vaudeville/__main__.py
@@ -10,6 +10,7 @@ import glob
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 
 def _find_log_files() -> list[str]:
@@ -19,7 +20,7 @@ def _find_log_files() -> list[str]:
         session_id = log_path.removeprefix("/tmp/vaudeville-").removesuffix(".log")
         pid_file = f"/tmp/vaudeville-{session_id}.pid"
         try:
-            pid = int(open(pid_file).read().strip())
+            pid = int(Path(pid_file).read_text().strip())
             os.kill(pid, 0)  # check if alive
             logs.append(log_path)
         except (FileNotFoundError, ValueError, ProcessLookupError, PermissionError):
@@ -39,7 +40,13 @@ def cmd_tail(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
-    if len(logs) > 1 and not args.all:
+    if args.session:
+        target = f"/tmp/vaudeville-{args.session}.log"
+        if not os.path.exists(target):
+            print(f"[vaudeville] Log not found: {target}", file=sys.stderr)
+            sys.exit(1)
+        logs = [target]
+    elif len(logs) > 1 and not args.all:
         print(f"[vaudeville] {len(logs)} active sessions found:", file=sys.stderr)
         for log in logs:
             print(f"  {log}", file=sys.stderr)
@@ -48,13 +55,6 @@ def cmd_tail(args: argparse.Namespace) -> None:
             file=sys.stderr,
         )
         sys.exit(1)
-
-    if args.session:
-        target = f"/tmp/vaudeville-{args.session}.log"
-        if not os.path.exists(target):
-            print(f"[vaudeville] Log not found: {target}", file=sys.stderr)
-            sys.exit(1)
-        logs = [target]
 
     try:
         subprocess.run(["tail", "-f"] + logs)
@@ -70,10 +70,11 @@ def main() -> None:
     sub = parser.add_subparsers(dest="command")
 
     tail_parser = sub.add_parser("tail", help="Tail active daemon logs")
-    tail_parser.add_argument(
+    session_group = tail_parser.add_mutually_exclusive_group()
+    session_group.add_argument(
         "--all", action="store_true", help="Tail all active sessions"
     )
-    tail_parser.add_argument("--session", help="Tail a specific session ID")
+    session_group.add_argument("--session", help="Tail a specific session ID")
 
     args = parser.parse_args()
     if args.command is None:

--- a/vaudeville/__main__.py
+++ b/vaudeville/__main__.py
@@ -1,0 +1,88 @@
+"""Vaudeville CLI entry point.
+
+Usage: uv run python -m vaudeville <command>
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import subprocess
+import sys
+
+
+def _find_log_files() -> list[str]:
+    """Find active vaudeville log files with a running daemon."""
+    logs: list[str] = []
+    for log_path in sorted(glob.glob("/tmp/vaudeville-*.log")):
+        session_id = log_path.removeprefix("/tmp/vaudeville-").removesuffix(".log")
+        pid_file = f"/tmp/vaudeville-{session_id}.pid"
+        try:
+            pid = int(open(pid_file).read().strip())
+            os.kill(pid, 0)  # check if alive
+            logs.append(log_path)
+        except (FileNotFoundError, ValueError, ProcessLookupError, PermissionError):
+            continue
+    return logs
+
+
+def cmd_tail(args: argparse.Namespace) -> None:
+    """Tail active vaudeville daemon logs."""
+    logs = _find_log_files()
+
+    if not logs:
+        print("[vaudeville] No active daemon found.", file=sys.stderr)
+        print(
+            "Start a Claude Code session with vaudeville hooks to spawn a daemon.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if len(logs) > 1 and not args.all:
+        print(f"[vaudeville] {len(logs)} active sessions found:", file=sys.stderr)
+        for log in logs:
+            print(f"  {log}", file=sys.stderr)
+        print(
+            "Use --all to tail all, or specify --session <id>.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if args.session:
+        target = f"/tmp/vaudeville-{args.session}.log"
+        if not os.path.exists(target):
+            print(f"[vaudeville] Log not found: {target}", file=sys.stderr)
+            sys.exit(1)
+        logs = [target]
+
+    try:
+        subprocess.run(["tail", "-f"] + logs)
+    except KeyboardInterrupt:
+        pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="vaudeville",
+        description="Vaudeville SLM hook enforcement",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    tail_parser = sub.add_parser("tail", help="Tail active daemon logs")
+    tail_parser.add_argument(
+        "--all", action="store_true", help="Tail all active sessions"
+    )
+    tail_parser.add_argument("--session", help="Tail a specific session ID")
+
+    args = parser.parse_args()
+    if args.command is None:
+        parser.print_help()
+        sys.exit(1)
+
+    if args.command == "tail":
+        cmd_tail(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -56,6 +56,7 @@ def handle_request(
 
         rule = rules.get(rule_name)
         if rule is None:
+            logger.info("CLASSIFY rule=%s verdict=clean (unknown rule)", rule_name)
             return _response("clean", f"Unknown rule: {rule_name}")
 
         text = str(input_data.get("text", ""))
@@ -67,8 +68,18 @@ def handle_request(
         )
         context = rule.resolve_context(input_data, plugin_root)
         prompt = rule.format_prompt(text, context)
+        t0 = time.monotonic()
         raw_output = backend.classify(prompt, max_tokens=50)
+        latency_ms = (time.monotonic() - t0) * 1000
         response = parse_verdict(raw_output)
+        logger.info(
+            "CLASSIFY rule=%s verdict=%s action=%s latency_ms=%.0f reason=%s",
+            rule_name,
+            response.verdict,
+            rule.action,
+            latency_ms,
+            response.reason,
+        )
         return _response(response.verdict, response.reason, rule.action)
 
     except Exception as exc:

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -56,7 +56,10 @@ def handle_request(
 
         rule = rules.get(rule_name)
         if rule is None:
-            logger.info("CLASSIFY rule=%s verdict=clean (unknown rule)", rule_name)
+            logger.info(
+                "CLASSIFY rule=%s verdict=clean action=block latency_ms=0 reason=unknown_rule",
+                rule_name,
+            )
             return _response("clean", f"Unknown rule: {rule_name}")
 
         text = str(input_data.get("text", ""))
@@ -72,13 +75,14 @@ def handle_request(
         raw_output = backend.classify(prompt, max_tokens=50)
         latency_ms = (time.monotonic() - t0) * 1000
         response = parse_verdict(raw_output)
+        safe_reason = response.reason.replace("\n", " ").replace("\r", " ")[:200]
         logger.info(
             "CLASSIFY rule=%s verdict=%s action=%s latency_ms=%.0f reason=%s",
             rule_name,
             response.verdict,
             rule.action,
             latency_ms,
-            response.reason,
+            safe_reason,
         )
         return _response(response.verdict, response.reason, rule.action)
 


### PR DESCRIPTION
## Summary

- Logs every CLASSIFY request in the daemon with rule name, verdict, action, inference latency (ms), and reason — structured for easy grep/filtering.
- Adds `python -m vaudeville tail` CLI that auto-discovers active daemon sessions via PID files and follows their logs in real time (`--all` for multiple sessions, `--session <id>` for a specific one).

## Test plan

- [x] All 59 existing tests pass
- [ ] Start a session, run `uv run python -m vaudeville tail`, verify log lines stream with CLASSIFY prefix
- [ ] Confirm `--all` and `--session` flags work with multiple active daemons

🤖 Generated with [Claude Code](https://claude.com/claude-code)