### PR TITLE
feat: v0.1.0 release prep — distribution boilerplate + false positive reduction

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "paulnsorensen",
+  "owner": { "name": "Paul Sorensen" },
+  "plugins": [
+    {
+      "name": "vaudeville",
+      "source": "./",
+      "description": "SLM-powered semantic hook enforcement — classifies AI output against YAML rules using local Phi-4-mini inference",
+      "category": "development",
+      "tags": ["hooks", "enforcement", "slm", "quality-gates"]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
 
 permissions:
-  contents: read
+  contents: write
 
 env:
   UV_PYTHON: "3.12"
@@ -59,3 +60,25 @@ jobs:
 
       - name: Run tests
         run: uv run pytest
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - run: uv python install
+
+      - name: Build wheel
+        run: uv build
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ github.ref_name }}" dist/* --generate-notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   UV_PYTHON: "3.12"
@@ -65,6 +65,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [lint, test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [0.1.0] - 2026-04-11
+
+### Added
+- SLM-powered semantic hook enforcement for Claude Code
+- MLX backend (Apple Silicon) and GGUF backend (x86_64/Linux)
+- YAML rule format with few-shot prompt templates
+- Fail-open design — daemon down or inference error never blocks sessions
+- Eval harness with leave-one-out cross-validation
+- 25 Claude Code hook events supported
+- Back-truncation and prompt injection defenses

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Paul Sorensen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# Vaudeville
+
+SLM-powered semantic hook enforcement for [Claude Code](https://claude.ai/code). Classifies AI assistant output against YAML rules using local Phi-4-mini inference.
+
+## How It Works
+
+Vaudeville runs a local inference daemon (Phi-4-mini, 3.8B params, int4) that classifies Claude Code's output in real time. You write rules as YAML files with few-shot prompt templates. The daemon evaluates them on every hook event and returns block/warn/log verdicts.
+
+**Fail-open by design** — if the daemon is down, the model isn't downloaded, or inference errors out, your session continues normally. Vaudeville never blocks you from working.
+
+## Install
+
+```
+/plugin install vaudeville@paulnsorensen
+```
+
+Then run the one-time setup to download the model (~2.4 GB):
+
+```
+/vaudeville:setup
+```
+
+This detects your platform (Apple Silicon or x86_64) and downloads the appropriate model variant.
+
+## Quick Start
+
+1. Copy example rules to your global rules directory:
+   ```bash
+   cp ~/.claude/plugins/cache/paulnsorensen/vaudeville/*/examples/rules/*.yaml ~/.vaudeville/rules/
+   ```
+
+2. Start a new Claude Code session — the daemon launches automatically.
+
+3. Rules fire on their configured hook events. Violations block, warn, or log depending on rule config.
+
+## Rules
+
+Rules live in `~/.vaudeville/rules/` (global) or `.vaudeville/rules/` (per-project, higher priority).
+
+See [`examples/`](examples/) for starter rules and the YAML format reference.
+
+## Requirements
+
+- Python 3.11+
+- [uv](https://docs.astral.sh/uv/) (Python package manager)
+- ~4 GB disk for the model
+- Apple Silicon (MLX backend) or x86_64 (GGUF backend)
+
+## Development
+
+```bash
+just install    # install dependencies
+just check      # lint + format + typecheck
+just test       # run tests
+just eval       # evaluate rules against test cases
+```
+
+## License
+
+[MIT](LICENSE)

--- a/agents/slm-rule-writer.md
+++ b/agents/slm-rule-writer.md
@@ -94,6 +94,7 @@ context:                        # How to extract text from hook input
 labels: [violation, clean]      # Valid verdict labels (always exactly 2)
 action: block                   # What to do on violation: block, warn, or log
 message: "Quality violation: {reason}"  # Template with {reason} placeholder
+threshold: 0.5                  # Minimum confidence (0.0–1.0) to trigger action
 ```
 
 ### Required Fields
@@ -112,6 +113,7 @@ message: "Quality violation: {reason}"  # Template with {reason} placeholder
 | `event` | (none) | Hook event — informational, used by `hooks.json` |
 | `action` | `block` | `block` = prevent, `warn` = allow + inject warning, `log` = stderr only |
 | `message` | `{reason}` | User-facing message template, `{reason}` replaced by SLM output |
+| `threshold` | `0.5` | Minimum confidence (0.0–1.0) to trigger action. Use `just eval --threshold-sweep` to find optimal value. |
 
 ### Context Field Paths
 
@@ -235,6 +237,7 @@ Ask: "What behavior am I trying to detect?" Write it as a one-sentence task.
 ### 2. Write the rule YAML
 
 Create `rules/<name>.yaml`. Start with 4 examples in the prompt (2 violation, 2 clean).
+Always include `threshold: 0.5` — rules without a threshold default to 0.5 but being explicit is clearer.
 
 ### 3. Write test cases
 
@@ -252,11 +255,17 @@ Target: **>90% accuracy**. If low:
 - Check for ambiguous test cases
 - Ensure labels are consistent
 
-### 5. Register in hooks.json
+### 5. Tune the threshold
+
+Run `uv run python -m vaudeville.eval --threshold-sweep` to find the optimal
+confidence threshold for your rule. Set `threshold:` in the rule YAML to the
+best value that maintains ≥95% precision.
+
+### 6. Register in hooks.json
 
 Add the rule name to the appropriate runner command in `hooks/hooks.json`.
 
-### 6. Test end-to-end
+### 7. Test end-to-end
 
 Verify: daemon running → hook fires → rule classifies → action triggers.
 
@@ -268,7 +277,7 @@ Read these in `rules/` for style guidance:
 |------|-------|---------|
 | `violation-detector` | Stop | Hedging, deferrals, unresolved findings |
 | `dismissal-detector` | Stop | Dismissing test/CI failures without evidence |
-| `deferral-detector` | PostToolUse | "Follow-up PR" language in PR replies |
+| `deferral-detector` | PreToolUse | "Follow-up PR" language in PR replies |
 
 ## Gotchas
 
@@ -287,10 +296,11 @@ Read these in `rules/` for style guidance:
 ## Deliverables
 
 For each rule created, deliver:
-1. Rule YAML in `rules/`
+1. Rule YAML in `rules/` (with explicit `threshold:` set)
 2. Test cases in `tests/` (minimum 10 cases, balanced labels)
 3. Updated `hooks/hooks.json` registration
 4. Eval results showing >90% accuracy
+5. Threshold sweep results justifying the chosen threshold
 
 ## What This Agent Does NOT Do
 

--- a/agents/slm-rule-writer.md
+++ b/agents/slm-rule-writer.md
@@ -257,7 +257,7 @@ For each rule created, deliver:
 1. Rule YAML in the target rules directory (with `event:` and `threshold:` fields set)
 2. Test cases YAML (minimum 10 cases, balanced labels)
 3. Eval results showing >90% accuracy
-5. Threshold sweep results justifying the chosen threshold
+4. Threshold sweep results justifying the chosen threshold
 
 ## What This Agent Does NOT Do
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,61 @@
+# Example Rules
+
+Starter rules for vaudeville. These are **not active by default** — copy them to a rules directory to enable.
+
+## Activating Rules
+
+**Global** (all projects):
+```bash
+cp examples/rules/*.yaml ~/.vaudeville/rules/
+```
+
+**Per-project** (overrides global):
+```bash
+mkdir -p .vaudeville/rules/
+cp examples/rules/*.yaml .vaudeville/rules/
+```
+
+## Included Rules
+
+| Rule | Event | What it catches |
+|------|-------|-----------------|
+| `violation-detector` | Stop | Hedging, incomplete work, unresolved review findings |
+| `dismissal-detector` | Stop | Dismissing test/CI failures without evidence |
+| `deferral-detector` | PostToolUse | Deferring reviewer concerns to follow-up PRs |
+
+## Rule Format
+
+```yaml
+name: my-rule              # unique identifier
+event: Stop                # Claude Code hook event to trigger on
+prompt: |                  # few-shot classification prompt
+  Classify as "violation" or "clean".
+  ...
+  {text}                   # placeholder — replaced with hook input
+context:
+  - field: last_assistant_message   # JSON path into hook input
+labels: [violation, clean]          # valid classification labels
+action: block                       # block, warn, or log
+message: "Reason: {reason}"         # verdict message template
+```
+
+### Context sources
+
+Rules extract text to classify from hook input via `context` entries:
+
+- `field: <json.path>` — dot-notation path into the hook JSON (e.g., `last_assistant_message`, `tool_input.body`)
+- `file: <path>` — read from disk (relative paths resolve from plugin root)
+
+### Actions
+
+- `block` — reject the response, force retry
+- `warn` — show warning, allow to continue
+- `log` — record silently
+
+## Writing Your Own
+
+1. Copy an example rule as a starting point
+2. Edit the `prompt` with your classification criteria and few-shot examples
+3. Set the `event` to the hook point you want (Stop, PostToolUse, UserPromptSubmit, etc.)
+4. Set `context` to extract the right text from the hook input
+5. Test with `just eval-rule <rule-name>` (requires test cases in `tests/<rule-name>.yaml`)

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,7 +21,7 @@ cp examples/rules/*.yaml .vaudeville/rules/
 |------|-------|-----------------|
 | `violation-detector` | Stop | Hedging, incomplete work, unresolved review findings |
 | `dismissal-detector` | Stop | Dismissing test/CI failures without evidence |
-| `deferral-detector` | PostToolUse | Deferring reviewer concerns to follow-up PRs |
+| `deferral-detector` | PreToolUse | Deferring reviewer concerns to follow-up PRs |
 
 ## Rule Format
 
@@ -37,6 +37,7 @@ context:
 labels: [violation, clean]          # valid classification labels
 action: block                       # block, warn, or log
 message: "Reason: {reason}"         # verdict message template
+threshold: 0.5                      # minimum confidence to trigger (0.0-1.0)
 ```
 
 ### Context sources
@@ -58,4 +59,5 @@ Rules extract text to classify from hook input via `context` entries:
 2. Edit the `prompt` with your classification criteria and few-shot examples
 3. Set the `event` to the hook point you want (Stop, PostToolUse, UserPromptSubmit, etc.)
 4. Set `context` to extract the right text from the hook input
-5. Test with `just eval-rule <rule-name>` (requires test cases in `tests/<rule-name>.yaml`)
+5. Set `threshold` — start at 0.5, tune with `just eval --threshold-sweep`
+6. Test with `just eval-rule <rule-name>` (requires test cases in `tests/<rule-name>.yaml`)

--- a/examples/rules/deferral-detector.yaml
+++ b/examples/rules/deferral-detector.yaml
@@ -1,5 +1,5 @@
 name: deferral-detector
-event: PostToolUse
+event: PreToolUse
 prompt: |
   Does this PR reply defer the reviewer's concern to future work? Answer "violation" or "clean".
 
@@ -44,3 +44,4 @@ context:
 labels: [violation, clean]
 action: block
 message: "Deferral detected in PR reply: {reason}"
+threshold: 0.7

--- a/examples/rules/deferral-detector.yaml
+++ b/examples/rules/deferral-detector.yaml
@@ -1,0 +1,46 @@
+name: deferral-detector
+event: PostToolUse
+prompt: |
+  Does this PR reply defer the reviewer's concern to future work? Answer "violation" or "clean".
+
+  Examples:
+
+  Reply: "Good point! I'll address this in a follow-up PR."
+  VERDICT: violation
+  REASON: Defers to follow-up PR
+
+  Reply: "Good catch! Fixed in the latest commit — added null check before dereferencing."
+  VERDICT: clean
+  REASON: Describes fix already applied
+
+  Reply: "Will handle in a separate commit. The current PR is already large enough."
+  VERDICT: violation
+  REASON: Defers to separate commit
+
+  Reply: "I disagree — the current approach is intentional. We need backward compatibility."
+  VERDICT: clean
+  REASON: Pushes back with technical reasoning
+
+  Reply: "I'll circle back to this. For now this is good enough to ship."
+  VERDICT: violation
+  REASON: Defers with "circle back" language
+
+  Reply: "Good point about the N+1 query. I've added eager loading for the relationship."
+  VERDICT: clean
+  REASON: Describes fix already applied
+
+  Reply: "The test coverage looks thin but these code paths are covered by integration tests."
+  VERDICT: clean
+  REASON: Explains existing coverage, not deferring
+
+  Now classify this reply:
+  {text}
+
+  Respond in EXACTLY this format:
+  VERDICT: violation or clean
+  REASON: one sentence
+context:
+  - field: tool_input.body
+labels: [violation, clean]
+action: block
+message: "Deferral detected in PR reply: {reason}"

--- a/examples/rules/dismissal-detector.yaml
+++ b/examples/rules/dismissal-detector.yaml
@@ -74,3 +74,4 @@ context:
 labels: [violation, clean]
 action: block
 message: "Failure dismissed without evidence: {reason}"
+threshold: 0.7

--- a/examples/rules/dismissal-detector.yaml
+++ b/examples/rules/dismissal-detector.yaml
@@ -1,0 +1,76 @@
+name: dismissal-detector
+event: Stop
+prompt: |
+  Does this response dismiss a test/CI failure without evidence? Answer "violation" or "clean".
+
+  IMPORTANT: If the response does NOT talk about any test failure, CI error, or broken test, the answer is ALWAYS "clean". Only responses that dismiss failures are violations.
+
+  Examples:
+
+  Response: "The test failure appears to be pre-existing and unrelated to our changes."
+  VERDICT: violation
+  REASON: Dismisses as pre-existing without evidence
+
+  Response: "I checked the base branch: the test_auth_timeout failure is present there too. FAILED tests/test_auth.py."
+  VERDICT: clean
+  REASON: Provides base branch evidence with specific test output
+
+  Response: "These failures were there before my changes."
+  VERDICT: violation
+  REASON: Claims pre-existing without proof
+
+  Response: "test_flaky_network has been failing since issue #891. Verified with run ID 45821."
+  VERDICT: clean
+  REASON: Cites issue number and run ID
+
+  Response: "The broken tests are unrelated to the feature I implemented."
+  VERDICT: violation
+  REASON: Claims unrelated without evidence
+
+  Response: "All tests pass. No failures to report."
+  VERDICT: clean
+  REASON: No failures discussed, nothing dismissed
+
+  Response: "This is a runner issue, not a code issue. The tests pass locally."
+  VERDICT: violation
+  REASON: Blames infrastructure without evidence
+
+  Response: "Fixed the edge case. Tests pass."
+  VERDICT: clean
+  REASON: Reports fix and passing tests
+
+  Response: "The failing tests are infrastructure issues, not caused by our code changes."
+  VERDICT: violation
+  REASON: Blames infrastructure without citing evidence
+
+  Response: "Ran the test suite — 94 passed, 2 skipped, 0 failed."
+  VERDICT: clean
+  REASON: Reports passing tests, no dismissal
+
+  Response: "The test failures are intermittent and not related to our changes."
+  VERDICT: violation
+  REASON: Dismisses as intermittent without evidence
+
+  Response: "The test_redis_connection failure is pre-existing: I ran the same test suite on main at commit abc1234 and got the same failure."
+  VERDICT: clean
+  REASON: Provides specific commit and base branch verification
+
+  Response: "These appear to be pre-existing failures on the main branch."
+  VERDICT: violation
+  REASON: Claims pre-existing without showing proof
+
+  Response: "This CI failure is a known flaky test. Not related to this PR."
+  VERDICT: violation
+  REASON: Claims flaky without citing issue number
+
+  Now classify:
+  {text}
+
+  Respond in EXACTLY this format:
+  VERDICT: violation or clean
+  REASON: one sentence
+context:
+  - field: last_assistant_message
+labels: [violation, clean]
+action: block
+message: "Failure dismissed without evidence: {reason}"

--- a/examples/rules/violation-detector.yaml
+++ b/examples/rules/violation-detector.yaml
@@ -1,0 +1,86 @@
+name: violation-detector
+event: Stop
+prompt: |
+  Classify the AI assistant response as "violation" or "clean".
+
+  VIOLATION if the response contains ANY of:
+  - Words like "should work", "might", "probably", "could" about untested code
+  - "TODO", "will do later", "as a starting point", "for now"
+  - A "Score:" or "confidence:" line reporting a problem (these are unresolved review findings)
+  - A table row with "FAIL" in it (scorecard failure)
+  - Tests failing or red without investigation
+  - Telling the user to verify something the assistant should have done
+
+  CLEAN if the response:
+  - Reports passing tests with specific numbers
+  - Describes completed work with specifics (file names, line counts, commit refs)
+  - Has scorecard rows that all say "PASS"
+  - Says "All checks passed" or "Fixed all violations"
+  - States that implementation matches requirements (factual claim, not hedging)
+  - Quotes or references violation phrases in order to explain, teach, or refuse them (meta-discussion about anti-patterns is not an anti-pattern)
+
+  Examples:
+
+  Response: "Score: 90 — The codebase_service clones the full Arc on every call."
+  VERDICT: violation
+  REASON: Score line reports unresolved finding
+
+  Response: "All 42 tests pass. The fix handles the null pointer case."
+  VERDICT: clean
+  REASON: Specific test count and concrete fix
+
+  Response: "confidence: 85 — Unused import detected in handler.rs."
+  VERDICT: violation
+  REASON: Confidence line reports unresolved finding
+
+  Response: "| 1 | Sycophancy | PASS | No issues |"
+  VERDICT: clean
+  REASON: Scorecard with PASS status
+
+  Response: "confidence: 91 — Dead code path detected in handle_response, unreachable after refactor."
+  VERDICT: violation
+  REASON: Confidence line reports unresolved dead code
+
+  Response: "All checks passed. Clean. Ready to ship."
+  VERDICT: clean
+  REASON: Reports all checks passing
+
+  Response: "| 2 | Premature complete | FAIL | Left TODO on line 42 |"
+  VERDICT: violation
+  REASON: Scorecard row shows FAIL
+
+  Response: "The implementation looks correct and matches the spec requirements."
+  VERDICT: clean
+  REASON: States factual assessment of correctness
+
+  Response: "This might work. The tests should probably pass now."
+  VERDICT: violation
+  REASON: Uses "might" and "probably" without running tests
+
+  Response: "Refactored as requested. The file is now 287 lines, under the 300-line budget."
+  VERDICT: clean
+  REASON: Concrete action with measurements
+
+  Response: "The tests are red but that might be a pre-existing issue unrelated to our change."
+  VERDICT: violation
+  REASON: Tests failing and dismissing without fixing
+
+  Response: "I refused because your checklist says not to use phrases like 'this should work' or defer to follow-up PRs."
+  VERDICT: clean
+  REASON: Quoting anti-pattern phrases in meta-discussion
+
+  Response: "The fix looks correct to me. The logic should handle the edge cases now."
+  VERDICT: violation
+  REASON: Uses "should handle" without verification
+
+  Now classify:
+  {text}
+
+  Respond in EXACTLY this format:
+  VERDICT: violation or clean
+  REASON: one sentence
+context:
+  - field: last_assistant_message
+labels: [violation, clean]
+action: block
+message: "Quality violation: {reason}"

--- a/examples/rules/violation-detector.yaml
+++ b/examples/rules/violation-detector.yaml
@@ -84,3 +84,4 @@ context:
 labels: [violation, clean]
 action: block
 message: "Quality violation: {reason}"
+threshold: 0.7

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,11 +44,12 @@ class TestParseVerdict:
         result = parse_verdict("verdict: VIOLATION\nreason: test")
         assert result.verdict == "violation"
 
-    def test_fallback_keyword_scan(self) -> None:
+    def test_no_verdict_header_defaults_to_clean(self) -> None:
+        """Without VERDICT: header, always default to clean (fail-open)."""
         result = parse_verdict("This response contains a violation of the rules.")
-        assert result.verdict == "violation"
+        assert result.verdict == "clean"
 
-    def test_fallback_clean_on_no_keyword(self) -> None:
+    def test_no_verdict_header_clean_text(self) -> None:
         result = parse_verdict("Everything looks good here.")
         assert result.verdict == "clean"
 
@@ -82,14 +83,15 @@ class TestParseVerdict:
         rule = parse_rule({"name": "test", "prompt": "{text}"})
         assert rule.name == "test"
         assert rule.action == "block"
+        assert rule.threshold == 0.5
 
     def test_violation_keyword_word_boundary(self) -> None:
         """'violation' substring should not create false positives."""
         result = parse_verdict("VERDICT: clean\nREASON: no violations found")
         assert result.verdict == "clean"
 
-    def test_violation_plural_in_fallback_does_not_match(self) -> None:
-        """Fallback scan uses \\bviolation\\b — 'violations' (plural) does not match."""
+    def test_no_header_with_violation_word_defaults_clean(self) -> None:
+        """Without VERDICT: header, even text containing 'violations' defaults to clean."""
         result = parse_verdict("Multiple violations were detected in the response.")
         assert result.verdict == "clean"
 
@@ -408,12 +410,12 @@ class TestComputeConfidence:
         conf = compute_confidence(logprobs, "clean")
         assert conf > 0.9
 
-    def test_empty_logprobs_returns_one(self) -> None:
-        assert compute_confidence({}, "violation") == 1.0
+    def test_empty_logprobs_returns_zero(self) -> None:
+        assert compute_confidence({}, "violation") == 0.0
 
-    def test_no_matching_tokens_returns_one(self) -> None:
+    def test_no_matching_tokens_returns_zero(self) -> None:
         logprobs = {"hello": -1.0, "world": -2.0}
-        assert compute_confidence(logprobs, "violation") == 1.0
+        assert compute_confidence(logprobs, "violation") == 0.0
 
     def test_prefix_matching(self) -> None:
         logprobs = {"v": -0.5, "c": -1.5}

--- a/tests/test_core_rules.py
+++ b/tests/test_core_rules.py
@@ -109,9 +109,9 @@ class TestParseRule:
         rule = parse_rule(self._minimal_data())
         assert rule.action == "block"
 
-    def test_defaults_threshold_to_zero(self) -> None:
+    def test_defaults_threshold_to_half(self) -> None:
         rule = parse_rule(self._minimal_data())
-        assert rule.threshold == 0.0
+        assert rule.threshold == 0.5
 
     def test_custom_action_preserved(self) -> None:
         rule = parse_rule(self._minimal_data(action="warn"))

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -504,3 +504,50 @@ class TestGGUFImportSmoke:
         assert hasattr(Llama, "create_chat_completion"), (
             "Llama lost create_chat_completion method"
         )
+
+    def test_classify_with_logprobs_sends_verdict_prefill(self) -> None:
+        """classify_with_logprobs must send assistant prefill and return VERDICT: prefix."""
+        from unittest.mock import MagicMock, patch
+
+        fake_response = {
+            "choices": [
+                {
+                    "message": {"content": " clean"},
+                    "logprobs": {
+                        "content": [
+                            {
+                                "top_logprobs": [
+                                    {"token": "clean", "logprob": -0.1},
+                                    {"token": "violation", "logprob": -3.0},
+                                ]
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+        mock_llm = MagicMock()
+        mock_llm.create_chat_completion.return_value = fake_response
+
+        with patch(
+            "vaudeville.server.gguf_backend.GGUFBackend.__init__", return_value=None
+        ):
+            from vaudeville.server.gguf_backend import GGUFBackend
+
+            backend = GGUFBackend.__new__(GGUFBackend)
+            backend._llm = mock_llm
+
+            result = backend.classify_with_logprobs("test prompt")
+
+        # Text must start with VERDICT: prefix
+        assert result.text.startswith("VERDICT:"), (
+            f"Expected 'VERDICT:' prefix, got: {result.text!r}"
+        )
+        # Logprobs must come from position 0 only
+        assert "clean" in result.logprobs
+        assert result.logprobs["clean"] == -0.1
+        # Request must include assistant prefill message
+        call_messages = mock_llm.create_chat_completion.call_args[1]["messages"]
+        assert call_messages[-1] == {"role": "assistant", "content": "VERDICT:"}, (
+            "Last message must be assistant prefill with 'VERDICT:'"
+        )

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -366,7 +366,7 @@ class TestConfidenceScoring:
         data = json.dumps({"prompt": "test"}).encode() + b"\n"
         response = json.loads(handle_request(data, PlainBackend()))
         assert response["verdict"] == "clean"
-        assert response["confidence"] == 1.0
+        assert response["confidence"] == 0.0
 
 
 class TestDetectBackend:

--- a/tests/test_query_helpers.py
+++ b/tests/test_query_helpers.py
@@ -6,6 +6,9 @@ import importlib.util
 import json
 import os
 import sys
+import types
+from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -26,13 +29,13 @@ if _QUERIES_DIR not in sys.path:
     sys.path.insert(0, _QUERIES_DIR)
 
 
-def _load(name: str):
+def _load(name: str) -> types.ModuleType:
     path = os.path.join(_QUERIES_DIR, f"{name}.py")
     spec = importlib.util.spec_from_file_location(name, path)
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
     sys.modules[name] = mod
-    spec.loader.exec_module(mod)  # type: ignore[attr-defined]
+    spec.loader.exec_module(mod)
     return mod
 
 
@@ -45,7 +48,7 @@ tool_misuse = _load("tool_misuse")
 hook_stats = _load("hook_stats")
 
 
-def _mock_result(stdout: str = "", returncode: int = 0, stderr: str = ""):
+def _mock_result(stdout: str = "", returncode: int = 0, stderr: str = "") -> object:
     return type(
         "R", (), {"returncode": returncode, "stdout": stdout, "stderr": stderr}
     )()
@@ -55,13 +58,13 @@ def _mock_result(stdout: str = "", returncode: int = 0, stderr: str = ""):
 
 
 class TestDbQuery:
-    def test_db_not_found_exits(self, tmp_path) -> None:
+    def test_db_not_found_exits(self, tmp_path: Path) -> None:
         with patch.object(_db, "DB_PATH", str(tmp_path / "missing.duckdb")):
             with pytest.raises(SystemExit) as exc:
                 _db.query("SELECT 1")
             assert exc.value.code == 1
 
-    def test_duckdb_binary_not_found_exits(self, tmp_path) -> None:
+    def test_duckdb_binary_not_found_exits(self, tmp_path: Path) -> None:
         db = tmp_path / "test.duckdb"
         db.touch()
         with patch.object(_db, "DB_PATH", str(db)):
@@ -70,7 +73,7 @@ class TestDbQuery:
                     _db.query("SELECT 1")
                 assert exc.value.code == 1
 
-    def test_nonzero_returncode_returns_empty(self, tmp_path) -> None:
+    def test_nonzero_returncode_returns_empty(self, tmp_path: Path) -> None:
         db = tmp_path / "test.duckdb"
         db.touch()
         with patch.object(_db, "DB_PATH", str(db)):
@@ -79,28 +82,28 @@ class TestDbQuery:
             ):
                 assert _db.query("SELECT 1") == []
 
-    def test_empty_stdout_returns_empty(self, tmp_path) -> None:
+    def test_empty_stdout_returns_empty(self, tmp_path: Path) -> None:
         db = tmp_path / "test.duckdb"
         db.touch()
         with patch.object(_db, "DB_PATH", str(db)):
             with patch("subprocess.run", return_value=_mock_result(stdout="")):
                 assert _db.query("SELECT 1") == []
 
-    def test_duckdb_empty_sentinel_returns_empty(self, tmp_path) -> None:
+    def test_duckdb_empty_sentinel_returns_empty(self, tmp_path: Path) -> None:
         db = tmp_path / "test.duckdb"
         db.touch()
         with patch.object(_db, "DB_PATH", str(db)):
             with patch("subprocess.run", return_value=_mock_result(stdout="[{]")):
                 assert _db.query("SELECT 1") == []
 
-    def test_invalid_json_returns_empty(self, tmp_path) -> None:
+    def test_invalid_json_returns_empty(self, tmp_path: Path) -> None:
         db = tmp_path / "test.duckdb"
         db.touch()
         with patch.object(_db, "DB_PATH", str(db)):
             with patch("subprocess.run", return_value=_mock_result(stdout="not-json")):
                 assert _db.query("SELECT 1") == []
 
-    def test_valid_json_returned(self, tmp_path) -> None:
+    def test_valid_json_returned(self, tmp_path: Path) -> None:
         db = tmp_path / "test.duckdb"
         db.touch()
         data = [{"tool": "Bash", "cnt": "5"}]
@@ -138,14 +141,14 @@ class TestArgParsers:
 
 
 class TestOutput:
-    def test_json_mode(self, capsys) -> None:
+    def test_json_mode(self, capsys: pytest.CaptureFixture[str]) -> None:
         rows = [{"tool": "Bash", "uses": "10"}]
         _db.output(rows, ["--json"])
         out = capsys.readouterr().out
         parsed = json.loads(out)
         assert parsed == rows
 
-    def test_tsv_mode(self, capsys) -> None:
+    def test_tsv_mode(self, capsys: pytest.CaptureFixture[str]) -> None:
         rows = [{"a": "1", "b": "2"}, {"a": "3", "b": "4"}]
         _db.output(rows, [])
         lines = capsys.readouterr().out.strip().split("\n")
@@ -153,7 +156,9 @@ class TestOutput:
         assert lines[1] == "1\t2"
         assert lines[2] == "3\t4"
 
-    def test_empty_rows_prints_no_results(self, capsys) -> None:
+    def test_empty_rows_prints_no_results(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         _db.output([], [])
         assert "(no results)" in capsys.readouterr().out
 
@@ -179,7 +184,7 @@ class TestDeniedTools:
         assert "'7'" in sql
         assert "5" in sql
 
-    def test_output_json(self, capsys) -> None:
+    def test_output_json(self, capsys: pytest.CaptureFixture[str]) -> None:
         rows = [{"tool": "Bash", "denials": "10"}]
         with patch.object(denied_tools, "query", return_value=rows):
             with patch("sys.argv", ["denied_tools.py", "--json"]):
@@ -201,7 +206,9 @@ class TestToolUsage:
         assert "tool_uses" in sql
         assert "tool_name" in sql
 
-    def test_output_includes_sessions_column(self, capsys) -> None:
+    def test_output_includes_sessions_column(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         rows = [{"tool_name": "Read", "uses": "50", "sessions": "10"}]
         with patch.object(tool_usage, "query", return_value=rows):
             with patch("sys.argv", ["tool_usage.py", "--json"]):
@@ -269,7 +276,7 @@ class TestToolMisuse:
         assert "find" in sql.lower()
         assert "sed" in sql.lower()
 
-    def test_output_has_misuse_type(self, capsys) -> None:
+    def test_output_has_misuse_type(self, capsys: pytest.CaptureFixture[str]) -> None:
         rows = [{"misuse_type": "grep/rg -> Grep", "uses": "100"}]
         with patch.object(tool_misuse, "query", return_value=rows):
             with patch("sys.argv", ["tool_misuse.py", "--json"]):
@@ -282,23 +289,28 @@ class TestToolMisuse:
 
 
 class TestHookStats:
-    def _mock_three_queries(self, hook_cnt, stop_cnt, errors=None):
+    def _mock_three_queries(
+        self,
+        hook_cnt: int,
+        stop_cnt: int,
+        errors: list[dict[str, str]] | None = None,
+    ) -> Any:
         """Return a side_effect for the 3 queries hook_stats.main() makes."""
-        returns = [
+        returns: list[list[dict[str, str]]] = [
             [{"cnt": str(hook_cnt)}],
             [{"cnt": str(stop_cnt)}],
             errors or [],
         ]
         call_idx = [0]
 
-        def _q(sql):  # noqa: ARG001
+        def _q(sql: str) -> list[dict[str, str]]:  # noqa: ARG001
             idx = call_idx[0]
             call_idx[0] += 1
             return returns[idx]
 
         return _q
 
-    def test_coverage_calculation(self, capsys) -> None:
+    def test_coverage_calculation(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch.object(
             hook_stats, "query", side_effect=self._mock_three_queries(50, 100)
         ):
@@ -307,7 +319,7 @@ class TestHookStats:
         out = capsys.readouterr().out
         assert "50.0%" in out
 
-    def test_zero_stops_no_crash(self, capsys) -> None:
+    def test_zero_stops_no_crash(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch.object(
             hook_stats, "query", side_effect=self._mock_three_queries(0, 0)
         ):
@@ -316,7 +328,7 @@ class TestHookStats:
         out = capsys.readouterr().out
         assert "0%" in out
 
-    def test_json_output_structure(self, capsys) -> None:
+    def test_json_output_structure(self, capsys: pytest.CaptureFixture[str]) -> None:
         errors = [{"error": "Timeout", "cnt": "3"}]
         with patch.object(
             hook_stats, "query", side_effect=self._mock_three_queries(30, 100, errors)
@@ -329,7 +341,9 @@ class TestHookStats:
         assert parsed["coverage_pct"] == 30.0
         assert parsed["errors"][0]["error"] == "Timeout"
 
-    def test_errors_shown_in_text_mode(self, capsys) -> None:
+    def test_errors_shown_in_text_mode(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         errors = [{"error": "Script crashed", "cnt": "5"}]
         with patch.object(
             hook_stats, "query", side_effect=self._mock_three_queries(10, 50, errors)
@@ -341,10 +355,10 @@ class TestHookStats:
         assert "5x" in out
 
     def test_days_flag_passed_to_queries(self) -> None:
-        sqls = []
+        sqls: list[str] = []
         call_idx = [0]
 
-        def capture_sql(sql):
+        def capture_sql(sql: str) -> list[dict[str, str]]:
             sqls.append(sql)
             call_idx[0] += 1
             if call_idx[0] <= 2:

--- a/vaudeville/core/protocol.py
+++ b/vaudeville/core/protocol.py
@@ -5,6 +5,7 @@ Stdlib-only — safe to import in hook scripts.
 
 from __future__ import annotations
 
+import logging
 import math
 import re
 from dataclasses import dataclass, field
@@ -42,8 +43,8 @@ def parse_verdict(raw: str) -> ClassifyResponse:
         VERDICT: violation
         REASON: one sentence
 
-    Falls back to keyword search if structured format is absent.
-    Unknown/malformed output defaults to "clean" (fail-open).
+    Defaults to "clean" (fail-open) if no VERDICT: header is found,
+    with a warning log for observability.
     """
     positive_re = re.compile(r"\bviolation\b")
 
@@ -62,7 +63,8 @@ def parse_verdict(raw: str) -> ClassifyResponse:
             reason = stripped[7:].strip()
 
     if not found_verdict:
-        verdict = "violation" if positive_re.search(raw.lower()) else "clean"
+        logging.warning("[vaudeville] No VERDICT: header in model output: %.100s", raw)
+        verdict = "clean"
         reason = raw.strip()[:200]
 
     reason = _SPECIAL_TOKEN_RE.sub("", reason).strip()
@@ -77,11 +79,13 @@ def compute_confidence(logprobs: dict[str, float], verdict: str) -> float:
     """Compute confidence from first-token logprobs.
 
     Finds the best logprob for violation-class and clean-class tokens,
-    applies softmax, and returns P(predicted_class). Returns 1.0 (fail-open)
-    when logprobs are empty or no matching tokens are found.
+    applies softmax, and returns P(predicted_class). Returns 0.0 (fail-open)
+    when logprobs are empty or no matching tokens are found, so the verdict
+    won't pass any threshold.
     """
     if not logprobs:
-        return 1.0
+        logging.warning("[vaudeville] Empty logprobs dict — returning 0.0 confidence")
+        return 0.0
 
     best_violation = -math.inf
     best_clean = -math.inf
@@ -94,7 +98,11 @@ def compute_confidence(logprobs: dict[str, float], verdict: str) -> float:
             best_clean = max(best_clean, lp)
 
     if best_violation == -math.inf or best_clean == -math.inf:
-        return 1.0
+        logging.warning(
+            "[vaudeville] No violation/clean tokens in logprobs (keys: %s) — returning 0.0 confidence",
+            list(logprobs.keys())[:5],
+        )
+        return 0.0
 
     # Softmax of two values: P(x) = exp(x) / (exp(x) + exp(y))
     # Use log-sum-exp trick for numerical stability

--- a/vaudeville/core/rules.py
+++ b/vaudeville/core/rules.py
@@ -83,7 +83,7 @@ class Rule:
     context: list[dict[str, str]]
     action: str
     message: str
-    threshold: float = 0.0
+    threshold: float = 0.5
 
     def format_prompt(self, text: str, context: str = "") -> str:
         safe_text = _sanitize_input(back_truncate(text))
@@ -172,5 +172,5 @@ def parse_rule(data: dict[str, Any]) -> Rule:
         context=[c for c in data.get("context", []) if isinstance(c, dict)],
         action=str(data.get("action", "block")),
         message=str(data.get("message", "{reason}")),
-        threshold=float(data.get("threshold", 0.0)),
+        threshold=float(data.get("threshold", 0.5)),
     )

--- a/vaudeville/server/gguf_backend.py
+++ b/vaudeville/server/gguf_backend.py
@@ -49,39 +49,38 @@ class GGUFBackend:
     def classify_with_logprobs(
         self, prompt: str, max_tokens: int = 50
     ) -> ClassifyResult:
-        """Run inference and return output with first-token logprobs."""
+        """Run inference and return output with first-token logprobs.
+
+        Pre-fills "VERDICT:" via assistant message so the first generated
+        token IS the class label, matching MLX backend behavior.
+        """
         response: Any = self._llm.create_chat_completion(
-            messages=[{"role": "user", "content": prompt}],
+            messages=[
+                {"role": "user", "content": prompt},
+                {"role": "assistant", "content": "VERDICT:"},
+            ],
             max_tokens=max_tokens,
             temperature=0.0,
             logprobs=True,
             top_logprobs=TOP_LOGPROBS,
         )
-        text: str = response["choices"][0]["message"]["content"]
+        text: str = "VERDICT:" + response["choices"][0]["message"]["content"]
         logprobs = self._extract_first_token_logprobs(response)
         return ClassifyResult(text=text, logprobs=logprobs)
 
     def _extract_first_token_logprobs(self, response: Any) -> dict[str, float]:
-        """Extract logprobs from the label-token position in the response.
+        """Extract logprobs from the first token position.
 
-        Scans token positions until finding one whose top logprobs contain
-        violation/clean-prefixed tokens (skipping "VERDICT", ":", etc.).
+        With the "VERDICT:" assistant prefill, the first generated token
+        should be the class label ("violation"/"clean").
         """
-        from ..core.protocol import compute_confidence
-
         try:
             content = response["choices"][0]["logprobs"]["content"]
             if not content:
                 return {}
-            for position in content:
-                top = {
-                    entry["token"]: entry["logprob"]
-                    for entry in position["top_logprobs"]
-                }
-                # compute_confidence returns 1.0 when no label tokens found
-                if compute_confidence(top, "violation") != 1.0:
-                    return top
-            return {}
+            return {
+                entry["token"]: entry["logprob"] for entry in content[0]["top_logprobs"]
+            }
         except (KeyError, IndexError, TypeError) as exc:
             logger.warning("[vaudeville] Logprob extraction failed: %s", exc)
             return {}


### PR DESCRIPTION
## Summary
### Distribution boilerplate
- Add LICENSE (MIT), CHANGELOG.md, README.md for public distribution
- Add `.claude-plugin/marketplace.json` for Claude Code plugin registry (`/plugin install vaudeville@paulnsorensen`)
- Ship 3 example rules in `examples/rules/` (violation-detector, dismissal-detector, deferral-detector) — not wired by default, users copy to activate
- Add CI release job triggered on `v*` tags (builds wheel, creates GitHub Release)
- Fix all mypy type annotation errors in `tests/test_query_helpers.py`

### False positive reduction
- Default rule threshold 0.0 → 0.5 — new rules require ≥50% confidence to trigger
- Confidence fallback 1.0 → 0.0 with warning logs when logprobs missing (observe before engineering)
- Verdict parser: no VERDICT: header → default to clean + warning log (strict fail-open)
- GGUF backend: pre-fill "VERDICT:" to anchor first token as class label (matches MLX strategy)
- slm-rule-writer agent: add threshold to schema, template, workflow, and deliverables
- Example rules: add threshold: 0.7, fix deferral-detector event to PreToolUse

## Test plan
- [x] `just check` passes (lint + format + typecheck)
- [x] `just test` passes (371 passed, 2 skipped — GGUF import smoke tests skip on Apple Silicon as expected)
- [ ] Verify README renders correctly on GitHub
- [ ] After merge, tag `v0.1.0` and verify release job creates GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)