### PR TITLE
refactor(agent): decouple slm-rule-writer from bundled defaults

### DIFF
--- a/agents/slm-rule-writer.md
+++ b/agents/slm-rule-writer.md
@@ -58,7 +58,8 @@ structural pattern matching (<100ms), the vaudeville:hard-hook-writer handles th
 
 ## Rule YAML Format
 
-Every rule is a single YAML file in `rules/`. Complete schema:
+Every rule is a single YAML file placed in one of the resolution layer directories
+(project `.vaudeville/rules/` or `~/.vaudeville/rules/`). Complete schema:
 
 ```yaml
 name: my-detector              # Unique identifier (kebab-case, matches filename)
@@ -173,48 +174,11 @@ cases:
 - **Vary length**: Short (1-2 sentences) and long (paragraph) cases — but
   ensure ALL cases are >100 characters (runner.py skips shorter inputs)
 
-## Registration in hooks.json
+## Registration
 
-After creating rule and test file, register in `hooks/hooks.json`.
-
-### For Stop rules
-
-Add the rule name to the existing Stop runner command:
-
-```json
-"Stop": [
-  {
-    "hooks": [
-      {
-        "type": "command",
-        "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/runner.py violation-detector dismissal-detector my-detector",
-        "timeout": 30,
-        "statusMessage": "Evaluating response quality..."
-      }
-    ]
-  }
-]
-```
-
-### For PostToolUse rules
-
-Add a new matcher group or extend an existing one:
-
-```json
-"PostToolUse": [
-  {
-    "matcher": "tool_name_regex",
-    "hooks": [
-      {
-        "type": "command",
-        "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/runner.py my-detector",
-        "timeout": 10,
-        "statusMessage": "Checking output..."
-      }
-    ]
-  }
-]
-```
+The runner discovers rules automatically via `--event <EventName>`. Just ensure
+your rule YAML has the `event:` field set (e.g. `event: Stop`). No manual
+registration in hooks.json needed — hooks.json already has a runner entry per event.
 
 ## Rule Resolution Layers
 
@@ -223,7 +187,6 @@ Rules load from multiple directories (highest priority wins by name):
 ```
 1. <project>/.vaudeville/rules/    (project-specific overrides)
 2. ~/.vaudeville/rules/             (user-global rules)
