### PR TITLE
feat(skills): add hook-suggester analyzers and /tune skill

### DIFF
--- a/skills/hook-suggester/scripts/analyze.py
+++ b/skills/hook-suggester/scripts/analyze.py
@@ -352,6 +352,148 @@ def check_repeated_bash_patterns(days, min_occ):
     }
 
 
+def check_correction_patterns(days, min_occ):
+    """Mine user messages that correct Claude's behavior — SLM rule candidates."""
+    rows = query(f"""
+        SELECT
+            substr(message::VARCHAR, 1, 150) AS user_msg,
+            count(*) AS occurrences
+        FROM raw_entries
+        WHERE type = 'user'
+          AND userType = 'external'
+          AND length(message::VARCHAR) < 200
+          AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+          AND (message::VARCHAR ILIKE '%no,%'
+               OR message::VARCHAR ILIKE '%wrong%'
+               OR message::VARCHAR ILIKE '%that''s not%'
+               OR message::VARCHAR ILIKE '%stop %doing%'
+               OR message::VARCHAR ILIKE '%I said%'
+               OR message::VARCHAR ILIKE '%not what I%')
+        GROUP BY user_msg
+        HAVING count(*) >= {min_occ}
+        ORDER BY occurrences DESC
+        LIMIT 10;
+    """)
+    if not rows:
+        return None
+    total = sum(int(r["occurrences"]) for r in rows)
+    examples = [r["user_msg"][:100] for r in rows]
+    return {
+        "id": "correction-patterns",
+        "event": "Stop",
+        "priority": "medium",
+        "title": "User correction patterns — SLM rule candidates",
+        "description": (
+            f"Found {total} user corrections across {len(rows)} patterns "
+            f"in the last {days} days. Each repeated correction is a "
+            f"candidate SLM rule."
+        ),
+        "examples": examples,
+        "hook_type": "slm-rule",
+        "suggested_action": "warn",
+    }
+
+
+def check_retry_loops(days, min_occ):
+    """Find tools called repeatedly on the same file with errors between."""
+    rows = query(f"""
+        WITH sequenced AS (
+            SELECT
+                tu.sessionId,
+                tu.tool_name,
+                tu.file_path,
+                tu.timestamp,
+                tr.is_error,
+                LAG(tr.is_error) OVER (
+                    PARTITION BY tu.sessionId, tu.file_path
+                    ORDER BY tu.timestamp
+                ) AS prev_error,
+                LAG(tu.tool_name) OVER (
+                    PARTITION BY tu.sessionId, tu.file_path
+                    ORDER BY tu.timestamp
+                ) AS prev_tool
+            FROM tool_uses tu
+            JOIN tool_results tr ON tu.tool_use_id = tr.tool_use_id
+            WHERE tu.file_path IS NOT NULL
+              AND tu.timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+        )
+        SELECT
+            tool_name,
+            count(*) AS retry_count
+        FROM sequenced
+        WHERE prev_error = 'true'
+          AND tool_name = prev_tool
+        GROUP BY tool_name
+        HAVING count(*) >= {min_occ}
+        ORDER BY retry_count DESC
+        LIMIT 10;
+    """)
+    if not rows:
+        return None
+    total = sum(int(r["retry_count"]) for r in rows)
+    examples = [f"{r['tool_name']} ({r['retry_count']} retries)" for r in rows]
+    return {
+        "id": "retry-loops",
+        "event": "PostToolUse",
+        "priority": "medium",
+        "title": "Error-retry loops — guessing instead of reading errors",
+        "description": (
+            f"Found {total} error→retry chains across {len(rows)} tools "
+            f"in the last {days} days. A PostToolUse rule can catch "
+            f"repeated failures on the same file."
+        ),
+        "examples": examples,
+        "hook_type": "slm-rule",
+        "suggested_action": "warn",
+    }
+
+
+def check_permission_tool_waste(days, min_occ):
+    """Find tools that fail on permissions and get retried."""
+    rows = query(f"""
+        WITH perm_failures AS (
+            SELECT
+                tu.tool_name,
+                tu.sessionId,
+                tu.timestamp,
+                tu.tool_use_id
+            FROM tool_uses tu
+            JOIN tool_results tr ON tu.tool_use_id = tr.tool_use_id
+            WHERE tr.is_error = 'true'
+              AND tu.timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+              AND (tr.content ILIKE '%permission%'
+                   OR tr.content ILIKE '%denied%'
+                   OR tr.content ILIKE '%not allowed%')
+        )
+        SELECT
+            tool_name,
+            count(*) AS failures
+        FROM perm_failures
+        GROUP BY tool_name
+        HAVING count(*) >= {min_occ}
+        ORDER BY failures DESC
+        LIMIT 10;
+    """)
+    if not rows:
+        return None
+    total = sum(int(r["failures"]) for r in rows)
+    examples = [f"{r['tool_name']} ({r['failures']} permission failures)" for r in rows]
+    return {
+        "id": "permission-tool-waste",
+        "event": "PreToolUse",
+        "priority": "low",
+        "title": "Tools wasting turns on permission walls",
+        "description": (
+            f"Found {total} permission-related failures across "
+            f"{len(rows)} tools in the last {days} days. "
+            f"A PreToolUse hook can intercept before the turn is burned."
+        ),
+        "examples": examples,
+        "hook_type": "workflow",
+        "suggested_action": "warn",
+    }
+
+
 def main():
     args = sys.argv[1:]
     days = DEFAULT_DAYS
