### PR TITLE
feat: add VAUDEVILLE_SKIP env var to bypass hooks

### DIFF
--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -135,6 +135,11 @@ def _load_rules_for_event(event: str) -> list:
 
 
 def _run() -> None:
+    if os.environ.get("VAUDEVILLE_SKIP", "") == "1":
+        _dbg("VAUDEVILLE_SKIP=1 — bypassing all rules")
+        print("{}")
+        sys.exit(0)
+
     args = sys.argv[1:]
 
     # Parse --event flag

--- a/justfile
+++ b/justfile
@@ -86,7 +86,7 @@ eval-rule rule:
 
 # Calibrate threshold for a rule (e.g., `just eval-calibrate violation-detector`)
 eval-calibrate rule:
-    uv run python -m vaudeville.eval --calibrate {{rule}}
+    VAUDEVILLE_SKIP=1 uv run python -m vaudeville.eval --calibrate {{rule}}
 
 # Clean build and test artifacts
 clean:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -138,6 +138,48 @@ class TestVerdictToHookResponse:
         assert "vaudeville hook [r] prevented response:" in resp["systemMessage"]
 
 
+class TestSkipEnvVar:
+    """Tests for VAUDEVILLE_SKIP bypass."""
+
+    def test_skip_exits_immediately(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with (
+            patch.dict(os.environ, {"VAUDEVILLE_SKIP": "1"}),
+            patch.object(sys, "argv", ["runner.py", "--event", "Stop"]),
+            patch("sys.stdin", io.StringIO('{"body": "text"}')),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            runner._run()
+        assert exc_info.value.code == 0
+        assert capsys.readouterr().out.strip() == "{}"
+
+    def test_skip_not_set_proceeds(self) -> None:
+        """Without VAUDEVILLE_SKIP, runner proceeds normally."""
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch.object(sys, "argv", ["runner.py", "--event", "Stop"]),
+            patch("sys.stdin", io.StringIO('{"body": "text"}')),
+            patch("runner._load_rules_for_event", return_value=[]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            env = os.environ.copy()
+            env.pop("VAUDEVILLE_SKIP", None)
+            with patch.dict(os.environ, env, clear=True):
+                runner._run()
+        assert exc_info.value.code == 0
+
+    def test_skip_value_must_be_1(self) -> None:
+        """VAUDEVILLE_SKIP=true or other values don't trigger skip."""
+        with (
+            patch.dict(os.environ, {"VAUDEVILLE_SKIP": "true"}),
+            patch.object(sys, "argv", ["runner.py", "--event", "Stop"]),
+            patch("sys.stdin", io.StringIO('{"body": "text"}')),
+            patch("runner._load_rules_for_event", return_value=[]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            runner._run()
+        assert exc_info.value.code == 0
+
+
 class TestRunPipeline:
     """Tests for _run() — the main execution loop."""
 


### PR DESCRIPTION
## Summary

- Adds `VAUDEVILLE_SKIP=1` env var check at the top of the hook runner — when set, all rule evaluation is bypassed (fail-open with `{}`).
- `just eval-calibrate` now sets `VAUDEVILLE_SKIP=1` automatically so hooks don't interfere during tuning runs.
- 3 new tests: skip works, unset proceeds normally, only the value `"1"` triggers the bypass.

## Test plan

- [x] `just check` passes (lint + typecheck + test)
- [x] All 520 tests pass