### PR TITLE
feat(setup): create ~/.vaudeville/rules/ during setup

### DIFF
--- a/agents/hard-hook-writer.md
+++ b/agents/hard-hook-writer.md
@@ -5,13 +5,13 @@ description: >
   settings.json or hooks.json. Use this agent when the user describes enforcement
   that can be done with regex, string matching, file inspection, or structural
   checks. The enforcement target is shaped data (commands, file paths, JSON
-  fields), not natural language. Spawned by the add-hook skill, but also
+  fields), not natural language. Spawned by the vaudeville:add-hook skill, but also
   directly invocable.
 
   <example>
   Context: User wants to prevent a dangerous command
   user: "Block rm -rf /"
-  assistant: "I'll use the hard-hook-writer agent to create a PreToolUse Bash guard."
+  assistant: "I'll use the vaudeville:hard-hook-writer agent to create a PreToolUse Bash guard."
   <commentary>
   Structural pattern match on a command string — deterministic, no SLM needed.
   </commentary>
@@ -20,7 +20,7 @@ description: >
   <example>
   Context: User wants automatic formatting after writes
   user: "Auto-format Python files after Claude writes them"
-  assistant: "I'll use the hard-hook-writer agent to create a PostToolUse formatter hook."
+  assistant: "I'll use the vaudeville:hard-hook-writer agent to create a PostToolUse formatter hook."
   <commentary>
   Structural automation triggered by file extension — fast, deterministic.
   </commentary>
@@ -29,7 +29,7 @@ description: >
   <example>
   Context: User wants to protect sensitive files
   user: "Warn when editing .env files"
-  assistant: "I'll use the hard-hook-writer agent to create a PreToolUse Edit/Write guard."
+  assistant: "I'll use the vaudeville:hard-hook-writer agent to create a PreToolUse Edit/Write guard."
   <commentary>
   File path pattern match — regex is sufficient, no intent classification needed.
   </commentary>
@@ -38,7 +38,7 @@ description: >
   <example>
   Context: User wants context injection at session start
   user: "Inject my team's coding standards when a session starts"
-  assistant: "I'll use the hard-hook-writer agent to create a SessionStart context hook."
+  assistant: "I'll use the vaudeville:hard-hook-writer agent to create a SessionStart context hook."
   <commentary>
   Context injection is structural — read a file, print to stdout. No classification.
   </commentary>
@@ -54,7 +54,7 @@ JS/Python/Bash hook scripts for Claude Code.
 
 Your hooks run in <100ms. They enforce structural rules: command patterns, file
 paths, JSON field checks, automated formatting, context injection. They do NOT
-classify natural language — that's the slm-rule-writer's job.
+classify natural language — that's the vaudeville:slm-rule-writer's job.
 
 ## Hook Locations
 
@@ -273,7 +273,7 @@ Always explain what the hook does, which event it targets, and how to test it.
 
 ## What This Agent Does NOT Do
 
-- Classify natural language intent, tone, or meaning (use slm-rule-writer)
+- Classify natural language intent, tone, or meaning (use vaudeville:slm-rule-writer)
 - Create vaudeville YAML rules or run the eval harness
 - Modify existing hooks without explicit user approval
 - Debug hook execution failures (troubleshoot manually via session logs)

--- a/agents/slm-rule-writer.md
+++ b/agents/slm-rule-writer.md
@@ -5,13 +5,13 @@ description: >
   (Phi-4-mini) via the daemon, plus test cases and hooks.json registration.
   Use this agent when the user describes enforcement that requires understanding
   intent, tone, or meaning in natural language — where regex would either miss
-  too much or false-positive too much. Spawned by the add-hook skill, but also
+  too much or false-positive too much. Spawned by the vaudeville:add-hook skill, but also
   directly invocable.
 
   <example>
   Context: User wants to catch hedging in Claude's responses
   user: "Detect when Claude hedges about untested code"
-  assistant: "I'll use the slm-rule-writer agent to create a Stop rule that classifies hedging language."
+  assistant: "I'll use the vaudeville:slm-rule-writer agent to create a Stop rule that classifies hedging language."
   <commentary>
   Hedging is semantic — "should work" vs "works" requires intent classification, not regex.
   </commentary>
@@ -20,7 +20,7 @@ description: >
   <example>
   Context: User wants to catch dismissal of test failures
   user: "Catch when Claude dismisses test failures"
-  assistant: "I'll use the slm-rule-writer agent to create a Stop rule for dismissal detection."
+  assistant: "I'll use the vaudeville:slm-rule-writer agent to create a Stop rule for dismissal detection."
   <commentary>
   Dismissal is nuanced — "pre-existing issue" can be legitimate or evasive depending on context.
   </commentary>