@@ -378,6 +520,9 @@ def main():
         check_hook_failures,
         check_code_write_volume,
         check_repeated_bash_patterns,
+        check_correction_patterns,
+        check_retry_loops,
+        check_permission_tool_waste,
     ]
 
     suggestions = []

--- a/skills/hook-suggester/scripts/analyze.py
+++ b/skills/hook-suggester/scripts/analyze.py
@@ -450,7 +450,7 @@ def check_retry_loops(days, min_occ):
 
 
 def check_permission_tool_waste(days, min_occ):
-    """Find tools that fail on permissions and get retried."""
+    """Find tools that hit permission errors, burning turns a PreToolUse hook could intercept."""
     rows = query(f"""
         WITH perm_failures AS (
             SELECT

--- a/skills/hook-suggester/scripts/analyze.py
+++ b/skills/hook-suggester/scripts/analyze.py
@@ -363,6 +363,7 @@ def check_correction_patterns(days, min_occ):
           AND userType = 'external'
           AND length(message::VARCHAR) < 200
           AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+          AND typeof(message) = 'VARCHAR'
           AND (message::VARCHAR ILIKE '%no,%'
                OR message::VARCHAR ILIKE '%wrong%'
                OR message::VARCHAR ILIKE '%that''s not%'
@@ -461,9 +462,9 @@ def check_permission_tool_waste(days, min_occ):
             JOIN tool_results tr ON tu.tool_use_id = tr.tool_use_id
             WHERE tr.is_error = 'true'
               AND tu.timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
-              AND (tr.content ILIKE '%permission%'
-                   OR tr.content ILIKE '%denied%'
-                   OR tr.content ILIKE '%not allowed%')
+              AND (tr.content ILIKE '%permission denied%'
+                   OR tr.content ILIKE '%permission%' AND tr.content ILIKE '%denied%'
+                   OR tr.content ILIKE '%not allowed%' AND tr.content ILIKE '%permission%')
         )
         SELECT
             tool_name,

--- a/skills/tune/SKILL.md
+++ b/skills/tune/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: vaudeville:tune
+description: >
+  Tune a single vaudeville SLM rule to meet precision/recall targets. Runs eval,
+  analyzes misclassifications (FP/FN), edits the rule prompt, and re-evaluates
+  in a loop. Use when the user says "tune rule", "fix rule accuracy", "improve
+  rule", "tune violation-detector", "why is my rule failing", or invokes /tune
+  with a rule name. Requires the vaudeville daemon to be running for inference.
+model: sonnet
+context: fork
+allowed-tools: Bash(uv:*), Bash(bash:*), Read, Edit, Write, Glob
+---
+
+# tune
+
+Automated single-rule tuning loop. Target: >= 95% precision AND >= 80% recall.
+
+## Arguments
+
+The first argument is the rule name (e.g., `violation-detector`). Required.
+
+Optional flags after the rule name:
+- `--calibrate` — after tuning, run threshold calibration
+- `--max-iterations N` — max tuning loops (default: 3)
+
+## Prerequisites
+
+The vaudeville daemon must be running (the eval harness needs the MLX backend).
+Rules live in `rules_dev/`. Test cases live in `tests/`.
+
+## Workflow
+
+### Step 1: Validate the rule exists
+
+Check that `rules_dev/<rule-name>.yaml` exists and that there's a matching
+test file in `tests/` (any YAML file with `rule: <rule-name>`).
+
+```bash
+ls rules_dev/<rule-name>.yaml
+```
+
+Find the test file:
+```bash
+grep -l "^rule: <rule-name>" tests/*.yaml
+```
+
+If either is missing, report the error and stop.
+
+### Step 2: Run baseline eval
+
+Run eval for this specific rule using the project's eval wrapper:
+
+```bash
+bash ralphs/rule-tuning-v2/run-eval.sh 2>&1 | grep -E "(Evaluating <rule-name>|=== <rule-name>|Accuracy|Precision|Recall|F1|Confusion|Confidence|Misclass|actual=)"
+```
+
+If the run-eval.sh script doesn't support single-rule filtering, use:
+
+```bash
+uv run python -m vaudeville.eval --rules-dir rules_dev --rule <rule-name> 2>&1 | grep -E "(^Evaluating|^===|Accuracy|Precision|Recall|F1|Confusion|Confidence|Misclass|actual=|WARNING|ALL RULES|SOME RULES)"
+```
+
+Record the baseline precision, recall, F1, and any misclassifications.
+
+### Step 3: Analyze misclassifications
+
+For each misclassification from the eval output, categorize it:
+
+- **FP (false positive)**: `actual=clean predicted=violation` — model is too aggressive.
+  The text is legitimately clean but the rule prompt is triggering on it.
+- **FN (false negative)**: `actual=violation predicted=clean` — model is too lenient.
+  The text contains a real violation but the rule prompt isn't catching it.
+
+Diagnosis strategy:
+- Read the full rule prompt in `rules_dev/<rule-name>.yaml`
+- Read the full test case text in the test file (the eval output truncates to 80 chars)
+- For each FP: identify what pattern in the prompt is over-matching
+- For each FN: identify what violation pattern is missing from the prompt
+
+### Step 4: Edit the rule prompt
+
+Based on the analysis, make targeted edits to the rule's `prompt:` field:
+
+**For FPs (too aggressive):**
+- Add a "CLEAN if..." clause that covers the FP pattern
+- Add a clean example that matches the FP text pattern
+- Narrow an overly broad violation criterion
+
+**For FNs (too lenient):**
+- Add or strengthen a "VIOLATION if..." clause for the missed pattern
+- Add a violation example that matches the FN text pattern
+- Make violation criteria more specific (not just broader)
+
+**Budget constraints:**
+- Keep total prompt under 2000 characters
+- Keep examples at 4-8 total (don't exceed 8)
+- If at the example budget, replace the weakest example rather than adding
+
+After editing, read the file back to verify the edit was clean.
+
+### Step 5: Re-run eval
+
+Run the same eval command as Step 2. Compare against baseline:
+
+- Did precision improve? (FPs should decrease)
+- Did recall improve? (FNs should decrease)
+- Did we regress on either metric?
+
+If both metrics meet target (>= 95% P, >= 80% R), report success.
+
+### Step 6: Loop or stop
+
+If targets not met and iterations < max (default 3):
+- Go back to Step 3 with the new misclassifications
+- Each iteration should target the highest-impact misclassification
+
+If targets not met after max iterations:
+- Report final metrics
+- List remaining misclassifications
+- Add a YAML comment to the rule noting the limitation
+
+### Step 7: Optional calibration
+
+If `--calibrate` was passed and the rule has >= 20 test cases:
+
+```bash
+uv run python -m vaudeville.eval --rules-dir rules_dev --calibrate <rule-name> 2>&1 | grep -E "(Calibrated|threshold|Updated|ERROR|WARNING)"
+```
+
+Report the calibrated threshold and updated metrics.
+
+## Output Format
+
+Report results as a compact tuning log:
+
+```
+## Tune: <rule-name>
+
+**Baseline**: P=XX.X% R=XX.X% F1=XX.X% (TP=N FP=N TN=N FN=N)
+
+### Iteration 1
+- FPs: N (pattern: <description>)
+- FNs: N (pattern: <description>)
+- Edit: <what was changed in the prompt>
+- Result: P=XX.X% R=XX.X% F1=XX.X%
+
+### Iteration 2 (if needed)
+...
+
+**Final**: P=XX.X% R=XX.X% F1=XX.X% [PASS/FAIL]
+**Threshold**: X.XX (if calibrated)
+```
+
+## Gotchas
+
+- The eval harness loads the MLX model on every run — each eval takes 30-60s.
+  Don't run unnecessary iterations.
+- Prompt edits that fix FPs can cause FNs and vice versa. Track both metrics
+  every iteration — never optimize for one at the expense of the other.
+- Test case text in eval output is truncated to 80 chars. Always read the full
+  test case from the YAML file before diagnosing.
+- The 2000-char prompt budget is real — Phi-4-mini degrades badly on longer prompts.
+  If you're at budget, trade a weak example for a better one rather than expanding.
+- Rules in `rules_dev/` are the source of truth. Never edit `examples/rules/` or
+  `~/.vaudeville/rules/`.

--- a/skills/tune/SKILL.md
+++ b/skills/tune/SKILL.md
@@ -4,11 +4,13 @@ description: >
   Tune a single vaudeville SLM rule to meet precision/recall targets. Runs eval,
   analyzes misclassifications (FP/FN), edits the rule prompt, and re-evaluates
   in a loop. Use when the user says "tune rule", "fix rule accuracy", "improve
-  rule", "tune violation-detector", "why is my rule failing", or invokes /tune
-  with a rule name. Requires the vaudeville daemon to be running for inference.
+  rule precision", "reduce false positives", "recall is too low", "tune
+  violation-detector", "why is my rule failing", or wants to iterate on an SLM
+  rule prompt until it meets accuracy targets. Requires the vaudeville daemon
+  to be running for inference.
 model: sonnet
 context: fork
-allowed-tools: Bash(uv:*), Bash(bash:*), Read, Edit, Write, Glob
+allowed-tools: Bash(uv:*), Bash(ls:*), Read, Edit, Write, Glob, Grep
 ---
 
 # tune
@@ -48,13 +50,7 @@ If either is missing, report the error and stop.
 
 ### Step 2: Run baseline eval
 
-Run eval for this specific rule using the project's eval wrapper:
-
-```bash
-bash ralphs/rule-tuning-v2/run-eval.sh 2>&1 | grep -E "(Evaluating <rule-name>|=== <rule-name>|Accuracy|Precision|Recall|F1|Confusion|Confidence|Misclass|actual=)"
-```
-
-If the run-eval.sh script doesn't support single-rule filtering, use:
+Run eval for this specific rule:
 
 ```bash
 uv run python -m vaudeville.eval --rules-dir rules_dev --rule <rule-name> 2>&1 | grep -E "(^Evaluating|^===|Accuracy|Precision|Recall|F1|Confusion|Confidence|Misclass|actual=|WARNING|ALL RULES|SOME RULES)"

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -251,3 +251,85 @@ class TestCheckRepeatedBashPatterns:
             result = analyze.check_repeated_bash_patterns(14, 3)
         assert result is not None
         assert len(result["examples"][0].split(" (")[0]) <= 80
+
+
+class TestCheckCorrectionPatterns:
+    def test_returns_none_when_no_rows(self) -> None:
+        with patch.object(analyze, "query", return_value=[]):
+            assert analyze.check_correction_patterns(14, 3) is None
+
+    def test_returns_suggestion_with_correction_examples(self) -> None:
+        rows = [
+            {"user_msg": "no, that's not what I meant", "occurrences": "5"},
+            {"user_msg": "wrong approach, use the Grep tool", "occurrences": "3"},
+        ]
+        with patch.object(analyze, "query", return_value=rows):
+            result = analyze.check_correction_patterns(14, 3)
+        assert result is not None
+        assert result["id"] == "correction-patterns"
+        assert result["event"] == "Stop"
+        assert result["hook_type"] == "slm-rule"
+        assert len(result["examples"]) == 2
+
+    def test_long_messages_truncated(self) -> None:
+        long_msg = "no, " + "x" * 200
+        rows = [{"user_msg": long_msg, "occurrences": "3"}]
+        with patch.object(analyze, "query", return_value=rows):
+            result = analyze.check_correction_patterns(14, 3)
+        assert result is not None
+        assert len(result["examples"][0]) <= 100
+
+
+class TestCheckRetryLoops:
+    def test_returns_none_when_no_rows(self) -> None:
+        with patch.object(analyze, "query", return_value=[]):
+            assert analyze.check_retry_loops(14, 3) is None
+
+    def test_returns_suggestion_with_tool_retries(self) -> None:
+        rows = [
+            {"tool_name": "Bash", "retry_count": "15"},
+            {"tool_name": "Edit", "retry_count": "8"},
+        ]
+        with patch.object(analyze, "query", return_value=rows):
+            result = analyze.check_retry_loops(14, 3)
+        assert result is not None
+        assert result["id"] == "retry-loops"
+        assert result["event"] == "PostToolUse"
+        assert result["hook_type"] == "slm-rule"
+        assert any("Bash" in ex for ex in result["examples"])
+
+    def test_total_count_sums_retries(self) -> None:
+        rows = [
+            {"tool_name": "Bash", "retry_count": "10"},
+            {"tool_name": "Edit", "retry_count": "5"},
+        ]
+        with patch.object(analyze, "query", return_value=rows):
+            result = analyze.check_retry_loops(14, 3)
+        assert result is not None
+        assert "15" in result["description"]
+
+
+class TestCheckPermissionToolWaste:
+    def test_returns_none_when_no_rows(self) -> None:
+        with patch.object(analyze, "query", return_value=[]):
+            assert analyze.check_permission_tool_waste(14, 3) is None
+
+    def test_returns_suggestion_with_permission_failures(self) -> None:
+        rows = [
+            {"tool_name": "Bash", "failures": "20"},
+            {"tool_name": "Write", "failures": "5"},
+        ]
+        with patch.object(analyze, "query", return_value=rows):
+            result = analyze.check_permission_tool_waste(14, 3)
+        assert result is not None
+        assert result["id"] == "permission-tool-waste"
+        assert result["event"] == "PreToolUse"
+        assert result["hook_type"] == "workflow"
+        assert len(result["examples"]) == 2
+
+    def test_total_count_sums_failures(self) -> None:
+        rows = [{"tool_name": "Bash", "failures": "10"}]
+        with patch.object(analyze, "query", return_value=rows):
+            result = analyze.check_permission_tool_waste(14, 3)
+        assert result is not None
+        assert "10" in result["description"]

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -271,6 +271,16 @@ class TestCheckCorrectionPatterns:
         assert result["hook_type"] == "slm-rule"
         assert len(result["examples"]) == 2
 
+    def test_total_count_sums_occurrences(self) -> None:
+        rows = [
+            {"user_msg": "no, wrong", "occurrences": "7"},
+            {"user_msg": "that's not right", "occurrences": "3"},
+        ]
+        with patch.object(analyze, "query", return_value=rows):
+            result = analyze.check_correction_patterns(14, 3)
+        assert result is not None
+        assert "10" in result["description"]
+
     def test_long_messages_truncated(self) -> None:
         long_msg = "no, " + "x" * 200
         rows = [{"user_msg": long_msg, "occurrences": "3"}]


### PR DESCRIPTION
## Summary
- **3 new hook-suggester analyzers**: correction-patterns (mines user corrections for SLM rule candidates), retry-loops (detects error→retry chains), permission-tool-waste (finds tools burning turns on permission failures)
- **`/tune` skill**: automated single-rule tuning loop — runs eval, analyzes FP/FN misclassifications, edits the rule prompt, re-evaluates up to 3 iterations targeting ≥95% precision / ≥80% recall
- **Tests**: 82 lines covering all three new analyzers (empty results, suggestion shape, edge cases)

Extracted from `ralph/rule-tuning-v0.1` branch for focused review.

## Test plan
- [ ] `just test tests/test_analyze.py` — new analyzer tests pass
- [ ] `just check` — lint + typecheck + test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)