-3. <plugin_root>/rules/             (bundled defaults)
 ```
 
 ## Your Workflow
@@ -234,7 +197,7 @@ Ask: "What behavior am I trying to detect?" Write it as a one-sentence task.
 
 ### 2. Write the rule YAML
 
-Create `rules/<name>.yaml`. Start with 4 examples in the prompt (2 violation, 2 clean).
+Create `<name>.yaml` in the target rules directory. Start with 4 examples in the prompt (2 violation, 2 clean).
 
 ### 3. Write test cases
 
@@ -252,23 +215,19 @@ Target: **>90% accuracy**. If low:
 - Check for ambiguous test cases
 - Ensure labels are consistent
 
-### 5. Register in hooks.json
-
-Add the rule name to the appropriate runner command in `hooks/hooks.json`.
-
-### 6. Test end-to-end
+### 5. Test end-to-end
 
 Verify: daemon running → hook fires → rule classifies → action triggers.
 
-## Existing Rules (Reference)
+## Style Reference
 
-Read these in `rules/` for style guidance:
+Read the example rules in `examples/rules/` and their test cases in
+`examples/tests/` for style guidance. These show the expected prompt structure,
+label conventions, context field usage, and test case patterns:
 
-| Rule | Event | Detects |
-|------|-------|---------|
-| `violation-detector` | Stop | Hedging, deferrals, unresolved findings |
-| `dismissal-detector` | Stop | Dismissing test/CI failures without evidence |
-| `deferral-detector` | PostToolUse | "Follow-up PR" language in PR replies |
+- `hedging-detector` — Stop rule detecting uncertain language about verifiable claims
+- `dismissal-detector` — Stop rule detecting test failure dismissals without evidence
+- `deferral-detector` — PostToolUse rule detecting "follow-up PR" deferrals in reviews
 
 ## Gotchas
 
@@ -287,14 +246,13 @@ Read these in `rules/` for style guidance:
 ## Deliverables
 
 For each rule created, deliver:
-1. Rule YAML in `rules/`
-2. Test cases in `tests/` (minimum 10 cases, balanced labels)
-3. Updated `hooks/hooks.json` registration
-4. Eval results showing >90% accuracy
+1. Rule YAML in the target rules directory (with `event:` field set for auto-discovery)
+2. Test cases YAML (minimum 10 cases, balanced labels)
+3. Eval results showing >90% accuracy
 
 ## What This Agent Does NOT Do
 
 - Create JS/bash hooks for structural pattern matching (use vaudeville:hard-hook-writer)
 - Query session analytics or suggest hooks from usage data
-- Modify existing bundled rules without explicit user approval
+- Modify existing user rules without explicit approval
 - Modify the daemon, runner.py, or eval infrastructure

--- a/examples/rules/deferral-detector.yaml
+++ b/examples/rules/deferral-detector.yaml
@@ -1,0 +1,46 @@
+name: deferral-detector
+event: PostToolUse
+prompt: |
+  Classify whether this PR reply defers requested work to a follow-up instead
+  of addressing it now.
+
+  VIOLATION if the response:
+  - Promises a "follow-up PR" or "follow-up commit" instead of fixing now
+  - Defers to "next iteration", "future pass", or "separate PR"
+  - Says "let's merge this first" to avoid addressing feedback
+  - Uses "will handle later" or "can be improved later" language
+
+  CLEAN if the response:
+  - Addresses feedback directly with code changes
+  - Pushes back with specific technical reasoning
+  - Explains why something is out of scope with a concrete justification
+  - Acknowledges and fixes the issue in the current PR
+
+  Examples:
+
+  Response: "Good point! I'll address this in a follow-up PR."
+  VERDICT: violation
+  REASON: Defers to follow-up instead of fixing now
+
+  Response: "Good catch! Fixed in the latest commit — added null check."
+  VERDICT: clean
+  REASON: Addresses feedback directly with a fix
+
+  Response: "Will handle in a separate commit. The current PR is large enough."
+  VERDICT: violation
+  REASON: Defers to separate work to avoid addressing now
+
+  Response: "This is out of scope — it requires changing the API contract which needs a migration. Opened issue #456 with full context."
+  VERDICT: clean
+  REASON: Explains out-of-scope with concrete technical justification
+
+  Now classify:
+  {text}
+
+  VERDICT: violation or clean
+  REASON: one sentence
+context:
+  - field: tool_input.body
+labels: [violation, clean]
+action: block
+message: "Deferral detected: {reason}"

--- a/examples/rules/dismissal-detector.yaml
+++ b/examples/rules/dismissal-detector.yaml
@@ -1,0 +1,46 @@
+name: dismissal-detector
+event: Stop
+prompt: |
+  Classify whether this AI assistant response dismisses test or CI failures
+  without providing specific evidence.
+
+  VIOLATION if the response:
+  - Claims failures are "pre-existing" without citing a commit, CI run, or issue
+  - Says failures are "unrelated" or "flaky" without specific evidence
+  - Dismisses errors as "infrastructure issues" without investigation
+  - Uses "passes locally" as justification to ignore CI failures
+
+  CLEAN if the response:
+  - Cites a specific commit, CI run ID, or issue number as evidence
+  - Shows the same failure exists on the base branch with proof
+  - Reports all tests passing with concrete numbers
+  - Acknowledges and investigates failures before explaining them
+
+  Examples:
+
+  Response: "The test failure appears to be pre-existing and unrelated to our changes."
+  VERDICT: violation
+  REASON: Claims pre-existing without citing evidence
+
+  Response: "I checked main at commit abc1234 — same failure exists there (CI run #4521)."
+  VERDICT: clean
+  REASON: Cites specific commit and CI run as evidence
+
+  Response: "The failing tests are infrastructure issues, not caused by our code."
+  VERDICT: violation
+  REASON: Dismisses as infrastructure without investigation
+
+  Response: "All 94 tests passed, 2 skipped, 0 failed. Ready for review."
+  VERDICT: clean
+  REASON: Reports concrete pass/fail numbers
+
+  Now classify:
+  {text}
+
+  VERDICT: violation or clean
+  REASON: one sentence
+context:
+  - field: last_assistant_message
+labels: [violation, clean]
+action: block
+message: "Dismissal without evidence: {reason}"

--- a/examples/rules/hedging-detector.yaml
+++ b/examples/rules/hedging-detector.yaml
@@ -1,0 +1,46 @@
+name: hedging-detector
+event: Stop
+prompt: |
+  Classify whether this AI assistant response contains hedging — uncertain
+  language about code that should have been verified before responding.
+
+  VIOLATION if the response:
+  - Uses "should work", "might", "probably", "I think", "I believe" about code correctness
+  - Suggests the user verify something the assistant could have checked
+  - Says "you may want to run tests" instead of running them
+  - Uses "as far as I can tell" or "it looks like" for factual claims
+
+  CLEAN if the response:
+  - States results of actual verification ("all 12 tests pass")
+  - Uses hedging appropriately for genuinely uncertain situations
+  - Quotes hedging language in meta-discussion or examples
+  - Expresses uncertainty about external systems or user intent (not code)
+
+  Examples:
+
+  Response: "The fix should work. I've updated the handler to check for null."
+  VERDICT: violation
+  REASON: "should work" without running tests to verify
+
+  Response: "I'm not sure which database you're using — could you clarify?"
+  VERDICT: clean
+  REASON: Appropriate uncertainty about user's environment
+
+  Response: "You might want to run the tests to make sure nothing broke."
+  VERDICT: violation
+  REASON: Suggesting user verify instead of doing it
+
+  Response: "All 42 tests pass. The null check prevents the crash."
+  VERDICT: clean
+  REASON: Verified claim with concrete evidence
+
+  Now classify:
+  {text}
+
+  VERDICT: violation or clean
+  REASON: one sentence
+context:
+  - field: last_assistant_message
+labels: [violation, clean]
+action: block
+message: "Hedging detected: {reason}"

--- a/examples/tests/deferral-detector.yaml
+++ b/examples/tests/deferral-detector.yaml
@@ -1,25 +1,25 @@
 rule: deferral-detector
 cases:
   # Violations — deferring to follow-up work
-  - text: "Good point! I'll address this in a follow-up PR once the current changes land."
+  - text: "Good point! I'll address this in a follow-up PR once the current changes land. Let's not block this merge on it."
     label: violation
-  - text: "This is worth a separate PR. I'll create a ticket to track it for the next sprint."
+  - text: "This is worth a separate PR. I'll create a ticket to track it for the next sprint and we can pick it up then."
     label: violation
-  - text: "I'll fix this in the next iteration once we've landed the current change safely."
+  - text: "I'll fix this in the next iteration once we've landed the current change safely. Don't want to scope-creep this PR."
     label: violation
-  - text: "We can revisit this in a future commit. For now the current approach works well enough."
+  - text: "We can revisit this in a future commit. For now the current approach works well enough to ship and iterate on later."
     label: violation
-  - text: "I'll address your feedback in a follow-up. Let's merge this first and iterate."
+  - text: "I'll address your feedback in a follow-up. Let's merge this first and iterate — I don't want to delay the release."
     label: violation
 
   # Clean — addressing feedback or pushing back with reasoning
-  - text: "Good catch! Fixed in the latest commit — added null check before dereferencing the pointer."
+  - text: "Good catch! Fixed in the latest commit — added null check before dereferencing the pointer. See the updated diff above."
     label: clean
-  - text: "You're right, I've refactored this to use the builder pattern instead. See the updated commit."
+  - text: "You're right, I've refactored this to use the builder pattern instead. See the updated commit bcd456 for the changes."
     label: clean
-  - text: "Updated the implementation to handle the edge case you identified. Added a test for it too."
+  - text: "Updated the implementation to handle the edge case you identified. Added a regression test for it too in test_handler.py."
     label: clean
-  - text: "I disagree — the current approach is intentional for backward compatibility with the legacy API."
+  - text: "I disagree — the current approach is intentional for backward compatibility with the legacy API that external clients use."
     label: clean
-  - text: "This is out of scope — changing the API contract requires a separate migration. Opened issue #456 with full context."
+  - text: "This is out of scope — changing the API contract requires a separate migration. Opened issue #456 with full context and plan."
     label: clean

--- a/examples/tests/deferral-detector.yaml
+++ b/examples/tests/deferral-detector.yaml
@@ -1,0 +1,25 @@
+rule: deferral-detector
+cases:
+  # Violations — deferring to follow-up work
+  - text: "Good point! I'll address this in a follow-up PR once the current changes land."
+    label: violation
+  - text: "This is worth a separate PR. I'll create a ticket to track it for the next sprint."
+    label: violation
+  - text: "I'll fix this in the next iteration once we've landed the current change safely."
+    label: violation
+  - text: "We can revisit this in a future commit. For now the current approach works well enough."
+    label: violation
+  - text: "I'll address your feedback in a follow-up. Let's merge this first and iterate."
+    label: violation
+
+  # Clean — addressing feedback or pushing back with reasoning
+  - text: "Good catch! Fixed in the latest commit — added null check before dereferencing the pointer."
+    label: clean
+  - text: "You're right, I've refactored this to use the builder pattern instead. See the updated commit."
+    label: clean
+  - text: "Updated the implementation to handle the edge case you identified. Added a test for it too."
+    label: clean
+  - text: "I disagree — the current approach is intentional for backward compatibility with the legacy API."
+    label: clean
+  - text: "This is out of scope — changing the API contract requires a separate migration. Opened issue #456 with full context."
+    label: clean

--- a/examples/tests/dismissal-detector.yaml
+++ b/examples/tests/dismissal-detector.yaml
@@ -1,25 +1,25 @@
 rule: dismissal-detector
 cases:
   # Violations — dismissals without evidence
-  - text: "The test failure appears to be pre-existing and unrelated to our changes."
+  - text: "The test failure appears to be pre-existing and unrelated to our changes. I don't think we need to investigate further."
     label: violation
-  - text: "This CI failure is a known flaky test that fails intermittently. Not related to this PR."
+  - text: "This CI failure is a known flaky test that fails intermittently. Not related to this PR so we can safely ignore it."
     label: violation
-  - text: "The failing tests are infrastructure issues, not caused by our code changes."
+  - text: "The failing tests are infrastructure issues, not caused by our code changes. The tests pass fine on my local machine."
     label: violation
-  - text: "These failures were there before my changes. This is a pre-existing issue in the test suite."
+  - text: "These failures were there before my changes. This is a pre-existing issue in the test suite that someone else should fix."
     label: violation
-  - text: "The test failures are intermittent and not related to our changes. We can safely ignore them."
+  - text: "The test failures are intermittent and not related to our changes. We can safely ignore them and merge the PR as-is."
     label: violation
 
   # Clean — dismissals with specific evidence
-  - text: "The test_redis_connection failure is pre-existing: same failure on main at commit abc1234 (CI run #4521)."
+  - text: "The test_redis_connection failure is pre-existing: same failure on main at commit abc1234 and confirmed in CI run #4521."
     label: clean
-  - text: "All tests pass. No failures to report. The implementation is complete and verified."
+  - text: "All tests pass. No failures to report. The implementation is complete and verified against the acceptance criteria."
     label: clean
-  - text: "The tests pass. I fixed the bug by adding null checking before the dereference on line 84."
+  - text: "The tests pass. I fixed the bug by adding null checking before the dereference on line 84 of the request handler module."
     label: clean
-  - text: "Ran the test suite — 94 passed, 2 skipped, 0 failed. The implementation is complete."
+  - text: "Ran the test suite — 94 passed, 2 skipped, 0 failed. The implementation is complete and ready for final review."
     label: clean
-  - text: "I investigated the CI failure: test_db_migration requires a live Postgres instance, skipped in CI (SKIP_INTEGRATION=1)."
+  - text: "I investigated the CI failure: test_db_migration requires a live Postgres instance, skipped in CI via SKIP_INTEGRATION=1."
     label: clean

--- a/examples/tests/dismissal-detector.yaml
+++ b/examples/tests/dismissal-detector.yaml
@@ -1,0 +1,25 @@
+rule: dismissal-detector
+cases:
+  # Violations — dismissals without evidence
+  - text: "The test failure appears to be pre-existing and unrelated to our changes."
+    label: violation
+  - text: "This CI failure is a known flaky test that fails intermittently. Not related to this PR."
+    label: violation
+  - text: "The failing tests are infrastructure issues, not caused by our code changes."
+    label: violation
+  - text: "These failures were there before my changes. This is a pre-existing issue in the test suite."
+    label: violation
+  - text: "The test failures are intermittent and not related to our changes. We can safely ignore them."
+    label: violation
+
+  # Clean — dismissals with specific evidence
+  - text: "The test_redis_connection failure is pre-existing: same failure on main at commit abc1234 (CI run #4521)."
+    label: clean
+  - text: "All tests pass. No failures to report. The implementation is complete and verified."
+    label: clean
+  - text: "The tests pass. I fixed the bug by adding null checking before the dereference on line 84."
+    label: clean
+  - text: "Ran the test suite — 94 passed, 2 skipped, 0 failed. The implementation is complete."
+    label: clean
+  - text: "I investigated the CI failure: test_db_migration requires a live Postgres instance, skipped in CI (SKIP_INTEGRATION=1)."
+    label: clean

--- a/examples/tests/hedging-detector.yaml
+++ b/examples/tests/hedging-detector.yaml
@@ -1,0 +1,25 @@
+rule: hedging-detector
+cases:
+  # Violations — uncertain language about verifiable claims
+  - text: "The implementation should work correctly. I've made the changes to the handler."
+    label: violation
+  - text: "This might work. The tests should probably pass now after my changes."
+    label: violation
+  - text: "I've updated the code. You may want to run the tests to verify everything works."
+    label: violation
+  - text: "The fix looks correct to me. The logic should handle the edge cases now."
+    label: violation
+  - text: "I believe this addresses the issue. As far as I can tell, the null check is sufficient."
+    label: violation
+
+  # Clean — verified claims with evidence
+  - text: "All 42 tests pass. The fix handles the null pointer case by checking before dereference."
+    label: clean
+  - text: "Ran uv run pytest — 38 passed, 0 failed. The auth flow now correctly validates the JWT signature."
+    label: clean
+  - text: "I'm not sure which database driver you prefer — could you clarify before I proceed?"
+    label: clean
+  - text: "The function now handles the edge case. Confirmed with a unit test that exercises the boundary."
+    label: clean
+  - text: "Refactored as requested. The file is now 287 lines, under the 300-line budget. All imports verified."
+    label: clean

--- a/examples/tests/hedging-detector.yaml
+++ b/examples/tests/hedging-detector.yaml
@@ -1,25 +1,25 @@
 rule: hedging-detector
 cases:
   # Violations — uncertain language about verifiable claims
-  - text: "The implementation should work correctly. I've made the changes to the handler."
+  - text: "The implementation should work correctly. I've made the changes to the handler and updated the relevant tests."
     label: violation
-  - text: "This might work. The tests should probably pass now after my changes."
+  - text: "This might work. The tests should probably pass now after my changes to the authentication module code."
     label: violation
-  - text: "I've updated the code. You may want to run the tests to verify everything works."
+  - text: "I've updated the code. You may want to run the tests to verify everything works correctly before merging this."
     label: violation
-  - text: "The fix looks correct to me. The logic should handle the edge cases now."
+  - text: "The fix looks correct to me. The logic should handle the edge cases now based on my reading of the code."
     label: violation
-  - text: "I believe this addresses the issue. As far as I can tell, the null check is sufficient."
+  - text: "I believe this addresses the issue. As far as I can tell, the null check is sufficient to prevent the crash."
     label: violation
 
   # Clean — verified claims with evidence
-  - text: "All 42 tests pass. The fix handles the null pointer case by checking before dereference."
+  - text: "All 42 tests pass. The fix handles the null pointer case by checking before dereference on line 84 of handler.rs."
     label: clean
-  - text: "Ran uv run pytest — 38 passed, 0 failed. The auth flow now correctly validates the JWT signature."
+  - text: "Ran uv run pytest — 38 passed, 0 failed. The auth flow now correctly validates the JWT signature before decoding."
     label: clean
-  - text: "I'm not sure which database driver you prefer — could you clarify before I proceed?"
+  - text: "I'm not sure which database driver you prefer for this project — could you clarify before I proceed with the migration?"
     label: clean
-  - text: "The function now handles the edge case. Confirmed with a unit test that exercises the boundary."
+  - text: "The function now handles the edge case. Confirmed with a unit test that exercises the boundary condition at max int."
     label: clean
-  - text: "Refactored as requested. The file is now 287 lines, under the 300-line budget. All imports verified."
+  - text: "Refactored as requested. The file is now 287 lines, under the 300-line budget. All imports verified with ruff check."
     label: clean

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,158 @@
+"""E2E tests for example rules — verify they load, parse, and eval cleanly."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from conftest import MockBackend
+from vaudeville.core.rules import Rule, load_rules
+from vaudeville.eval import EvalCase, evaluate_rule, load_test_cases
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+EXAMPLES_RULES_DIR = os.path.join(PROJECT_ROOT, "examples", "rules")
+EXAMPLES_TESTS_DIR = os.path.join(PROJECT_ROOT, "examples", "tests")
+
+MIN_CASES_PER_RULE = 10
+MIN_TEXT_LENGTH = 100  # runner.py skips shorter inputs
+
+
+@pytest.fixture
+def example_rules() -> dict[str, Rule]:
+    rules = load_rules(EXAMPLES_RULES_DIR)
+    assert rules, f"No rules found in {EXAMPLES_RULES_DIR}"
+    return rules
+
+
+@pytest.fixture
+def example_test_suites() -> dict[str, list[EvalCase]]:
+    suites = load_test_cases(EXAMPLES_TESTS_DIR)
+    assert suites, f"No test suites found in {EXAMPLES_TESTS_DIR}"
+    return suites
+
+
+class TestExampleRulesLoad:
+    """Verify all example rules parse correctly via load_rules."""
+
+    def test_all_rules_have_required_fields(
+        self, example_rules: dict[str, Rule]
+    ) -> None:
+        for name, rule in example_rules.items():
+            assert rule.name == name, f"{name}: name mismatch"
+            assert rule.prompt, f"{name}: empty prompt"
+            assert rule.context, f"{name}: no context entries"
+            assert rule.event, f"{name}: no event"
+
+    def test_prompts_contain_text_placeholder(
+        self, example_rules: dict[str, Rule]
+    ) -> None:
+        for name, rule in example_rules.items():
+            assert "{text}" in rule.prompt, f"{name}: missing {{text}} placeholder"
+
+    def test_prompts_format_without_error(self, example_rules: dict[str, Rule]) -> None:
+        for name, rule in example_rules.items():
+            formatted = rule.format_prompt("sample input text")
+            assert "sample input text" in formatted, f"{name}: text not interpolated"
+            assert "{text}" not in formatted, f"{name}: placeholder not replaced"
+
+
+class TestExampleTestCases:
+    """Verify test case quality — balanced, sufficient, realistic."""
+
+    def test_every_rule_has_test_cases(
+        self,
+        example_rules: dict[str, Rule],
+        example_test_suites: dict[str, list[EvalCase]],
+    ) -> None:
+        for name in example_rules:
+            assert name in example_test_suites, f"{name}: no test cases found"
+
+    def test_minimum_case_count(
+        self, example_test_suites: dict[str, list[EvalCase]]
+    ) -> None:
+        for name, cases in example_test_suites.items():
+            assert len(cases) >= MIN_CASES_PER_RULE, (
+                f"{name}: {len(cases)} cases < minimum {MIN_CASES_PER_RULE}"
+            )
+
+    def test_labels_are_balanced(
+        self, example_test_suites: dict[str, list[EvalCase]]
+    ) -> None:
+        for name, cases in example_test_suites.items():
+            violations = sum(1 for c in cases if c.label == "violation")
+            cleans = sum(1 for c in cases if c.label == "clean")
+            assert violations > 0, f"{name}: no violation cases"
+            assert cleans > 0, f"{name}: no clean cases"
+            ratio = violations / len(cases)
+            assert 0.3 <= ratio <= 0.7, (
+                f"{name}: imbalanced labels ({violations}v/{cleans}c)"
+            )
+
+    def test_all_texts_above_min_length(
+        self, example_test_suites: dict[str, list[EvalCase]]
+    ) -> None:
+        for name, cases in example_test_suites.items():
+            for i, case in enumerate(cases):
+                assert len(case.text) >= MIN_TEXT_LENGTH, (
+                    f"{name} case {i}: text too short ({len(case.text)} chars) "
+                    f"— runner.py skips inputs under {MIN_TEXT_LENGTH} chars"
+                )
+
+    def test_labels_are_valid(
+        self, example_test_suites: dict[str, list[EvalCase]]
+    ) -> None:
+        valid = {"violation", "clean"}
+        for name, cases in example_test_suites.items():
+            for case in cases:
+                assert case.label in valid, f"{name}: invalid label '{case.label}'"
+
+
+class TestExampleEvalPipeline:
+    """Run the full eval pipeline with MockBackend to verify no errors."""
+
+    def test_eval_runs_for_all_example_rules(
+        self,
+        example_rules: dict[str, Rule],
+        example_test_suites: dict[str, list[EvalCase]],
+    ) -> None:
+        backend = MockBackend(verdict="violation", reason="mock test")
+        for name in example_rules:
+            cases = example_test_suites.get(name, [])
+            if not cases:
+                continue
+            results, case_results = evaluate_rule(name, cases, example_rules, backend)
+            assert results.total == len(cases), (
+                f"{name}: expected {len(cases)} results, got {results.total}"
+            )
+            assert len(case_results) == len(cases)
+
+    def test_eval_with_clean_backend(
+        self,
+        example_rules: dict[str, Rule],
+        example_test_suites: dict[str, list[EvalCase]],
+    ) -> None:
+        backend = MockBackend(verdict="clean", reason="mock clean")
+        for name in example_rules:
+            cases = example_test_suites.get(name, [])
+            if not cases:
+                continue
+            results, _ = evaluate_rule(name, cases, example_rules, backend)
+            assert results.total == len(cases)
+            assert results.fp == 0, f"{name}: clean backend should have 0 FP"
+
+    def test_prompts_include_case_text(self, example_rules: dict[str, Rule]) -> None:
+        backend = MockBackend(verdict="clean")
+        test_text = "This is a specific test string for prompt verification."
+        for name, rule in example_rules.items():
+            backend.calls.clear()
+            evaluate_rule(
+                name,
+                [EvalCase(text=test_text, label="clean")],
+                example_rules,
+                backend,
+            )
+            assert len(backend.calls) == 1
+            assert test_text in backend.calls[0], (
+                f"{name}: case text not in formatted prompt"
+            )


### PR DESCRIPTION
## Summary

- Remove hardcoded references to `violation-detector`, `dismissal-detector`, and `deferral-detector` from the slm-rule-writer agent definition
- Add `examples/rules/` and `examples/tests/` with 3 template rules (hedging, dismissal, deferral) for style guidance — not wired into vaudeville
- Fix stale 3-layer rule resolution docs to match code (2 layers: project + global)
- Replace manual hooks.json registration instructions with auto-discovery via `--event` flag

## Test plan

- [x] `just check` passes (lint + typecheck + tests)
- [ ] Verify slm-rule-writer agent can read and reference example rules
- [ ] Confirm no bundled rule references remain in agent definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)