@@ -29,7 +29,7 @@ description: >
   <example>
   Context: User wants to detect deferral language in PR replies
   user: "Flag when Claude defers to follow-up PRs in review replies"
-  assistant: "I'll use the slm-rule-writer agent to create a PostToolUse rule for deferral detection."
+  assistant: "I'll use the vaudeville:slm-rule-writer agent to create a PostToolUse rule for deferral detection."
   <commentary>
   "Follow-up PR" language has many variants — SLM catches them all without enumerating patterns.
   </commentary>
@@ -38,7 +38,7 @@ description: >
   <example>
   Context: User wants to detect sycophantic agreement
   user: "Stop Claude from agreeing with everything I say"
-  assistant: "I'll use the slm-rule-writer agent to create a Stop rule for sycophancy detection."
+  assistant: "I'll use the vaudeville:slm-rule-writer agent to create a Stop rule for sycophancy detection."
   <commentary>
   Sycophancy is contextual — "Great idea!" is fine sometimes, problematic other times. Needs SLM.
   </commentary>
@@ -54,7 +54,7 @@ rules for semantic text classification using the local Phi-4-mini SLM.
 
 Your rules run in 1-5s via the vaudeville daemon. They classify natural language
 by intent, tone, and meaning — things regex cannot reliably detect. For
-structural pattern matching (<100ms), the hard-hook-writer handles that instead.
+structural pattern matching (<100ms), the vaudeville:hard-hook-writer handles that instead.
 
 ## Rule YAML Format
 
@@ -294,7 +294,7 @@ For each rule created, deliver:
 
 ## What This Agent Does NOT Do
 
-- Create JS/bash hooks for structural pattern matching (use hard-hook-writer)
+- Create JS/bash hooks for structural pattern matching (use vaudeville:hard-hook-writer)
 - Query session analytics or suggest hooks from usage data
 - Modify existing bundled rules without explicit user approval
 - Modify the daemon, runner.py, or eval infrastructure

--- a/skills/add-hook/SKILL.md
+++ b/skills/add-hook/SKILL.md
@@ -7,13 +7,13 @@ description: >
   hook", "new hook", "enforce X", "guard against X", "block X", "prevent X",
   "detect when Claude does X", "catch X", "stop Claude from X", "add
   enforcement", "quality gate for X", or describes any behavior to enforce.
-  This skill routes to hard-hook-writer (JS/Python/Bash) or slm-rule-writer
+  This skill routes to vaudeville:hard-hook-writer (JS/Python/Bash) or vaudeville:slm-rule-writer
   (SLM/YAML) based on whether the enforcement is structural or semantic.
   Also trigger when the user says "add a rule", "new rule", "create a
   detector", "SLM rule for X", or describes behavior requiring semantic
   classification. Do NOT use for suggesting hooks from usage data (use
-  hook-suggester), querying session analytics (use session-analytics),
-  checking daemon status (use `status` skill), or debugging existing hooks.
+  vaudeville:hook-suggester), querying session analytics (use vaudeville:session-analytics),
+  checking daemon status (use `vaudeville:status` skill), or debugging existing hooks.
 model: sonnet
 context: fork
 allowed-tools: Agent, Read, Glob, Grep
@@ -37,7 +37,7 @@ The user describes what they want to enforce in natural language:
 
 Analyze the description and route to the correct specialist.
 
-**Route to `slm-rule-writer` agent when:**
+**Route to `vaudeville:slm-rule-writer` agent when:**
 - The check requires understanding intent or context
 - Simple regex would have high false positives
 - Content being checked is natural language (responses, PR comments, commit messages)
@@ -45,7 +45,7 @@ Analyze the description and route to the correct specialist.
 - Keywords: detect, catch, tone, quality, hedging, dismissal, deferral, sycophancy,
   completeness, "when Claude does X"
 
-**Route to `hard-hook-writer` agent when:**
+**Route to `vaudeville:hard-hook-writer` agent when:**
 - The check is structural (file paths, command patterns, JSON fields)
 - A regex or string match is sufficient
 - Speed matters (structural hooks are <100ms, SLM is 1-5s)
@@ -64,9 +64,9 @@ If the request could reasonably go either way, ask:
 
 Before spawning, tell the user which type was chosen and why:
 
-- "Routing to **slm-rule-writer** because detecting [X] requires
+- "Routing to **vaudeville:slm-rule-writer** because detecting [X] requires
   understanding intent — a regex would miss variations."
