### PR TITLE
feat(analytics): add pre-built query helpers for session analytics

### DIFF
--- a/skills/session-analytics/SKILL.md
+++ b/skills/session-analytics/SKILL.md
@@ -329,8 +329,9 @@ ORDER BY day DESC, hour;
 ## Pre-built query scripts
 
 For common analytics questions, use these scripts instead of writing inline SQL
-or Python. All scripts live in `<skill-dir>/scripts/queries/` and accept
-`--days N`, `--limit N`, and `--json` flags.
+or Python. All scripts live in `<skill-dir>/scripts/queries/`. Most accept
+`--days N`, `--limit N`, and `--json` flags; `hook_stats.py` accepts `--days`
+and `--json` but uses a fixed error-pattern limit of 10.
 
 ```bash
 # Denied tool names ranked by frequency (replaces inline Python regex extraction)
@@ -352,8 +353,9 @@ python3 <skill-dir>/scripts/queries/tool_misuse.py [--days 14] [--json]
 python3 <skill-dir>/scripts/queries/hook_stats.py [--days 14] [--json]
 ```
 
-Use `--json` for structured output you can pipe to `jq`. Without it, output is
-tab-separated for human reading.
+Use `--json` for structured output you can pipe to `jq`. Without it, most
+scripts output tab-separated values; `hook_stats.py` prints a multi-line
+human-formatted summary instead.
 
 ## Query patterns
 