-- "Routing to **hard-hook-writer** because blocking [X] is a structural
+- "Routing to **vaudeville:hard-hook-writer** because blocking [X] is a structural
   pattern match — fast and deterministic."
 - "Hooks are runtime-enforced — Claude cannot override them, unlike
   CLAUDE.md instructions."
@@ -77,7 +77,7 @@ Then spawn the named agent:
 
 ```
 Agent(
-  subagent_type: "slm-rule-writer",
+  subagent_type: "vaudeville:slm-rule-writer",
   description: "Create SLM rule: <short summary>",
   prompt: "Create a vaudeville rule for: <user's description>.
     The plugin root is <CLAUDE_PLUGIN_ROOT path>.
@@ -89,7 +89,7 @@ Agent(
 
 ```
 Agent(
-  subagent_type: "hard-hook-writer",
+  subagent_type: "vaudeville:hard-hook-writer",
   description: "Create JS hook: <short summary>",
   prompt: "Create a hook for: <user's description>.
     Target location: <user or plugin scope>.
@@ -104,21 +104,21 @@ This skill only does routing and tradeoff communication.
 
 | Signal in user description | Route | Reason |
 |---------------------------|-------|--------|
-| "hedging", "sycophancy", "dismissal" | slm-rule-writer | Semantic classification |
-| "deferral", "follow-up PR", "separate commit" | slm-rule-writer | Intent detection |
-| "completeness", "TODO", "unfinished" | slm-rule-writer | Context understanding |
-| "tone", "quality", "when Claude does X" | slm-rule-writer | Natural language |
-| "block command X", "prevent rm" | hard-hook-writer | Exact pattern match |
-| "guard file X", "protect path" | hard-hook-writer | File path check |
-| "format after write", "auto-run" | hard-hook-writer | Structural automation |
-| "inject context", "add to prompt" | hard-hook-writer | Context injection |
-| "block force push", "no --no-verify" | hard-hook-writer | Command argument match |
+| "hedging", "sycophancy", "dismissal" | vaudeville:slm-rule-writer | Semantic classification |
+| "deferral", "follow-up PR", "separate commit" | vaudeville:slm-rule-writer | Intent detection |
+| "completeness", "TODO", "unfinished" | vaudeville:slm-rule-writer | Context understanding |
+| "tone", "quality", "when Claude does X" | vaudeville:slm-rule-writer | Natural language |
+| "block command X", "prevent rm" | vaudeville:hard-hook-writer | Exact pattern match |
+| "guard file X", "protect path" | vaudeville:hard-hook-writer | File path check |
+| "format after write", "auto-run" | vaudeville:hard-hook-writer | Structural automation |
+| "inject context", "add to prompt" | vaudeville:hard-hook-writer | Context injection |
+| "block force push", "no --no-verify" | vaudeville:hard-hook-writer | Command argument match |
 
 ## What This Skill Does NOT Do
 
-- Query session analytics (use `session-analytics`)
-- Suggest hooks from usage data (use `hook-suggester`)
-- Check daemon status (use `status` skill)
+- Query session analytics (use `vaudeville:session-analytics`)
+- Suggest hooks from usage data (use `vaudeville:hook-suggester`)
+- Check daemon status (use `vaudeville:status` skill)
 - Modify existing hooks without explicit approval
 
 ## UX Principles
@@ -134,7 +134,7 @@ This skill only does routing and tradeoff communication.
 
 ## Gotchas
 
-- If the vaudeville daemon isn't running, slm-rule-writer will create the
+- If the vaudeville daemon isn't running, vaudeville:slm-rule-writer will create the
   rule but it won't fire at runtime — remind user to run `/vaudeville:status`
   to verify the daemon is healthy
 - Ambiguous requests that contain BOTH structural and semantic signals

--- a/skills/hook-suggester/SKILL.md
+++ b/skills/hook-suggester/SKILL.md
@@ -2,10 +2,10 @@
 name: hook-suggester
 description: >
   Analyze Claude Code session history to suggest hooks tailored to the user's
-  actual usage patterns. Mines session-analytics data for dangerous commands,
+  actual usage patterns. Mines vaudeville:session-analytics data for dangerous commands,
   tool misuse, high error rates, permission friction, missing quality gates,
   broken hooks, and repeated automatable patterns — then generates concrete
-  hook implementations via add-hook. Use when the user asks "what hooks
+  hook implementations via vaudeville:add-hook. Use when the user asks "what hooks
   should I add", "suggest hooks", "analyze my usage for hooks", "what should
   I enforce", "improve my hooks", "hook suggestions", or wants to discover
   enforcement opportunities they haven't thought of. Also trigger for
@@ -13,8 +13,8 @@ description: >
   "what hooks do I need", "hook audit", "analyze my hooks", "optimize my
   workflow", "what's failing in my sessions", "guard against", or any question
   about optimizing their Claude Code workflow through hooks. Do NOT use for
-  creating a specific known hook (use add-hook), querying raw session data
-  (use session-analytics), or general workflow questions.
+  creating a specific known hook (use vaudeville:add-hook), querying raw session data
+  (use vaudeville:session-analytics), or general workflow questions.
 model: sonnet
 context: fork
 allowed-tools: Bash(python3:*), Bash(duckdb:*), Read, Skill
@@ -24,7 +24,7 @@ allowed-tools: Bash(python3:*), Bash(duckdb:*), Read, Skill
 
 Analyze session history → find patterns → suggest hooks → implement them.
 
-This skill bridges session-analytics (the data) and add-hook (the builder).
+This skill bridges vaudeville:session-analytics (the data) and vaudeville:add-hook (the builder).
 It answers: "What hooks would actually help me, based on how I work?"
 
 ## Workflow
@@ -78,19 +78,19 @@ The user may want all, some, or none.
 
 ### Step 4: Implement selected hooks
 
-For each suggestion the user approves, route through the unified `add-hook`
+For each suggestion the user approves, route through the unified `vaudeville:add-hook`
 skill. It handles the SLM-vs-JS routing decision automatically:
 
 ```
 Skill(skill: "vaudeville:add-hook", args: "<description of what to enforce>")
 ```
 
-`add-hook` will analyze the description and route to either:
-- **slm-rule-writer** agent — for semantic/intent checks (hedging, dismissal, deferral, etc.)
-- **hard-hook-writer** agent — for structural pattern checks (command guards, file guards, etc.)
+`vaudeville:add-hook` will analyze the description and route to either:
+- **vaudeville:slm-rule-writer** agent — for semantic/intent checks (hedging, dismissal, deferral, etc.)
+- **vaudeville:hard-hook-writer** agent — for structural pattern checks (command guards, file guards, etc.)
 
 Do NOT invoke these agents directly from this skill — always go through
-`add-hook` so routing logic stays centralized.
+`vaudeville:add-hook` so routing logic stays centralized.
 
 ## Example Session
 
@@ -117,14 +117,14 @@ User: suggest some hooks for me
          Found 230 code writes across 3 languages...
 
 4. Ask user which to implement
-5. Invoke add-hook for each approved suggestion
+5. Invoke vaudeville:add-hook for each approved suggestion
 ```
 
 ## What This Skill Doesn't Do
 
-- Create hooks without data backing (use add-hook directly)
-- Query arbitrary session analytics (use session-analytics)
-- Modify existing hooks (use add-hook)
+- Create hooks without data backing (use vaudeville:add-hook directly)
+- Query arbitrary session analytics (use vaudeville:session-analytics)
+- Modify existing hooks (use vaudeville:add-hook)
 - Make decisions for the user — always present and let them choose
 
 ## Gotchas
@@ -138,6 +138,6 @@ User: suggest some hooks for me
   may reflect agent behavior that's already correct for the subagent's context.
 - The analyzer runs 8 independent DuckDB queries. If the database is large (>100K
   entries), this can take 5-10 seconds. Don't run with --force unnecessarily.
-- add-hook is invoked per suggestion — if the user approves 5 hooks, that's
+- vaudeville:add-hook is invoked per suggestion — if the user approves 5 hooks, that's
   5 sequential Skill invocations. Batch acknowledgment is fine but implementation
   is serial.

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -115,4 +115,4 @@ When reporting results, include actionable guidance for common issues:
 | STALE PID | Daemon crashed | Check log for errors, restart session |
 | Socket missing | Startup race or crash | Restart session; if persistent, check disk space in /tmp |
 | Rule not wired | Rule file exists but not in hooks.json | Add it to the appropriate hook command in hooks.json |
-| Empty rules/ | No rules defined | Use `/add-hook` to create one |
+| Empty rules/ | No rules defined | Use `/vaudeville:add-hook` to create one |

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -7,6 +7,7 @@ import socket
 import tempfile
 import threading
 import time
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -191,11 +192,36 @@ class TestSetupGGUF:
         mock_llm.create_chat_completion.assert_called_once()
 
 
+class TestEnsureRulesDir:
+    def test_creates_rules_directory(self, tmp_path: Path) -> None:
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        with patch("vaudeville.setup.os.path.expanduser", return_value=str(fake_home)):
+            from vaudeville.setup import _ensure_rules_dir
+
+            _ensure_rules_dir()
+        assert (fake_home / ".vaudeville" / "rules").is_dir()
+
+    def test_idempotent_when_exists(self, tmp_path: Path) -> None:
+        fake_home = tmp_path / "home"
+        rules_dir = fake_home / ".vaudeville" / "rules"
+        rules_dir.mkdir(parents=True)
+        existing_file = rules_dir / "my-rule.yaml"
+        existing_file.write_text("name: keep-me")
+        with patch("vaudeville.setup.os.path.expanduser", return_value=str(fake_home)):
+            from vaudeville.setup import _ensure_rules_dir
+
+            _ensure_rules_dir()
+        assert rules_dir.is_dir()
+        assert existing_file.read_text() == "name: keep-me"
+
+
 class TestSetupMain:
     def test_mlx_path_runs(self, capsys: pytest.CaptureFixture[str]) -> None:
         with (
             patch("vaudeville.setup._detect_platform", return_value="mlx"),
             patch("vaudeville.setup._setup_mlx"),
+            patch("vaudeville.setup._ensure_rules_dir"),
         ):
             from vaudeville.setup import main
 
@@ -206,6 +232,7 @@ class TestSetupMain:
         with (
             patch("vaudeville.setup._detect_platform", return_value="gguf"),
             patch("vaudeville.setup._setup_gguf"),
+            patch("vaudeville.setup._ensure_rules_dir"),
         ):
             from vaudeville.setup import main
 
@@ -219,6 +246,7 @@ class TestSetupMain:
                 "vaudeville.setup._setup_mlx",
                 side_effect=ImportError("mlx_lm not found"),
             ),
+            patch("vaudeville.setup._ensure_rules_dir"),
         ):
             from vaudeville.setup import main
 

--- a/tests/test_server_main.py
+++ b/tests/test_server_main.py
@@ -65,6 +65,7 @@ class TestSetupMain:
         with (
             patch("vaudeville.setup._detect_platform", return_value="mlx"),
             patch("vaudeville.setup._setup_mlx"),
+            patch("vaudeville.setup._ensure_rules_dir"),
         ):
             from vaudeville.setup import main
 
@@ -75,6 +76,7 @@ class TestSetupMain:
         with (
             patch("vaudeville.setup._detect_platform", return_value="gguf"),
             patch("vaudeville.setup._setup_gguf"),
+            patch("vaudeville.setup._ensure_rules_dir"),
         ):
             from vaudeville.setup import main
 
@@ -88,6 +90,7 @@ class TestSetupMain:
                 "vaudeville.setup._setup_mlx",
                 side_effect=ImportError("mlx_lm not found"),
             ),
+            patch("vaudeville.setup._ensure_rules_dir"),
         ):
             from vaudeville.setup import main
 

--- a/vaudeville/setup.py
+++ b/vaudeville/setup.py
@@ -6,6 +6,7 @@ Usage: uv run --group mlx python -m vaudeville.setup   # Apple Silicon
 
 from __future__ import annotations
 
+import os
 import platform
 import sys
 
@@ -55,10 +56,19 @@ def _setup_gguf() -> None:
     print("Inference verified.")
 
 
+def _ensure_rules_dir() -> None:
+    """Create ~/.vaudeville/rules/ if it doesn't exist."""
+    rules_dir = os.path.join(os.path.expanduser("~"), ".vaudeville", "rules")
+    os.makedirs(rules_dir, exist_ok=True)
+    print(f"Rules directory ready: {rules_dir}")
+
+
 def main() -> None:
     backend = _detect_platform()
     print(f"Detected platform: {platform.system()}/{platform.machine()} → {backend}")
     print("This is a one-time setup step.\n")
+
+    _ensure_rules_dir()
 
     try:
         if backend == "mlx":


### PR DESCRIPTION
## Summary
- Add `_ensure_rules_dir()` to setup script that creates `~/.vaudeville/rules/` with `os.makedirs(exist_ok=True)`
- Called early in `main()` so the global rules directory is ready after first-time setup
- Tests verify directory creation and idempotency (existing rules are preserved)

## Test plan
- [x] `just check` passes (lint + typecheck + tests)
- [x] New `TestEnsureRulesDir` tests cover creation and idempotency
- [x] Existing `TestSetupMain` tests updated to patch new function

🤖 Generated with [Claude Code](https://claude.com/claude-code)