--- a/skills/session-analytics/SKILL.md
+++ b/skills/session-analytics/SKILL.md
@@ -326,6 +326,35 @@ GROUP BY day, hour
 ORDER BY day DESC, hour;
 ```
 
+## Pre-built query scripts
+
+For common analytics questions, use these scripts instead of writing inline SQL
+or Python. All scripts live in `<skill-dir>/scripts/queries/` and accept
+`--days N`, `--limit N`, and `--json` flags.
+
+```bash
+# Denied tool names ranked by frequency (replaces inline Python regex extraction)
+python3 <skill-dir>/scripts/queries/denied_tools.py [--days 14] [--json]
+
+# Top tools by usage count
+python3 <skill-dir>/scripts/queries/tool_usage.py [--days 14] [--json]
+
+# Tools ranked by error rate
+python3 <skill-dir>/scripts/queries/error_rates.py [--days 14] [--min-uses 5] [--json]
+
+# Most-repeated bash commands (add --dangerous for risky ones only)
+python3 <skill-dir>/scripts/queries/bash_patterns.py [--days 14] [--dangerous] [--json]
+
+# Bash commands that should use dedicated tools (cat→Read, grep→Grep, etc.)
+python3 <skill-dir>/scripts/queries/tool_misuse.py [--days 14] [--json]
+
+# Hook coverage ratio and error patterns
+python3 <skill-dir>/scripts/queries/hook_stats.py [--days 14] [--json]
+```
+
+Use `--json` for structured output you can pipe to `jq`. Without it, output is
+tab-separated for human reading.
+
 ## Query patterns
 
 When answering user questions:

--- a/skills/session-analytics/scripts/queries/_db.py
+++ b/skills/session-analytics/scripts/queries/_db.py
@@ -27,6 +27,9 @@ def query(sql: str) -> list[dict]:
     except FileNotFoundError:
         print("ERROR: duckdb not found on PATH", file=sys.stderr)
         sys.exit(1)
+    except subprocess.TimeoutExpired:
+        print("WARNING: query timed out after 30s", file=sys.stderr)
+        return []
     if result.returncode != 0:
         print(f"WARNING: query failed: {result.stderr.strip()[:200]}", file=sys.stderr)
         return []
@@ -44,7 +47,10 @@ def parse_days(args: list[str], default: int = 14) -> int:
     """Parse --days N from argv."""
     for i, arg in enumerate(args):
         if arg == "--days" and i + 1 < len(args):
-            return int(args[i + 1])
+            try:
+                return int(args[i + 1])
+            except ValueError:
+                raise SystemExit(f"Invalid value for --days: {args[i + 1]!r} (must be an integer)")
     return default
 
 
@@ -52,7 +58,10 @@ def parse_limit(args: list[str], default: int = 15) -> int:
     """Parse --limit N from argv."""
     for i, arg in enumerate(args):
         if arg == "--limit" and i + 1 < len(args):
-            return int(args[i + 1])
+            try:
+                return int(args[i + 1])
+            except ValueError:
+                raise SystemExit(f"Invalid value for --limit: {args[i + 1]!r} (must be an integer)")
     return default
 
 

--- a/skills/session-analytics/scripts/queries/_db.py
+++ b/skills/session-analytics/scripts/queries/_db.py
@@ -50,7 +50,9 @@ def parse_days(args: list[str], default: int = 14) -> int:
             try:
                 return int(args[i + 1])
             except ValueError:
-                raise SystemExit(f"Invalid value for --days: {args[i + 1]!r} (must be an integer)")
+                raise SystemExit(
+                    f"Invalid value for --days: {args[i + 1]!r} (must be an integer)"
+                )
     return default
 
 
@@ -61,7 +63,9 @@ def parse_limit(args: list[str], default: int = 15) -> int:
             try:
                 return int(args[i + 1])
             except ValueError:
-                raise SystemExit(f"Invalid value for --limit: {args[i + 1]!r} (must be an integer)")
+                raise SystemExit(
+                    f"Invalid value for --limit: {args[i + 1]!r} (must be an integer)"
+                )
     return default
 
 

--- a/skills/session-analytics/scripts/queries/_db.py
+++ b/skills/session-analytics/scripts/queries/_db.py
@@ -1,0 +1,70 @@
+"""Shared DuckDB query runner for session analytics scripts."""
+
+import json
+import os
+import subprocess
+import sys
+
+DB_PATH = os.path.expanduser("~/.claude/analytics/sessions.duckdb")
+
+
+def query(sql: str) -> list[dict]:
+    """Run a DuckDB query and return parsed JSON results."""
+    if not os.path.exists(DB_PATH):
+        print(
+            "ERROR: Database not found. Run session-analytics ingestion first.",
+            file=sys.stderr,
+        )
+        print(f"Expected: {DB_PATH}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        result = subprocess.run(
+            ["duckdb", DB_PATH, "-json", "-c", sql],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        print("ERROR: duckdb not found on PATH", file=sys.stderr)
+        sys.exit(1)
+    if result.returncode != 0:
+        print(f"WARNING: query failed: {result.stderr.strip()[:200]}", file=sys.stderr)
+        return []
+    raw = result.stdout.strip()
+    if not raw or raw == "[{]":
+        return []
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"WARNING: bad JSON from duckdb: {e}", file=sys.stderr)
+        return []
+
+
+def parse_days(args: list[str], default: int = 14) -> int:
+    """Parse --days N from argv."""
+    for i, arg in enumerate(args):
+        if arg == "--days" and i + 1 < len(args):
+            return int(args[i + 1])
+    return default
+
+
+def parse_limit(args: list[str], default: int = 15) -> int:
+    """Parse --limit N from argv."""
+    for i, arg in enumerate(args):
+        if arg == "--limit" and i + 1 < len(args):
+            return int(args[i + 1])
+    return default
+
+
+def output(rows: list[dict], args: list[str]) -> None:
+    """Print results as JSON (--json) or tab-separated."""
+    if "--json" in args:
+        print(json.dumps(rows, indent=2))
+    else:
+        if not rows:
+            print("(no results)")
+            return
+        keys = list(rows[0].keys())
+        print("\t".join(keys))
+        for row in rows:
+            print("\t".join(str(row.get(k, "")) for k in keys))

--- a/skills/session-analytics/scripts/queries/bash_patterns.py
+++ b/skills/session-analytics/scripts/queries/bash_patterns.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Most-repeated bash commands, optionally filtered to dangerous ones.
+
+Usage: python3 bash_patterns.py [--days 14] [--limit 15] [--dangerous] [--json]
+"""
+
+import sys
+from _db import output, parse_days, parse_limit, query
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    days = parse_days(args)
+    limit = parse_limit(args)
+    dangerous_only = "--dangerous" in args
+
+    danger_filter = (
+        """
+          AND (
+            bash_cmd LIKE '%rm -rf%'
+            OR (bash_cmd LIKE '%git push%--force%'
+                AND bash_cmd NOT LIKE '%--force-with-lease%')
+            OR bash_cmd LIKE '%DROP %'
+            OR bash_cmd LIKE '%> /dev/%'
+            OR bash_cmd LIKE '%chmod 777%'
+            OR bash_cmd LIKE '%--no-verify%'
+          )
+    """
+        if dangerous_only
+        else ""
+    )
+
+    rows = query(f"""
+        SELECT
+            bash_cmd,
+            count(*) AS uses
+        FROM tool_uses
+        WHERE tool_name = 'Bash'
+          AND bash_cmd IS NOT NULL
+          AND length(bash_cmd) > 10
+          AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+          {danger_filter}
+        GROUP BY bash_cmd
+        ORDER BY uses DESC
+        LIMIT {limit};
+    """)
+    output(rows, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/session-analytics/scripts/queries/denied_tools.py
+++ b/skills/session-analytics/scripts/queries/denied_tools.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Extract denied tool names from permission_denials, ranked by frequency.
+
+Usage: python3 denied_tools.py [--days 14] [--limit 15] [--json]
+"""
+
+import sys
+from _db import output, parse_days, parse_limit, query
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    days = parse_days(args)
+    limit = parse_limit(args)
+
+    rows = query(f"""
+        SELECT
+            CASE
+                WHEN content LIKE 'Permission to use % has been denied%'
+                    THEN regexp_extract(content, 'Permission to use (\\w+)', 1)
+                WHEN content LIKE '%The user doesn''t want to proceed%'
+                    THEN 'user_rejected'
+                WHEN content LIKE 'Hook PreToolUse:% denied this tool%'
+                    THEN 'hook_denied:' || regexp_extract(
+                        content, 'Hook PreToolUse:(\\w+)', 1)
+            END AS tool,
+            count(*) AS denials
+        FROM permission_denials
+        WHERE timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+        GROUP BY tool
+        HAVING tool IS NOT NULL
+        ORDER BY denials DESC
+        LIMIT {limit};
+    """)
+    output(rows, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/session-analytics/scripts/queries/error_rates.py
+++ b/skills/session-analytics/scripts/queries/error_rates.py
@@ -11,7 +11,10 @@ from _db import output, parse_days, parse_limit, query
 def parse_min_uses(args: list[str], default: int = 5) -> int:
     for i, arg in enumerate(args):
         if arg == "--min-uses" and i + 1 < len(args):
-            return int(args[i + 1])
+            try:
+                return int(args[i + 1])
+            except ValueError:
+                raise SystemExit(f"Invalid value for --min-uses: {args[i + 1]!r} (must be an integer)")
     return default
 
 

--- a/skills/session-analytics/scripts/queries/error_rates.py
+++ b/skills/session-analytics/scripts/queries/error_rates.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Tools ranked by error rate.
+
+Usage: python3 error_rates.py [--days 14] [--limit 15] [--min-uses 5] [--json]
+"""
+
+import sys
+from _db import output, parse_days, parse_limit, query
+
+
+def parse_min_uses(args: list[str], default: int = 5) -> int:
+    for i, arg in enumerate(args):
+        if arg == "--min-uses" and i + 1 < len(args):
+            return int(args[i + 1])
+    return default
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    days = parse_days(args)
+    limit = parse_limit(args)
+    min_uses = parse_min_uses(args)
+
+    rows = query(f"""
+        SELECT
+            tu.tool_name,
+            count(*) AS total,
+            sum(CASE WHEN tr.is_error = 'true' THEN 1 ELSE 0 END) AS errors,
+            round(
+                sum(CASE WHEN tr.is_error = 'true' THEN 1 ELSE 0 END)
+                * 100.0 / count(*), 1
+            ) AS error_pct
+        FROM tool_uses tu
+        JOIN tool_results tr ON tu.tool_use_id = tr.tool_use_id
+        WHERE tu.timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+        GROUP BY tu.tool_name
+        HAVING count(*) >= {min_uses}
+        ORDER BY error_pct DESC
+        LIMIT {limit};
+    """)
+    output(rows, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/session-analytics/scripts/queries/error_rates.py
+++ b/skills/session-analytics/scripts/queries/error_rates.py
@@ -14,7 +14,9 @@ def parse_min_uses(args: list[str], default: int = 5) -> int:
             try:
                 return int(args[i + 1])
             except ValueError:
-                raise SystemExit(f"Invalid value for --min-uses: {args[i + 1]!r} (must be an integer)")
+                raise SystemExit(
+                    f"Invalid value for --min-uses: {args[i + 1]!r} (must be an integer)"
+                )
     return default
 
 

--- a/skills/session-analytics/scripts/queries/hook_stats.py
+++ b/skills/session-analytics/scripts/queries/hook_stats.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Hook execution stats — coverage ratio and failure counts.
+
+Usage: python3 hook_stats.py [--days 14] [--json]
+"""
+
+import json
+import sys
+from _db import parse_days, query
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    days = parse_days(args)
+
+    hook_rows = query(f"""
+        SELECT count(*) AS cnt
+        FROM stop_hooks
+        WHERE timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY;
+    """)
+    stop_rows = query(f"""
+        SELECT count(*) AS cnt
+        FROM stop_events
+        WHERE timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY;
+    """)
+    error_rows = query(f"""
+        SELECT
+            json_extract_string(err_element, '$') AS error,
+            count(*) AS cnt
+        FROM stop_hooks,
+             unnest(json_extract(hookErrors, '$[*]')) AS t(err_element)
+        WHERE timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+          AND hookErrors IS NOT NULL
+          AND json_array_length(hookErrors) > 0
+        GROUP BY error
+        ORDER BY cnt DESC
+        LIMIT 10;
+    """)
+
+    hooks = int(hook_rows[0]["cnt"]) if hook_rows else 0
+    stops = int(stop_rows[0]["cnt"]) if stop_rows else 0
+    coverage = round(hooks / stops * 100, 1) if stops > 0 else 0
+
+    result = {
+        "days": days,
+        "stop_events": stops,
+        "hook_executions": hooks,
+        "coverage_pct": coverage,
+        "errors": error_rows,
+    }
+
+    if "--json" in args:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Stop events:     {stops}")
+        print(f"Hook executions: {hooks}")
+        print(f"Coverage:        {coverage}%")
+        if error_rows:
+            print(f"\nHook errors ({len(error_rows)} patterns):")
+            for r in error_rows:
+                print(f"  {r['cnt']}x  {r['error'][:80]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/session-analytics/scripts/queries/tool_misuse.py
+++ b/skills/session-analytics/scripts/queries/tool_misuse.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Detect bash commands that should use dedicated tools instead.
+
+Usage: python3 tool_misuse.py [--days 14] [--limit 15] [--json]
+"""
+
+import sys
+from _db import output, parse_days, parse_limit, query
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    days = parse_days(args)
+    limit = parse_limit(args)
+
+    rows = query(f"""
+        SELECT
+            CASE
+                WHEN bash_cmd LIKE 'cat %' OR bash_cmd LIKE 'head %'
+                    OR bash_cmd LIKE 'tail %' THEN 'cat/head/tail -> Read'
+                WHEN bash_cmd LIKE 'grep %' OR bash_cmd LIKE 'rg %'
+                    OR bash_cmd LIKE 'egrep %' THEN 'grep/rg -> Grep'
+                WHEN bash_cmd LIKE 'find %' OR bash_cmd LIKE 'fd %'
+                    THEN 'find/fd -> Glob'
+                WHEN bash_cmd LIKE 'sed %' OR bash_cmd LIKE '%sed -i%'
+                    THEN 'sed -> Edit'
+                WHEN bash_cmd LIKE 'echo %>>%' OR bash_cmd LIKE 'echo %>%'
+                    OR (bash_cmd LIKE 'cat %' AND bash_cmd LIKE '%>%')
+                    THEN 'echo/cat redirect -> Write'
+            END AS misuse_type,
+            count(*) AS uses
+        FROM tool_uses
+        WHERE tool_name = 'Bash'
+          AND bash_cmd IS NOT NULL
+          AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+        GROUP BY misuse_type
+        HAVING misuse_type IS NOT NULL
+        ORDER BY uses DESC
+        LIMIT {limit};
+    """)
+    output(rows, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/session-analytics/scripts/queries/tool_usage.py
+++ b/skills/session-analytics/scripts/queries/tool_usage.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Top tools by usage count.
+
+Usage: python3 tool_usage.py [--days 14] [--limit 15] [--json]
+"""
+
+import sys
+from _db import output, parse_days, parse_limit, query
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    days = parse_days(args)
+    limit = parse_limit(args)
+
+    rows = query(f"""
+        SELECT
+            tool_name,
+            count(*) AS uses,
+            count(DISTINCT sessionId) AS sessions
+        FROM tool_uses
+        WHERE timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+        GROUP BY tool_name
+        ORDER BY uses DESC
+        LIMIT {limit};
+    """)
+    output(rows, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_query_helpers.py
+++ b/tests/test_query_helpers.py
@@ -31,6 +31,7 @@ def _load(name: str):
     spec = importlib.util.spec_from_file_location(name, path)
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
     spec.loader.exec_module(mod)  # type: ignore[attr-defined]
     return mod
 

--- a/tests/test_query_helpers.py
+++ b/tests/test_query_helpers.py
@@ -1,0 +1,357 @@
+"""Tests for skills/session-analytics/scripts/queries/ helper modules."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# --- Module loading ---
+# The query scripts use `from _db import query`, so we add the queries
+# directory to sys.path and load each module by spec.
+
+_QUERIES_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "skills",
+    "session-analytics",
+    "scripts",
+    "queries",
+)
+
+if _QUERIES_DIR not in sys.path:
+    sys.path.insert(0, _QUERIES_DIR)
+
+
+def _load(name: str):
+    path = os.path.join(_QUERIES_DIR, f"{name}.py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+    return mod
+
+
+_db = _load("_db")
+denied_tools = _load("denied_tools")
+tool_usage = _load("tool_usage")
+error_rates = _load("error_rates")
+bash_patterns = _load("bash_patterns")
+tool_misuse = _load("tool_misuse")
+hook_stats = _load("hook_stats")
+
+
+def _mock_result(stdout: str = "", returncode: int = 0, stderr: str = ""):
+    return type(
+        "R", (), {"returncode": returncode, "stdout": stdout, "stderr": stderr}
+    )()
+
+
+# ── _db.query ──
+
+
+class TestDbQuery:
+    def test_db_not_found_exits(self, tmp_path) -> None:
+        with patch.object(_db, "DB_PATH", str(tmp_path / "missing.duckdb")):
+            with pytest.raises(SystemExit) as exc:
+                _db.query("SELECT 1")
+            assert exc.value.code == 1
+
+    def test_duckdb_binary_not_found_exits(self, tmp_path) -> None:
+        db = tmp_path / "test.duckdb"
+        db.touch()
+        with patch.object(_db, "DB_PATH", str(db)):
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                with pytest.raises(SystemExit) as exc:
+                    _db.query("SELECT 1")
+                assert exc.value.code == 1
+
+    def test_nonzero_returncode_returns_empty(self, tmp_path) -> None:
+        db = tmp_path / "test.duckdb"
+        db.touch()
+        with patch.object(_db, "DB_PATH", str(db)):
+            with patch(
+                "subprocess.run", return_value=_mock_result(returncode=1, stderr="err")
+            ):
+                assert _db.query("SELECT 1") == []
+
+    def test_empty_stdout_returns_empty(self, tmp_path) -> None:
+        db = tmp_path / "test.duckdb"
+        db.touch()
+        with patch.object(_db, "DB_PATH", str(db)):
+            with patch("subprocess.run", return_value=_mock_result(stdout="")):
+                assert _db.query("SELECT 1") == []
+
+    def test_duckdb_empty_sentinel_returns_empty(self, tmp_path) -> None:
+        db = tmp_path / "test.duckdb"
+        db.touch()
+        with patch.object(_db, "DB_PATH", str(db)):
+            with patch("subprocess.run", return_value=_mock_result(stdout="[{]")):
+                assert _db.query("SELECT 1") == []
+
+    def test_invalid_json_returns_empty(self, tmp_path) -> None:
+        db = tmp_path / "test.duckdb"
+        db.touch()
+        with patch.object(_db, "DB_PATH", str(db)):
+            with patch("subprocess.run", return_value=_mock_result(stdout="not-json")):
+                assert _db.query("SELECT 1") == []
+
+    def test_valid_json_returned(self, tmp_path) -> None:
+        db = tmp_path / "test.duckdb"
+        db.touch()
+        data = [{"tool": "Bash", "cnt": "5"}]
+        with patch.object(_db, "DB_PATH", str(db)):
+            with patch(
+                "subprocess.run", return_value=_mock_result(stdout=json.dumps(data))
+            ):
+                assert _db.query("SELECT 1") == data
+
+
+# ── _db.parse_days / parse_limit ──
+
+
+class TestArgParsers:
+    def test_parse_days_default(self) -> None:
+        assert _db.parse_days([]) == 14
+
+    def test_parse_days_custom(self) -> None:
+        assert _db.parse_days(["--days", "7"]) == 7
+
+    def test_parse_days_custom_default(self) -> None:
+        assert _db.parse_days([], default=30) == 30
+
+    def test_parse_limit_default(self) -> None:
+        assert _db.parse_limit([]) == 15
+
+    def test_parse_limit_custom(self) -> None:
+        assert _db.parse_limit(["--limit", "5"]) == 5
+
+    def test_parse_days_missing_value_returns_default(self) -> None:
+        assert _db.parse_days(["--days"]) == 14
+
+
+# ── _db.output ──
+
+
+class TestOutput:
+    def test_json_mode(self, capsys) -> None:
+        rows = [{"tool": "Bash", "uses": "10"}]
+        _db.output(rows, ["--json"])
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed == rows
+
+    def test_tsv_mode(self, capsys) -> None:
+        rows = [{"a": "1", "b": "2"}, {"a": "3", "b": "4"}]
+        _db.output(rows, [])
+        lines = capsys.readouterr().out.strip().split("\n")
+        assert lines[0] == "a\tb"
+        assert lines[1] == "1\t2"
+        assert lines[2] == "3\t4"
+
+    def test_empty_rows_prints_no_results(self, capsys) -> None:
+        _db.output([], [])
+        assert "(no results)" in capsys.readouterr().out
+
+
+# ── denied_tools ──
+# Scripts do `from _db import query`, so we must patch on the script module.
+
+
+class TestDeniedTools:
+    def test_queries_permission_denials_table(self) -> None:
+        with patch.object(denied_tools, "query", return_value=[]) as mock_q:
+            with patch("sys.argv", ["denied_tools.py"]):
+                denied_tools.main()
+        sql = mock_q.call_args[0][0]
+        assert "permission_denials" in sql
+        assert "regexp_extract" in sql
+
+    def test_passes_days_and_limit(self) -> None:
+        with patch.object(denied_tools, "query", return_value=[]) as mock_q:
+            with patch("sys.argv", ["denied_tools.py", "--days", "7", "--limit", "5"]):
+                denied_tools.main()
+        sql = mock_q.call_args[0][0]
+        assert "'7'" in sql
+        assert "5" in sql
+
+    def test_output_json(self, capsys) -> None:
+        rows = [{"tool": "Bash", "denials": "10"}]
+        with patch.object(denied_tools, "query", return_value=rows):
+            with patch("sys.argv", ["denied_tools.py", "--json"]):
+                denied_tools.main()
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed[0]["tool"] == "Bash"
+        assert parsed[0]["denials"] == "10"
+
+
+# ── tool_usage ──
+
+
+class TestToolUsage:
+    def test_queries_tool_uses_table(self) -> None:
+        with patch.object(tool_usage, "query", return_value=[]) as mock_q:
+            with patch("sys.argv", ["tool_usage.py"]):
+                tool_usage.main()
+        sql = mock_q.call_args[0][0]
+        assert "tool_uses" in sql
+        assert "tool_name" in sql
+
+    def test_output_includes_sessions_column(self, capsys) -> None:
+        rows = [{"tool_name": "Read", "uses": "50", "sessions": "10"}]
+        with patch.object(tool_usage, "query", return_value=rows):
+            with patch("sys.argv", ["tool_usage.py", "--json"]):
+                tool_usage.main()
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed[0]["sessions"] == "10"
+
+
+# ── error_rates ──
+
+
+class TestErrorRates:
+    def test_queries_tool_uses_join_results(self) -> None:
+        with patch.object(error_rates, "query", return_value=[]) as mock_q:
+            with patch("sys.argv", ["error_rates.py"]):
+                error_rates.main()
+        sql = mock_q.call_args[0][0]
+        assert "tool_uses tu" in sql
+        assert "tool_results tr" in sql
+        assert "error_pct" in sql
+
+    def test_min_uses_flag(self) -> None:
+        with patch.object(error_rates, "query", return_value=[]) as mock_q:
+            with patch("sys.argv", ["error_rates.py", "--min-uses", "20"]):
+                error_rates.main()
+        sql = mock_q.call_args[0][0]
+        assert "20" in sql
+
+    def test_parse_min_uses_default(self) -> None:
+        assert error_rates.parse_min_uses([]) == 5
+
+
+# ── bash_patterns ──
+
+
+class TestBashPatterns:
+    def test_normal_mode_no_danger_filter(self) -> None:
+        with patch.object(bash_patterns, "query", return_value=[]) as mock_q:
+            with patch("sys.argv", ["bash_patterns.py"]):
+                bash_patterns.main()
+        sql = mock_q.call_args[0][0]
+        assert "rm -rf" not in sql
+
+    def test_dangerous_mode_adds_filter(self) -> None:
+        with patch.object(bash_patterns, "query", return_value=[]) as mock_q:
+            with patch("sys.argv", ["bash_patterns.py", "--dangerous"]):
+                bash_patterns.main()
+        sql = mock_q.call_args[0][0]
+        assert "rm -rf" in sql
+        assert "--no-verify" in sql
+        assert "chmod 777" in sql
+
+
+# ── tool_misuse ──
+
+
+class TestToolMisuse:
+    def test_queries_misuse_patterns(self) -> None:
+        with patch.object(tool_misuse, "query", return_value=[]) as mock_q:
+            with patch("sys.argv", ["tool_misuse.py"]):
+                tool_misuse.main()
+        sql = mock_q.call_args[0][0]
+        assert "cat" in sql.lower()
+        assert "grep" in sql.lower()
+        assert "find" in sql.lower()
+        assert "sed" in sql.lower()
+
+    def test_output_has_misuse_type(self, capsys) -> None:
+        rows = [{"misuse_type": "grep/rg -> Grep", "uses": "100"}]
+        with patch.object(tool_misuse, "query", return_value=rows):
+            with patch("sys.argv", ["tool_misuse.py", "--json"]):
+                tool_misuse.main()
+        parsed = json.loads(capsys.readouterr().out)
+        assert "Grep" in parsed[0]["misuse_type"]
+
+
+# ── hook_stats ──
+
+
+class TestHookStats:
+    def _mock_three_queries(self, hook_cnt, stop_cnt, errors=None):
+        """Return a side_effect for the 3 queries hook_stats.main() makes."""
+        returns = [
+            [{"cnt": str(hook_cnt)}],
+            [{"cnt": str(stop_cnt)}],
+            errors or [],
+        ]
+        call_idx = [0]
+
+        def _q(sql):  # noqa: ARG001
+            idx = call_idx[0]
+            call_idx[0] += 1
+            return returns[idx]
+
+        return _q
+
+    def test_coverage_calculation(self, capsys) -> None:
+        with patch.object(
+            hook_stats, "query", side_effect=self._mock_three_queries(50, 100)
+        ):
+            with patch("sys.argv", ["hook_stats.py"]):
+                hook_stats.main()
+        out = capsys.readouterr().out
+        assert "50.0%" in out
+
+    def test_zero_stops_no_crash(self, capsys) -> None:
+        with patch.object(
+            hook_stats, "query", side_effect=self._mock_three_queries(0, 0)
+        ):
+            with patch("sys.argv", ["hook_stats.py"]):
+                hook_stats.main()
+        out = capsys.readouterr().out
+        assert "0%" in out
+
+    def test_json_output_structure(self, capsys) -> None:
+        errors = [{"error": "Timeout", "cnt": "3"}]
+        with patch.object(
+            hook_stats, "query", side_effect=self._mock_three_queries(30, 100, errors)
+        ):
+            with patch("sys.argv", ["hook_stats.py", "--json"]):
+                hook_stats.main()
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["stop_events"] == 100
+        assert parsed["hook_executions"] == 30
+        assert parsed["coverage_pct"] == 30.0
+        assert parsed["errors"][0]["error"] == "Timeout"
+
+    def test_errors_shown_in_text_mode(self, capsys) -> None:
+        errors = [{"error": "Script crashed", "cnt": "5"}]
+        with patch.object(
+            hook_stats, "query", side_effect=self._mock_three_queries(10, 50, errors)
+        ):
+            with patch("sys.argv", ["hook_stats.py"]):
+                hook_stats.main()
+        out = capsys.readouterr().out
+        assert "Script crashed" in out
+        assert "5x" in out
+
+    def test_days_flag_passed_to_queries(self) -> None:
+        sqls = []
+        call_idx = [0]
+
+        def capture_sql(sql):
+            sqls.append(sql)
+            call_idx[0] += 1
+            if call_idx[0] <= 2:
+                return [{"cnt": "0"}]
+            return []  # errors query returns no rows
+
+        with patch.object(hook_stats, "query", side_effect=capture_sql):
+            with patch("sys.argv", ["hook_stats.py", "--days", "7"]):
+                hook_stats.main()
+        for sql in sqls:
+            assert "'7'" in sql


### PR DESCRIPTION
## Summary

- Adds 6 standalone CLI query scripts in `scripts/queries/` that replace inline Python for common session analytics tasks (denied tools, tool usage, error rates, bash patterns, tool misuse, hook stats)
- Shared `_db.py` module provides DuckDB query runner, arg parsing (`--days`, `--limit`), and output formatting (`--json` or TSV)
- Updates SKILL.md with a "Pre-built query scripts" section documenting all helpers
- 33 unit tests covering the shared module and all 6 query scripts

## Test plan

- [x] All 6 scripts tested against live DuckDB database
- [x] 33 new tests pass (`uv run pytest tests/test_query_helpers.py`)
- [x] Full suite green (220 tests)
- [x] Ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)