### PR TITLE
feat(eval+skill): auto-condense, --rules-dir, thresholds, tier-advisor skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,6 @@ Hook entry point: `hooks/runner.py` (thin, stdlib-only, fail-open)
 ## Key Patterns
 
 - **Fail-open everywhere**: daemon down → allow, inference error → allow, unknown rule → allow
-- **Back-truncation**: input text is truncated to last 1500 tokens (violations cluster at end)
+- **Event-aware truncation**: input text is condensed to fit within token budget, preserving structure boundaries (tool calls, assistant turns)
 - **Prompt injection defense**: VERDICT:/REASON: markers are neutralized with zero-width spaces before interpolation
 - **Deterministic inference**: both backends use temp=0.0

--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -127,7 +127,7 @@ def main() -> None:
 
 def _load_rules_for_event(event: str) -> list:
     """Auto-discover all rules matching an event via layered resolution."""
-    from vaudeville.core.rules import load_rules_layered  # noqa: E402
+    from vaudeville.core import load_rules_layered  # noqa: E402
 
     project_root = _find_project_root()
     all_rules = load_rules_layered(project_root)

--- a/skills/hook-suggester/scripts/analyze.py
+++ b/skills/hook-suggester/scripts/analyze.py
@@ -10,489 +10,82 @@ Usage: python3 analyze.py [--days N] [--min-occurrences N] [--json]
 
 import json
 import os
-import subprocess
 import sys
 
-DB_PATH = os.path.expanduser("~/.claude/analytics/sessions.duckdb")
-DEFAULT_DAYS = 14
-DEFAULT_MIN_OCCURRENCES = 3
+from analyzers import (
+    DB_PATH,
+    DEFAULT_DAYS,
+    DEFAULT_MIN_OCCURRENCES,
+    check_code_write_volume,
+    check_correction_patterns,
+    check_dangerous_bash,
+    check_high_error_tools,
+    check_hook_failures,
+    check_missing_quality_hooks,
+    check_permission_friction,
+    check_permission_tool_waste,
+    check_repeated_bash_patterns,
+    check_retry_loops,
+    check_tool_misuse,
+    query,
+)
+
+__all__ = [
+    "DB_PATH",
+    "DEFAULT_DAYS",
+    "DEFAULT_MIN_OCCURRENCES",
+    "check_code_write_volume",
+    "check_correction_patterns",
+    "check_dangerous_bash",
+    "check_high_error_tools",
+    "check_hook_failures",
+    "check_missing_quality_hooks",
+    "check_permission_friction",
+    "check_permission_tool_waste",
+    "check_repeated_bash_patterns",
+    "check_retry_loops",
+    "check_tool_misuse",
+    "query",
+]
+
+ANALYZERS = [
+    check_dangerous_bash,
+    check_tool_misuse,
+    check_high_error_tools,
+    check_permission_friction,
+    check_missing_quality_hooks,
+    check_hook_failures,
+    check_code_write_volume,
+    check_repeated_bash_patterns,
+    check_correction_patterns,
+    check_retry_loops,
+    check_permission_tool_waste,
+]
+
+PRIORITY_ORDER = {"high": 0, "medium": 1, "low": 2}
 
 
-def query(sql):
-    """Run a DuckDB query and return parsed JSON results."""
-    try:
-        result = subprocess.run(
-            ["duckdb", DB_PATH, "-json", "-c", sql],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-    except FileNotFoundError:
-        print("ERROR: duckdb not found on PATH", file=sys.stderr)
-        sys.exit(1)
-    if result.returncode != 0:
-        print(
-            f"WARNING: duckdb query failed (exit {result.returncode})",
-            file=sys.stderr,
-        )
-        if result.stderr:
-            print(f"  {result.stderr.strip()[:200]}", file=sys.stderr)
-        return []
-    raw = result.stdout.strip()
-    if not raw or raw == "[{]":
-        return []
-    try:
-        return json.loads(raw)
-    except json.JSONDecodeError as e:
-        print(f"WARNING: Failed to parse DuckDB JSON output: {e}", file=sys.stderr)
-        return []
+def _print_suggestions(suggestions, days):
+    if not suggestions:
+        print("No hook suggestions found. Your setup looks solid!")
+        return
 
+    print(f"\n{'=' * 60}")
+    print(f"  HOOK SUGGESTIONS  ({len(suggestions)} found)")
+    print(f"  Based on {days} days of session data")
+    print(f"{'=' * 60}\n")
 
-def check_dangerous_bash(days, min_occ):
-    """Detect dangerous bash commands that should be guarded."""
-    rows = query(f"""
-        SELECT
-            bash_cmd,
-            count(*) AS uses
-        FROM tool_uses
-        WHERE tool_name = 'Bash'
-          AND bash_cmd IS NOT NULL
-          AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
-          AND (
-            bash_cmd LIKE '%rm -rf%'
-            OR (bash_cmd LIKE '%git push%--force%'
-                AND bash_cmd NOT LIKE '%--force-with-lease%')
-            OR bash_cmd LIKE '%DROP %'
-            OR bash_cmd LIKE '%> /dev/%'
-            OR bash_cmd LIKE '%chmod 777%'
-            OR bash_cmd LIKE '%--no-verify%'
-          )
-        GROUP BY bash_cmd
-        HAVING count(*) >= {min_occ}
-        ORDER BY uses DESC
-        LIMIT 10;
-    """)
-    if not rows:
-        return None
-    examples = [r["bash_cmd"][:80] for r in rows]
-    total = sum(int(r["uses"]) for r in rows)
-    return {
-        "id": "dangerous-bash",
-        "event": "PreToolUse",
-        "priority": "high",
-        "title": "Guard dangerous bash commands",
-        "description": (
-            f"Found {total} uses of dangerous bash patterns across "
-            f"{len(rows)} commands in the last {days} days."
-        ),
-        "examples": examples,
-        "hook_type": "safety",
-        "suggested_action": "block",
-    }
-
-
-def check_tool_misuse(days, min_occ):
-    """Detect bash used for tasks that have dedicated tools."""
-    rows = query(f"""
-        SELECT
-            CASE
-                WHEN bash_cmd LIKE 'cat %' OR bash_cmd LIKE 'head %'
-                    OR bash_cmd LIKE 'tail %' THEN 'cat/head/tail → Read tool'
-                WHEN bash_cmd LIKE 'grep %' OR bash_cmd LIKE 'rg %'
-                    OR bash_cmd LIKE 'egrep %' THEN 'grep/rg → Grep tool'
-                WHEN bash_cmd LIKE 'find %' OR bash_cmd LIKE 'fd %'
-                    THEN 'find/fd → Glob tool'
-                WHEN bash_cmd LIKE 'sed %' OR bash_cmd LIKE '%sed -i%'
-                    THEN 'sed → Edit tool'
-                WHEN bash_cmd LIKE 'echo %>>%' OR bash_cmd LIKE 'echo %>%'
-                    OR (bash_cmd LIKE 'cat %' AND bash_cmd LIKE '%>%')
-                    THEN 'echo/cat redirect → Write tool'
-            END AS misuse_type,
-            count(*) AS uses
-        FROM tool_uses
-        WHERE tool_name = 'Bash'
-          AND bash_cmd IS NOT NULL
-          AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
-        GROUP BY misuse_type
-        HAVING misuse_type IS NOT NULL AND count(*) >= {min_occ}
-        ORDER BY uses DESC;
-    """)
-    if not rows:
-        return None
-    total = sum(int(r["uses"]) for r in rows)
-    misuses = [f"{r['misuse_type']} ({r['uses']}x)" for r in rows]
-    return {
-        "id": "tool-misuse",
-        "event": "PreToolUse",
-        "priority": "medium",
-        "title": "Redirect bash to dedicated tools",
-        "description": (
-            f"Found {total} bash calls that should use dedicated tools. "
-            f"A PreToolUse hook can warn Claude to use the right tool."
-        ),
-        "examples": misuses,
-        "hook_type": "quality",
-        "suggested_action": "warn",
-    }
-
-
-def check_high_error_tools(days, min_occ):
-    """Detect tools with high error rates."""
-    rows = query(f"""
-        SELECT
-            tu.tool_name,
-            count(*) AS total,
-            sum(CASE WHEN tr.is_error = 'true' THEN 1 ELSE 0 END) AS errors,
-            round(
-                sum(CASE WHEN tr.is_error = 'true' THEN 1 ELSE 0 END)
-                * 100.0 / count(*), 1
-            ) AS error_pct
-        FROM tool_uses tu
-        JOIN tool_results tr ON tu.tool_use_id = tr.tool_use_id
-        WHERE tu.timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
-        GROUP BY tu.tool_name
-        HAVING count(*) >= {min_occ} AND error_pct > 20
-        ORDER BY error_pct DESC
-        LIMIT 10;
-    """)
-    if not rows:
-        return None
-    tools = [
-        f"{r['tool_name']} ({r['error_pct']}% errors, {r['total']} calls)" for r in rows
-    ]
-    return {
-        "id": "high-error-tools",
-        "event": "PostToolUse",
-        "priority": "medium",
-        "title": "Add validation for error-prone tools",
-        "description": (
-            f"Found {len(rows)} tools with >20% error rate. "
-            f"PostToolUse hooks can catch common failure patterns."
-        ),
-        "examples": tools,
-        "hook_type": "quality",
-        "suggested_action": "warn",
-    }
-
-
-def check_permission_friction(days, min_occ):
-    """Detect frequent permission denials."""
-    rows = query(f"""
-        SELECT
-            substr(content, 1, 100) AS denial,
-            count(*) AS denials
-        FROM permission_denials
-        WHERE timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
-        GROUP BY denial
-        HAVING count(*) >= {min_occ}
-        ORDER BY denials DESC
-        LIMIT 10;
-    """)
-    if not rows:
-        return None
-    total = sum(int(r["denials"]) for r in rows)
-    return {
-        "id": "permission-friction",
-        "event": "PreToolUse",
-        "priority": "low",
-        "title": "Reduce permission friction",
-        "description": (
-            f"Found {total} permission denials across {len(rows)} patterns. "
-            f"Consider adding allowlist entries or a PreToolUse hook that "
-            f"catches these before they hit the permission prompt."
-        ),
-        "examples": [r["denial"][:80] for r in rows],
-        "hook_type": "workflow",
-        "suggested_action": "info",
-    }
-
-
-def check_missing_quality_hooks(days):
-    """Detect if Stop hooks are underused."""
-    hook_rows = query(f"""
-        SELECT count(*) AS cnt
-        FROM stop_hooks
-        WHERE timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY;
-    """)
-    stop_rows = query(f"""
-        SELECT count(*) AS cnt
-        FROM stop_events
-        WHERE timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY;
-    """)
-    hook_count = int(hook_rows[0]["cnt"]) if hook_rows else 0
-    stop_count = int(stop_rows[0]["cnt"]) if stop_rows else 0
-
-    if stop_count == 0:
-        return None
-
-    ratio = hook_count / stop_count if stop_count > 0 else 0
-    if ratio > 0.5:
-        return None
-
-    return {
-        "id": "missing-quality-hooks",
-        "event": "Stop",
-        "priority": "high",
-        "title": "Add Stop hooks for quality enforcement",
-        "description": (
-            f"Only {hook_count}/{stop_count} stops "
-            f"({ratio * 100:.0f}%) triggered quality hooks. "
-            f"Stop hooks catch hedging, premature completion, and "
-            f"unverified claims before they reach you."
-        ),
-        "examples": [],
-        "hook_type": "quality",
-        "suggested_action": "block",
-    }
-
-
-def check_hook_failures(days, min_occ):
-    """Detect hooks that frequently error."""
-    error_rows = query(f"""
-        SELECT
-            json_extract_string(err_element, '$') AS err,
-            count(*) AS cnt
-        FROM stop_hooks,
-             unnest(json_extract(hookErrors, '$[*]')) AS t(err_element)
-        WHERE timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
-          AND hookErrors IS NOT NULL
-          AND json_array_length(hookErrors) > 0
-        GROUP BY err
-        HAVING count(*) >= {min_occ}
-        ORDER BY cnt DESC
-        LIMIT 5;
-    """)
-    if not error_rows:
-        return None
-    return {
-        "id": "hook-failures",
-        "event": "Stop",
-        "priority": "high",
-        "title": "Fix failing hooks",
-        "description": (
-            f"Found {len(error_rows)} hook error patterns. "
-            f"Broken hooks silently pass, defeating enforcement."
-        ),
-        "examples": [r["err"][:100] for r in error_rows],
-        "hook_type": "maintenance",
-        "suggested_action": "fix",
-    }
-
-
-def check_code_write_volume(days, min_occ):
-    """Detect languages with high code write volume."""
-    rows = query(f"""
-        SELECT
-            CASE
-                WHEN file_path LIKE '%.py' THEN 'Python'
-                WHEN file_path LIKE '%.ts' OR file_path LIKE '%.tsx' THEN 'TypeScript'
-                WHEN file_path LIKE '%.js' OR file_path LIKE '%.jsx' THEN 'JavaScript'
-                WHEN file_path LIKE '%.rs' THEN 'Rust'
-                WHEN file_path LIKE '%.go' THEN 'Go'
-            END AS lang,
-            count(*) AS writes
-        FROM tool_uses
-        WHERE tool_name IN ('Edit', 'Write')
-          AND file_path IS NOT NULL
-          AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
-        GROUP BY lang
-        HAVING lang IS NOT NULL AND count(*) >= {min_occ}
-        ORDER BY writes DESC;
-    """)
-    if not rows:
-        return None
-    langs = [f"{r['lang']} ({r['writes']} writes)" for r in rows]
-    total = sum(int(r["writes"]) for r in rows)
-    return {
-        "id": "auto-format",
-        "event": "PostToolUse",
-        "priority": "low",
-        "title": "Auto-format on file writes",
-        "description": (
-            f"Found {total} code file writes across {len(rows)} languages. "
-            f"A PostToolUse hook can auto-run formatters after Edit/Write."
-        ),
-        "examples": langs,
-        "hook_type": "workflow",
-        "suggested_action": "info",
-    }
-
-
-def check_repeated_bash_patterns(days, min_occ):
-    """Find frequently repeated bash commands that could be hooks."""
-    rows = query(f"""
-        SELECT
-            bash_cmd AS cmd,
-            count(*) AS uses
-        FROM tool_uses
-        WHERE tool_name = 'Bash'
-          AND bash_cmd IS NOT NULL
-          AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
-          AND length(bash_cmd) > 20
-        GROUP BY bash_cmd
-        HAVING count(*) >= {min_occ * 3}
-        ORDER BY uses DESC
-        LIMIT 10;
-    """)
-    if not rows:
-        return None
-    cmds = [f"{r['cmd'][:80]} ({r['uses']}x)" for r in rows]
-    return {
-        "id": "repeated-commands",
-        "event": "SessionStart",
-        "priority": "low",
-        "title": "Automate repeated commands",
-        "description": (
-            f"Found {len(rows)} bash commands repeated {min_occ * 3}+ times. "
-            f"Consider automating via SessionStart or UserPromptSubmit hooks."
-        ),
-        "examples": cmds,
-        "hook_type": "workflow",
-        "suggested_action": "info",
-    }
-
-
-def check_correction_patterns(days, min_occ):
-    """Mine user messages that correct Claude's behavior — SLM rule candidates."""
-    rows = query(f"""
-        SELECT
-            substr(message::VARCHAR, 1, 150) AS user_msg,
-            count(*) AS occurrences
-        FROM raw_entries
-        WHERE type = 'user'
-          AND userType = 'external'
-          AND length(message::VARCHAR) < 200
-          AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
-          AND typeof(message) = 'VARCHAR'
-          AND (message::VARCHAR ILIKE '%no,%'
-               OR message::VARCHAR ILIKE '%wrong%'
-               OR message::VARCHAR ILIKE '%that''s not%'
-               OR message::VARCHAR ILIKE '%stop %doing%'
-               OR message::VARCHAR ILIKE '%I said%'
-               OR message::VARCHAR ILIKE '%not what I%')
-        GROUP BY user_msg
-        HAVING count(*) >= {min_occ}
-        ORDER BY occurrences DESC
-        LIMIT 10;
-    """)
-    if not rows:
-        return None
-    total = sum(int(r["occurrences"]) for r in rows)
-    examples = [r["user_msg"][:100] for r in rows]
-    return {
-        "id": "correction-patterns",
-        "event": "Stop",
-        "priority": "medium",
-        "title": "User correction patterns — SLM rule candidates",
-        "description": (
-            f"Found {total} user corrections across {len(rows)} patterns "
-            f"in the last {days} days. Each repeated correction is a "
-            f"candidate SLM rule."
-        ),
-        "examples": examples,
-        "hook_type": "slm-rule",
-        "suggested_action": "warn",
-    }
-
-
-def check_retry_loops(days, min_occ):
-    """Find tools called repeatedly on the same file with errors between."""
-    rows = query(f"""
-        WITH sequenced AS (
-            SELECT
-                tu.sessionId,
-                tu.tool_name,
-                tu.file_path,
-                tu.timestamp,
-                tr.is_error,
-                LAG(tr.is_error) OVER (
-                    PARTITION BY tu.sessionId, tu.file_path
-                    ORDER BY tu.timestamp
-                ) AS prev_error,
-                LAG(tu.tool_name) OVER (
-                    PARTITION BY tu.sessionId, tu.file_path
-                    ORDER BY tu.timestamp
-                ) AS prev_tool
-            FROM tool_uses tu
-            JOIN tool_results tr ON tu.tool_use_id = tr.tool_use_id
-            WHERE tu.file_path IS NOT NULL
-              AND tu.timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
-        )
-        SELECT
-            tool_name,
-            count(*) AS retry_count
-        FROM sequenced
-        WHERE prev_error = 'true'
-          AND tool_name = prev_tool
-        GROUP BY tool_name
-        HAVING count(*) >= {min_occ}
-        ORDER BY retry_count DESC
-        LIMIT 10;
-    """)
-    if not rows:
-        return None
-    total = sum(int(r["retry_count"]) for r in rows)
-    examples = [f"{r['tool_name']} ({r['retry_count']} retries)" for r in rows]
-    return {
-        "id": "retry-loops",
-        "event": "PostToolUse",
-        "priority": "medium",
-        "title": "Error-retry loops — guessing instead of reading errors",
-        "description": (
-            f"Found {total} error→retry chains across {len(rows)} tools "
-            f"in the last {days} days. A PostToolUse rule can catch "
-            f"repeated failures on the same file."
-        ),
-        "examples": examples,
-        "hook_type": "slm-rule",
-        "suggested_action": "warn",
-    }
-
-
-def check_permission_tool_waste(days, min_occ):
-    """Find tools that hit permission errors, burning turns a PreToolUse hook could intercept."""
-    rows = query(f"""
-        WITH perm_failures AS (
-            SELECT
-                tu.tool_name,
-                tu.sessionId,
-                tu.timestamp,
-                tu.tool_use_id
-            FROM tool_uses tu
-            JOIN tool_results tr ON tu.tool_use_id = tr.tool_use_id
-            WHERE tr.is_error = 'true'
-              AND tu.timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
-              AND (tr.content ILIKE '%permission denied%'
-                   OR tr.content ILIKE '%permission%' AND tr.content ILIKE '%denied%'
-                   OR tr.content ILIKE '%not allowed%' AND tr.content ILIKE '%permission%')
-        )
-        SELECT
-            tool_name,
-            count(*) AS failures
-        FROM perm_failures
-        GROUP BY tool_name
-        HAVING count(*) >= {min_occ}
-        ORDER BY failures DESC
-        LIMIT 10;
-    """)
-    if not rows:
-        return None
-    total = sum(int(r["failures"]) for r in rows)
-    examples = [f"{r['tool_name']} ({r['failures']} permission failures)" for r in rows]
-    return {
-        "id": "permission-tool-waste",
-        "event": "PreToolUse",
-        "priority": "low",
-        "title": "Tools wasting turns on permission walls",
-        "description": (
-            f"Found {total} permission-related failures across "
-            f"{len(rows)} tools in the last {days} days. "
-            f"A PreToolUse hook can intercept before the turn is burned."
-        ),
-        "examples": examples,
-        "hook_type": "workflow",
-        "suggested_action": "warn",
-    }
+    for i, s in enumerate(suggestions, 1):
+        icon = {"high": "!!!", "medium": " ! ", "low": " . "}
+        pri = icon.get(s["priority"], "   ")
+        print(f"[{pri}] {i}. {s['title']}")
+        print(f"      Event: {s['event']}  |  Type: {s['hook_type']}")
+        print(f"      {s['description']}")
+        if s["examples"]:
+            print("      Examples:")
+            for ex in s["examples"][:5]:
+                print(f"        - {ex}")
+        print()
 
 
 def main():
@@ -512,60 +105,21 @@ def main():
         print(f"Expected: {DB_PATH}")
         sys.exit(1)
 
-    analyzers = [
-        check_dangerous_bash,
-        check_tool_misuse,
-        check_high_error_tools,
-        check_permission_friction,
-        check_missing_quality_hooks,
-        check_hook_failures,
-        check_code_write_volume,
-        check_repeated_bash_patterns,
-        check_correction_patterns,
-        check_retry_loops,
-        check_permission_tool_waste,
-    ]
-
     suggestions = []
-    for analyzer in analyzers:
+    for analyzer in ANALYZERS:
         try:
-            # check_missing_quality_hooks only takes days
-            if analyzer == check_missing_quality_hooks:
-                result = analyzer(days)
-            else:
-                result = analyzer(days, min_occ)
+            result = analyzer(days, min_occ)
             if result:
                 suggestions.append(result)
         except Exception as e:
             print(f"WARNING: {analyzer.__name__} failed: {e}", file=sys.stderr)
 
-    # Sort by priority
-    priority_order = {"high": 0, "medium": 1, "low": 2}
-    suggestions.sort(key=lambda s: priority_order.get(s["priority"], 3))
+    suggestions.sort(key=lambda s: PRIORITY_ORDER.get(s["priority"], 3))
 
     if as_json:
         print(json.dumps(suggestions, indent=2))
     else:
-        if not suggestions:
-            print("No hook suggestions found. Your setup looks solid!")
-            return
-
-        print(f"\n{'=' * 60}")
-        print(f"  HOOK SUGGESTIONS  ({len(suggestions)} found)")
-        print(f"  Based on {days} days of session data")
-        print(f"{'=' * 60}\n")
-
-        for i, s in enumerate(suggestions, 1):
-            icon = {"high": "!!!", "medium": " ! ", "low": " . "}
-            pri = icon.get(s["priority"], "   ")
-            print(f"[{pri}] {i}. {s['title']}")
-            print(f"      Event: {s['event']}  |  Type: {s['hook_type']}")
-            print(f"      {s['description']}")
-            if s["examples"]:
-                print("      Examples:")
-                for ex in s["examples"][:5]:
-                    print(f"        - {ex}")
-            print()
+        _print_suggestions(suggestions, days)
 
 
 if __name__ == "__main__":

--- a/skills/hook-suggester/scripts/analyzers.py
+++ b/skills/hook-suggester/scripts/analyzers.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+import json
+import os
+import subprocess
+import sys
+
+DB_PATH = os.path.expanduser("~/.claude/analytics/sessions.duckdb")
+DEFAULT_DAYS = 14
+DEFAULT_MIN_OCCURRENCES = 3
+
+
+def query(sql):
+    """Run a DuckDB query and return parsed JSON results."""
+    try:
+        result = subprocess.run(
+            ["duckdb", DB_PATH, "-json", "-c", sql],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        print("ERROR: duckdb not found on PATH", file=sys.stderr)
+        sys.exit(1)
+    if result.returncode != 0:
+        print(
+            f"WARNING: duckdb query failed (exit {result.returncode})",
+            file=sys.stderr,
+        )
+        if result.stderr:
+            print(f"  {result.stderr.strip()[:200]}", file=sys.stderr)
+        return []
+    raw = result.stdout.strip()
+    if not raw or raw == "[{]":
+        return []
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"WARNING: Failed to parse DuckDB JSON output: {e}", file=sys.stderr)
+        return []
+
+
+def check_dangerous_bash(days, min_occ):
+    """Detect dangerous bash commands that should be guarded."""
+    rows = query(f"""
+        SELECT
+            bash_cmd,
+            count(*) AS uses
+        FROM tool_uses
+        WHERE tool_name = 'Bash'
+          AND bash_cmd IS NOT NULL
+          AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+          AND (
+            bash_cmd LIKE '%rm -rf%'
+            OR (bash_cmd LIKE '%git push%--force%'
+                AND bash_cmd NOT LIKE '%--force-with-lease%')
+            OR bash_cmd LIKE '%DROP %'
+            OR bash_cmd LIKE '%> /dev/%'
+            OR bash_cmd LIKE '%chmod 777%'
+            OR bash_cmd LIKE '%--no-verify%'
+          )
+        GROUP BY bash_cmd
+        HAVING count(*) >= {min_occ}
+        ORDER BY uses DESC
+        LIMIT 10;
+    """)
+    if not rows:
+        return None
+    examples = [r["bash_cmd"][:80] for r in rows]
+    total = sum(int(r["uses"]) for r in rows)
+    return {
+        "id": "dangerous-bash",
+        "event": "PreToolUse",
+        "priority": "high",
+        "title": "Guard dangerous bash commands",
+        "description": (
+            f"Found {total} uses of dangerous bash patterns across "
+            f"{len(rows)} commands in the last {days} days."
+        ),
+        "examples": examples,
+        "hook_type": "safety",
+        "suggested_action": "block",
+    }
+
+
+def check_tool_misuse(days, min_occ):
+    """Detect bash used for tasks that have dedicated tools."""
+    rows = query(f"""
+        SELECT
+            CASE
+                WHEN bash_cmd LIKE 'cat %' OR bash_cmd LIKE 'head %'
+                    OR bash_cmd LIKE 'tail %' THEN 'cat/head/tail → Read tool'
+                WHEN bash_cmd LIKE 'grep %' OR bash_cmd LIKE 'rg %'
+                    OR bash_cmd LIKE 'egrep %' THEN 'grep/rg → Grep tool'
+                WHEN bash_cmd LIKE 'find %' OR bash_cmd LIKE 'fd %'
+                    THEN 'find/fd → Glob tool'
+                WHEN bash_cmd LIKE 'sed %' OR bash_cmd LIKE '%sed -i%'
+                    THEN 'sed → Edit tool'
+                WHEN bash_cmd LIKE 'echo %>>%' OR bash_cmd LIKE 'echo %>%'
+                    OR (bash_cmd LIKE 'cat %' AND bash_cmd LIKE '%>%')
+                    THEN 'echo/cat redirect → Write tool'
+            END AS misuse_type,
+            count(*) AS uses
+        FROM tool_uses
+        WHERE tool_name = 'Bash'
+          AND bash_cmd IS NOT NULL
+          AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+        GROUP BY misuse_type
+        HAVING misuse_type IS NOT NULL AND count(*) >= {min_occ}
+        ORDER BY uses DESC;
+    """)
+    if not rows:
+        return None
+    total = sum(int(r["uses"]) for r in rows)
+    misuses = [f"{r['misuse_type']} ({r['uses']}x)" for r in rows]
+    return {
+        "id": "tool-misuse",
+        "event": "PreToolUse",
+        "priority": "medium",
+        "title": "Redirect bash to dedicated tools",
+        "description": (
+            f"Found {total} bash calls that should use dedicated tools. "
+            f"A PreToolUse hook can warn Claude to use the right tool."
+        ),
+        "examples": misuses,
+        "hook_type": "quality",
+        "suggested_action": "warn",
+    }
+
+
+def check_high_error_tools(days, min_occ):
+    """Detect tools with high error rates."""
+    rows = query(f"""
+        SELECT
+            tu.tool_name,
+            count(*) AS total,
+            sum(CASE WHEN tr.is_error = 'true' THEN 1 ELSE 0 END) AS errors,
+            round(
+                sum(CASE WHEN tr.is_error = 'true' THEN 1 ELSE 0 END)
+                * 100.0 / count(*), 1
+            ) AS error_pct
+        FROM tool_uses tu
+        JOIN tool_results tr ON tu.tool_use_id = tr.tool_use_id
+        WHERE tu.timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+        GROUP BY tu.tool_name
+        HAVING count(*) >= {min_occ} AND error_pct > 20
+        ORDER BY error_pct DESC
+        LIMIT 10;
+    """)
+    if not rows:
+        return None
+    tools = [
+        f"{r['tool_name']} ({r['error_pct']}% errors, {r['total']} calls)" for r in rows
+    ]
+    return {
+        "id": "high-error-tools",
+        "event": "PostToolUse",
+        "priority": "medium",
+        "title": "Add validation for error-prone tools",
+        "description": (
+            f"Found {len(rows)} tools with >20% error rate. "
+            f"PostToolUse hooks can catch common failure patterns."
+        ),
+        "examples": tools,
+        "hook_type": "quality",
+        "suggested_action": "warn",
+    }
+
+
+def check_permission_friction(days, min_occ):
+    """Detect frequent permission denials."""
+    rows = query(f"""
+        SELECT
+            substr(content, 1, 100) AS denial,
+            count(*) AS denials
+        FROM permission_denials
+        WHERE timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+        GROUP BY denial
+        HAVING count(*) >= {min_occ}
+        ORDER BY denials DESC
+        LIMIT 10;
+    """)
+    if not rows:
+        return None
+    total = sum(int(r["denials"]) for r in rows)
+    return {
+        "id": "permission-friction",
+        "event": "PreToolUse",
+        "priority": "low",
+        "title": "Reduce permission friction",
+        "description": (
+            f"Found {total} permission denials across {len(rows)} patterns. "
+            f"Consider adding allowlist entries or a PreToolUse hook that "
+            f"catches these before they hit the permission prompt."
+        ),
+        "examples": [r["denial"][:80] for r in rows],
+        "hook_type": "workflow",
+        "suggested_action": "info",
+    }
+
+
+def check_missing_quality_hooks(days, min_occ=None):  # noqa: ARG001
+    """Detect if Stop hooks are underused."""
+    hook_rows = query(f"""
+        SELECT count(*) AS cnt
+        FROM stop_hooks
+        WHERE timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY;
+    """)
+    stop_rows = query(f"""
+        SELECT count(*) AS cnt
+        FROM stop_events
+        WHERE timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY;
+    """)
+    hook_count = int(hook_rows[0]["cnt"]) if hook_rows else 0
+    stop_count = int(stop_rows[0]["cnt"]) if stop_rows else 0
+
+    if stop_count == 0:
+        return None
+
+    ratio = hook_count / stop_count if stop_count > 0 else 0
+    if ratio > 0.5:
+        return None
+
+    return {
+        "id": "missing-quality-hooks",
+        "event": "Stop",
+        "priority": "high",
+        "title": "Add Stop hooks for quality enforcement",
+        "description": (
+            f"Only {hook_count}/{stop_count} stops "
+            f"({ratio * 100:.0f}%) triggered quality hooks. "
+            f"Stop hooks catch hedging, premature completion, and "
+            f"unverified claims before they reach you."
+        ),
+        "examples": [],
+        "hook_type": "quality",
+        "suggested_action": "block",
+    }
+
+
+def check_hook_failures(days, min_occ):
+    """Detect hooks that frequently error."""
+    error_rows = query(f"""
+        SELECT
+            json_extract_string(err_element, '$') AS err,
+            count(*) AS cnt
+        FROM stop_hooks,
+             unnest(json_extract(hookErrors, '$[*]')) AS t(err_element)
+        WHERE timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+          AND hookErrors IS NOT NULL
+          AND json_array_length(hookErrors) > 0
+        GROUP BY err
+        HAVING count(*) >= {min_occ}
+        ORDER BY cnt DESC
+        LIMIT 5;
+    """)
+    if not error_rows:
+        return None
+    return {
+        "id": "hook-failures",
+        "event": "Stop",
+        "priority": "high",
+        "title": "Fix failing hooks",
+        "description": (
+            f"Found {len(error_rows)} hook error patterns. "
+            f"Broken hooks silently pass, defeating enforcement."
+        ),
+        "examples": [r["err"][:100] for r in error_rows],
+        "hook_type": "maintenance",
+        "suggested_action": "fix",
+    }
+
+
+def check_code_write_volume(days, min_occ):
+    """Detect languages with high code write volume."""
+    rows = query(f"""
+        SELECT
+            CASE
+                WHEN file_path LIKE '%.py' THEN 'Python'
+                WHEN file_path LIKE '%.ts' OR file_path LIKE '%.tsx' THEN 'TypeScript'
+                WHEN file_path LIKE '%.js' OR file_path LIKE '%.jsx' THEN 'JavaScript'
+                WHEN file_path LIKE '%.rs' THEN 'Rust'
+                WHEN file_path LIKE '%.go' THEN 'Go'
+            END AS lang,
+            count(*) AS writes
+        FROM tool_uses
+        WHERE tool_name IN ('Edit', 'Write')
+          AND file_path IS NOT NULL
+          AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+        GROUP BY lang
+        HAVING lang IS NOT NULL AND count(*) >= {min_occ}
+        ORDER BY writes DESC;
+    """)
+    if not rows:
+        return None
+    langs = [f"{r['lang']} ({r['writes']} writes)" for r in rows]
+    total = sum(int(r["writes"]) for r in rows)
+    return {
+        "id": "auto-format",
+        "event": "PostToolUse",
+        "priority": "low",
+        "title": "Auto-format on file writes",
+        "description": (
+            f"Found {total} code file writes across {len(rows)} languages. "
+            f"A PostToolUse hook can auto-run formatters after Edit/Write."
+        ),
+        "examples": langs,
+        "hook_type": "workflow",
+        "suggested_action": "info",
+    }
+
+
+def check_repeated_bash_patterns(days, min_occ):
+    """Find frequently repeated bash commands that could be hooks."""
+    rows = query(f"""
+        SELECT
+            bash_cmd AS cmd,
+            count(*) AS uses
+        FROM tool_uses
+        WHERE tool_name = 'Bash'
+          AND bash_cmd IS NOT NULL
+          AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+          AND length(bash_cmd) > 20
+        GROUP BY bash_cmd
+        HAVING count(*) >= {min_occ * 3}
+        ORDER BY uses DESC
+        LIMIT 10;
+    """)
+    if not rows:
+        return None
+    cmds = [f"{r['cmd'][:80]} ({r['uses']}x)" for r in rows]
+    return {
+        "id": "repeated-commands",
+        "event": "SessionStart",
+        "priority": "low",
+        "title": "Automate repeated commands",
+        "description": (
+            f"Found {len(rows)} bash commands repeated {min_occ * 3}+ times. "
+            f"Consider automating via SessionStart or UserPromptSubmit hooks."
+        ),
+        "examples": cmds,
+        "hook_type": "workflow",
+        "suggested_action": "info",
+    }
+
+
+def check_correction_patterns(days, min_occ):
+    """Mine user messages that correct Claude's behavior — SLM rule candidates."""
+    rows = query(f"""
+        SELECT
+            substr(message::VARCHAR, 1, 150) AS user_msg,
+            count(*) AS occurrences
+        FROM raw_entries
+        WHERE type = 'user'
+          AND userType = 'external'
+          AND length(message::VARCHAR) < 200
+          AND timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+          AND typeof(message) = 'VARCHAR'
+          AND (message::VARCHAR ILIKE '%no,%'
+               OR message::VARCHAR ILIKE '%wrong%'
+               OR message::VARCHAR ILIKE '%that''s not%'
+               OR message::VARCHAR ILIKE '%stop %doing%'
+               OR message::VARCHAR ILIKE '%I said%'
+               OR message::VARCHAR ILIKE '%not what I%')
+        GROUP BY user_msg
+        HAVING count(*) >= {min_occ}
+        ORDER BY occurrences DESC
+        LIMIT 10;
+    """)
+    if not rows:
+        return None
+    total = sum(int(r["occurrences"]) for r in rows)
+    examples = [r["user_msg"][:100] for r in rows]
+    return {
+        "id": "correction-patterns",
+        "event": "Stop",
+        "priority": "medium",
+        "title": "User correction patterns — SLM rule candidates",
+        "description": (
+            f"Found {total} user corrections across {len(rows)} patterns "
+            f"in the last {days} days. Each repeated correction is a "
+            f"candidate SLM rule."
+        ),
+        "examples": examples,
+        "hook_type": "slm-rule",
+        "suggested_action": "warn",
+    }
+
+
+def check_retry_loops(days, min_occ):
+    """Find tools called repeatedly on the same file with errors between."""
+    rows = query(f"""
+        WITH sequenced AS (
+            SELECT
+                tu.sessionId,
+                tu.tool_name,
+                tu.file_path,
+                tu.timestamp,
+                tr.is_error,
+                LAG(tr.is_error) OVER (
+                    PARTITION BY tu.sessionId, tu.file_path
+                    ORDER BY tu.timestamp
+                ) AS prev_error,
+                LAG(tu.tool_name) OVER (
+                    PARTITION BY tu.sessionId, tu.file_path
+                    ORDER BY tu.timestamp
+                ) AS prev_tool
+            FROM tool_uses tu
+            JOIN tool_results tr ON tu.tool_use_id = tr.tool_use_id
+            WHERE tu.file_path IS NOT NULL
+              AND tu.timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+        )
+        SELECT
+            tool_name,
+            count(*) AS retry_count
+        FROM sequenced
+        WHERE prev_error = 'true'
+          AND tool_name = prev_tool
+        GROUP BY tool_name
+        HAVING count(*) >= {min_occ}
+        ORDER BY retry_count DESC
+        LIMIT 10;
+    """)
+    if not rows:
+        return None
+    total = sum(int(r["retry_count"]) for r in rows)
+    examples = [f"{r['tool_name']} ({r['retry_count']} retries)" for r in rows]
+    return {
+        "id": "retry-loops",
+        "event": "PostToolUse",
+        "priority": "medium",
+        "title": "Error-retry loops — guessing instead of reading errors",
+        "description": (
+            f"Found {total} error→retry chains across {len(rows)} tools "
+            f"in the last {days} days. A PostToolUse rule can catch "
+            f"repeated failures on the same file."
+        ),
+        "examples": examples,
+        "hook_type": "slm-rule",
+        "suggested_action": "warn",
+    }
+
+
+def check_permission_tool_waste(days, min_occ):
+    """Find tools that hit permission errors, burning turns a PreToolUse hook could intercept."""
+    rows = query(f"""
+        WITH perm_failures AS (
+            SELECT
+                tu.tool_name,
+                tu.sessionId,
+                tu.timestamp,
+                tu.tool_use_id
+            FROM tool_uses tu
+            JOIN tool_results tr ON tu.tool_use_id = tr.tool_use_id
+            WHERE tr.is_error = 'true'
+              AND tu.timestamp::DATE >= CURRENT_DATE - INTERVAL '{days}' DAY
+              AND (tr.content ILIKE '%permission denied%'
+                   OR tr.content ILIKE '%permission%' AND tr.content ILIKE '%denied%'
+                   OR tr.content ILIKE '%not allowed%' AND tr.content ILIKE '%permission%')
+        )
+        SELECT
+            tool_name,
+            count(*) AS failures
+        FROM perm_failures
+        GROUP BY tool_name
+        HAVING count(*) >= {min_occ}
+        ORDER BY failures DESC
+        LIMIT 10;
+    """)
+    if not rows:
+        return None
+    total = sum(int(r["failures"]) for r in rows)
+    examples = [f"{r['tool_name']} ({r['failures']} permission failures)" for r in rows]
+    return {
+        "id": "permission-tool-waste",
+        "event": "PreToolUse",
+        "priority": "low",
+        "title": "Tools wasting turns on permission walls",
+        "description": (
+            f"Found {total} permission-related failures across "
+            f"{len(rows)} tools in the last {days} days. "
+            f"A PreToolUse hook can intercept before the turn is burned."
+        ),
+        "examples": examples,
+        "hook_type": "workflow",
+        "suggested_action": "warn",
+    }

--- a/skills/rule-admin/SKILL.md
+++ b/skills/rule-admin/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: vaudeville:rule-admin
+description: >
+  Promote, demote, or edit vaudeville rule tiers. Use when the user says
+  "promote rule", "demote rule", "move rule to warn", "move rule to block",
+  "rule-admin", "change tier", "promote to warn", "promote to block",
+  "demote to shadow", "delete rule", "enable rule", "disable rule",
+  or invokes /rule-admin. Typically used after /tier-advisor produces
+  recommendations. Do NOT use for analysis — use /tier-advisor for that.
+model: sonnet
+allowed-tools: Read, Edit, Write, Glob, Bash(cp:*), Bash(rm:*), Bash(ls:*)
+---
+
+# rule-admin
+
+Applies tier changes to vaudeville rule YAML files. Handles the mechanical
+steps of promoting, demoting, or deleting rules after /tier-advisor has
+produced recommendations.
+
+## Input
+
+A rule name and action. If not provided, ask. Valid actions:
+
+| Action | What it does |
+|--------|-------------|
+| `promote-to-warn` | Set `tier: warn` in `rules_dev/`, copy to `~/.vaudeville/rules/` |
+| `promote-to-block` | Set `tier: block` in `rules_dev/`, copy to `~/.vaudeville/rules/` |
+| `demote-to-shadow` | Set `tier: shadow` in `rules_dev/`, remove from `~/.vaudeville/rules/` |
+| `delete` | Remove from both `rules_dev/` and `~/.vaudeville/rules/` (confirm first) |
+
+## Steps
+
+### 1. Locate the rule
+
+Find the rule YAML file. Search in order:
+1. `${CLAUDE_PLUGIN_ROOT}/rules_dev/<rule-name>.yaml`
+2. `${CLAUDE_PLUGIN_ROOT}/rules/<rule-name>.yaml`
+3. `~/.vaudeville/rules/<rule-name>.yaml`
+
+If not found, tell the user and stop.
+
+### 2. Read current state
+
+Read the rule file and show the user:
+- Current `tier:` value (or "none" if field is absent)
+- Current `threshold:` value
+- Rule `event:` type
+
+### 3. Apply the change
+
+For **promote-to-warn**:
+1. Set `tier: warn` in the rule YAML
+2. Copy the file to `~/.vaudeville/rules/<rule-name>.yaml`
+
+For **promote-to-block**:
+1. Set `tier: block` in the rule YAML
+2. Copy the file to `~/.vaudeville/rules/<rule-name>.yaml`
+
+For **demote-to-shadow**:
+1. Set `tier: shadow` in the rule YAML
+2. Remove `~/.vaudeville/rules/<rule-name>.yaml` if it exists
+
+For **delete**:
+1. Confirm with the user before proceeding
+2. Remove the rule file from `rules_dev/` and `~/.vaudeville/rules/`
+
+### 4. Confirm
+
+Show the user what changed and where.
+
+## Gotchas
+
+- Always read the YAML before editing — rules may have comments or
+  non-standard field ordering that blind writes would destroy
+- The `~/.vaudeville/rules/` directory may not exist yet — create it
+  if needed when copying
+- Delete is destructive — always confirm before removing files
+- Some rules exist only in `~/.vaudeville/rules/` (user-created),
+  not in `rules_dev/` — handle both locations

--- a/skills/tier-advisor/SKILL.md
+++ b/skills/tier-advisor/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: vaudeville:tier-advisor
+description: >
+  Analyze vaudeville warn logs and eval data to recommend rule tier promotions
+  and demotions. Use when the user says "promote rule", "tier advisor",
+  "warn log analysis", "should we enforce", "demote rule", "rule metrics",
+  "tier recommendation", or invokes /tier-advisor.
+model: sonnet
+context: fork
+allowed-tools: Bash(uv:*), Bash(duckdb:*), Bash(python3:*), Read, Glob
+---
+
+# tier-advisor
+
+Reads `~/.vaudeville/logs/` JSONL files, ingests into DuckDB, computes
+per-rule metrics with user-agreement proxy, and outputs promotion/demotion
+recommendations.
+
+## Steps
+
+### 1. Ingest
+
+Run the ingest script to load fresh log data:
+
+```bash
+uv run python3 ${CLAUDE_PLUGIN_ROOT}/skills/tier-advisor/scripts/ingest.py
+```
+
+This reads `~/.vaudeville/logs/events.jsonl` and `violations.jsonl`,
+deduplicates, and upserts into `~/.claude/analytics/sessions.duckdb`
+as table `vaudeville_verdicts`.
+
+### 2. Analyze
+
+Run the analysis script to compute per-rule metrics:
+
+```bash
+uv run python3 ${CLAUDE_PLUGIN_ROOT}/skills/tier-advisor/scripts/analyze.py
+```
+
+This JOINs `vaudeville_verdicts` against `raw_entries` to compute the
+agreement proxy (next user message after a violation indicates whether the
+user agreed or disagreed with the verdict).
+
+### 3. Report
+
+Run the report script to produce grouped recommendations:
+
+```bash
+uv run python3 ${CLAUDE_PLUGIN_ROOT}/skills/tier-advisor/scripts/report.py
+```
+
+Output is markdown grouped by recommendation: promote-to-block,
+promote-to-warn, demote, insufficient-data.
+
+### 4. Present
+
+Show the report to the user. If the user confirms a promotion or demotion:
+- Edit the rule's `tier:` field in `rules_dev/<rule>.yaml`
+- For promotions to warn: copy rule to `~/.vaudeville/rules/<rule>.yaml`
+- For demotions to shadow: remove from `~/.vaudeville/rules/<rule>.yaml`
+
+## Thresholds
+
+| Transition | Min evals | Agreement | Violation rate | Confidence p50 |
+|------------|-----------|-----------|----------------|----------------|
+| shadow → warn | ≥50 | ≥70% | 2%–40% | — |
+| warn → block | ≥200 | ≥85% | 5%–30% | ≥0.7 |
+| warn → shadow | any | <50% | >60% | — |
+| delete candidate | shadow ≥14d | no improvement | — | — |

--- a/skills/tier-advisor/SKILL.md
+++ b/skills/tier-advisor/SKILL.md
@@ -4,7 +4,10 @@ description: >
   Analyze vaudeville warn logs and eval data to recommend rule tier promotions
   and demotions. Use when the user says "promote rule", "tier advisor",
   "warn log analysis", "should we enforce", "demote rule", "rule metrics",
-  "tier recommendation", or invokes /tier-advisor.
+  "tier recommendation", "warn to block", "shadow to warn", "rule performance",
+  "check rule health", "evaluate rule tiers", "promotion analysis",
+  or invokes /tier-advisor. Do NOT use for editing rule files — use
+  /rule-admin for that.
 model: sonnet
 context: fork
 allowed-tools: Bash(uv:*), Bash(duckdb:*), Bash(python3:*), Read, Glob
@@ -27,7 +30,7 @@ uv run python3 ${CLAUDE_PLUGIN_ROOT}/skills/tier-advisor/scripts/ingest.py
 ```
 
 This reads `~/.vaudeville/logs/events.jsonl` and `violations.jsonl`,
-deduplicates, and upserts into `~/.claude/analytics/sessions.duckdb`
+deduplicates, and replaces table contents in `~/.claude/analytics/sessions.duckdb`
 as table `vaudeville_verdicts`.
 
 ### 2. Analyze
@@ -55,10 +58,19 @@ promote-to-warn, demote, insufficient-data.
 
 ### 4. Present
 
-Show the report to the user. If the user confirms a promotion or demotion:
-- Edit the rule's `tier:` field in `rules_dev/<rule>.yaml`
-- For promotions to warn: copy rule to `~/.vaudeville/rules/<rule>.yaml`
-- For demotions to shadow: remove from `~/.vaudeville/rules/<rule>.yaml`
+Show the report to the user. If the user wants to act on a recommendation,
+tell them to use `/rule-admin` to promote, demote, or edit rule tiers.
+
+## Gotchas
+
+- Agreement proxy is approximate — the next-message heuristic misclassifies
+  multi-turn corrections where the user responds several messages later
+- DuckDB `raw_entries` table may not exist if session-analytics hasn't been
+  ingested yet — analyze.py returns empty agreement data, not an error
+- Empty `~/.vaudeville/logs/` produces zero records from ingest.py (exit 1),
+  which is expected — tell the user to run some sessions first
+- Short keywords in agreement matching use word boundaries, but multi-word
+  phrases still use substring matching — "it's fine" matches inside longer text
 
 ## Thresholds
 

--- a/skills/tier-advisor/scripts/analyze.py
+++ b/skills/tier-advisor/scripts/analyze.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Compute per-rule metrics with user-agreement proxy for tier-advisor.
+
+Joins vaudeville_verdicts against raw_entries to find the next user message
+after each violation, then classifies user response as agreement, disagreement,
+or uncertain.
+
+Output: JSON array of per-rule metric objects to stdout.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+DB_PATH = os.path.expanduser("~/.claude/analytics/sessions.duckdb")
+
+CORRECTION_KEYWORDS = [
+    "no",
+    "wrong",
+    "that's not",
+    "that is not",
+    "incorrect",
+    "don't",
+    "stop",
+    "undo",
+    "revert",
+    "not what I",
+]
+
+ACK_KEYWORDS = [
+    "fixed",
+    "good catch",
+    "thanks",
+    "thank you",
+    "nice catch",
+    "right",
+    "agreed",
+    "yes",
+    "correct",
+]
+
+PUSHBACK_KEYWORDS = [
+    "no that's fine",
+    "ignore that",
+    "that's okay",
+    "it's fine",
+    "false positive",
+    "not a problem",
+    "skip that",
+    "leave it",
+]
+
+
+def query(sql: str) -> list[dict]:
+    try:
+        result = subprocess.run(
+            ["duckdb", DB_PATH, "-json", "-c", sql],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        print("ERROR: duckdb not found on PATH", file=sys.stderr)
+        sys.exit(1)
+    if result.returncode != 0:
+        print(f"ERROR: query failed: {result.stderr[:200]}", file=sys.stderr)
+        return []
+    raw = result.stdout.strip()
+    if not raw:
+        return []
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+
+
+def compute_rule_metrics() -> list[dict]:
+    sql = """
+    SELECT
+        rule,
+        count(*) as total_evals,
+        count(*) FILTER (WHERE verdict = 'violation') as violations,
+        count(*) FILTER (WHERE verdict = 'clean') as cleans,
+        avg(confidence) as avg_confidence,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY confidence) as p50_confidence,
+        min(ts) as first_seen,
+        max(ts) as last_seen
+    FROM vaudeville_verdicts
+    GROUP BY rule
+    ORDER BY total_evals DESC
+    """
+    return query(sql)
+
+
+def compute_agreement_proxy() -> dict[str, dict]:
+    """Approximate user agreement by checking next user text after violations.
+
+    Returns per-rule agreement stats: {rule: {agreed, disagreed, uncertain}}.
+    """
+    violations_sql = """
+    SELECT
+        v.ts,
+        v.rule,
+        v.input_snippet,
+        v.reason
+    FROM vaudeville_verdicts v
+    WHERE v.verdict = 'violation'
+    AND v.input_snippet != ''
+    ORDER BY v.ts
+    """
+    violations = query(violations_sql)
+    if not violations:
+        return {}
+
+    next_msg_sql = """
+    SELECT
+        r.timestamp as ts,
+        json_extract_string(r.message, '$.content[0].text') as user_text,
+        json_extract_string(r.message, '$.content[0].type') as content_type
+    FROM raw_entries r
+    WHERE r.type = 'user'
+    AND json_extract_string(r.message, '$.content[0].type') = 'text'
+    AND length(json_extract_string(r.message, '$.content[0].text')) > 0
+    ORDER BY r.timestamp
+    """
+    user_msgs = query(next_msg_sql)
+
+    user_msg_times = [(m["ts"], m.get("user_text", "")) for m in user_msgs if m["ts"]]
+
+    agreement: dict[str, dict[str, int]] = {}
+
+    for v in violations:
+        rule = v["rule"]
+        if rule not in agreement:
+            agreement[rule] = {"agreed": 0, "disagreed": 0, "uncertain": 0}
+
+        v_ts = v["ts"]
+        next_text = _find_next_user_message(v_ts, user_msg_times)
+        if not next_text:
+            agreement[rule]["uncertain"] += 1
+            continue
+
+        lower = next_text.lower()
+        if any(kw in lower for kw in PUSHBACK_KEYWORDS):
+            agreement[rule]["disagreed"] += 1
+        elif any(kw in lower for kw in ACK_KEYWORDS):
+            agreement[rule]["agreed"] += 1
+        elif any(kw in lower for kw in CORRECTION_KEYWORDS):
+            agreement[rule]["agreed"] += 1
+        else:
+            agreement[rule]["uncertain"] += 1
+
+    return agreement
+
+
+def _find_next_user_message(
+    violation_ts: str, user_msgs: list[tuple[str, str]]
+) -> str | None:
+    for ts, text in user_msgs:
+        if ts > violation_ts:
+            return text
+    return None
+
+
+def build_analysis() -> list[dict]:
+    metrics = compute_rule_metrics()
+    agreement = compute_agreement_proxy()
+
+    results = []
+    for m in metrics:
+        rule = m["rule"]
+        total = m["total_evals"]
+        violations = m["violations"]
+        violation_rate = violations / total if total > 0 else 0.0
+
+        ag = agreement.get(rule, {"agreed": 0, "disagreed": 0, "uncertain": 0})
+        evaluated = ag["agreed"] + ag["disagreed"]
+        agreement_rate = ag["agreed"] / evaluated if evaluated > 0 else None
+
+        results.append(
+            {
+                "rule": rule,
+                "total_evals": total,
+                "violations": violations,
+                "cleans": m["cleans"],
+                "violation_rate": round(violation_rate, 4),
+                "avg_confidence": round(m["avg_confidence"], 3),
+                "p50_confidence": round(m["p50_confidence"], 3),
+                "first_seen": m["first_seen"],
+                "last_seen": m["last_seen"],
+                "agreement_rate": (
+                    round(agreement_rate, 3) if agreement_rate is not None else None
+                ),
+                "agreement_evaluated": evaluated,
+                "agreement_agreed": ag["agreed"],
+                "agreement_disagreed": ag["disagreed"],
+                "agreement_uncertain": ag["uncertain"],
+            }
+        )
+
+    return results
+
+
+def main() -> None:
+    results = build_analysis()
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tier-advisor/scripts/analyze.py
+++ b/skills/tier-advisor/scripts/analyze.py
@@ -10,6 +10,7 @@ Output: JSON array of per-rule metric objects to stdout.
 
 import json
 import os
+import re
 import subprocess
 import sys
 
@@ -50,6 +51,28 @@ PUSHBACK_KEYWORDS = [
     "skip that",
     "leave it",
 ]
+
+
+def _compile_keywords(keywords: list[str]) -> re.Pattern[str]:
+    """Compile keyword list into a single regex pattern.
+
+    Single-word keywords use word boundaries to prevent false positives
+    (e.g. "no" matching "know", "right" matching "copyright").
+    Multi-word phrases use substring matching.
+    """
+    patterns = []
+    for kw in keywords:
+        escaped = re.escape(kw)
+        if " " not in kw:
+            patterns.append(rf"\b{escaped}\b")
+        else:
+            patterns.append(escaped)
+    return re.compile("|".join(patterns), re.IGNORECASE)
+
+
+_PUSHBACK_RE = _compile_keywords(PUSHBACK_KEYWORDS)
+_ACK_RE = _compile_keywords(ACK_KEYWORDS)
+_CORRECTION_RE = _compile_keywords(CORRECTION_KEYWORDS)
 
 
 def query(sql: str) -> list[dict]:
@@ -141,26 +164,51 @@ def compute_agreement_proxy() -> dict[str, dict]:
             agreement[rule]["uncertain"] += 1
             continue
 
-        lower = next_text.lower()
-        if any(kw in lower for kw in PUSHBACK_KEYWORDS):
-            agreement[rule]["disagreed"] += 1
-        elif any(kw in lower for kw in ACK_KEYWORDS):
-            agreement[rule]["agreed"] += 1
-        elif any(kw in lower for kw in CORRECTION_KEYWORDS):
-            agreement[rule]["agreed"] += 1
-        else:
-            agreement[rule]["uncertain"] += 1
+        category = _classify_user_response(next_text)
+        agreement[rule][category] += 1
 
     return agreement
+
+
+def _classify_user_response(text: str) -> str:
+    """Classify user response as agreed, disagreed, or uncertain."""
+    if _PUSHBACK_RE.search(text):
+        return "disagreed"
+    if _ACK_RE.search(text):
+        return "agreed"
+    if _CORRECTION_RE.search(text):
+        return "agreed"
+    return "uncertain"
 
 
 def _find_next_user_message(
     violation_ts: str, user_msgs: list[tuple[str, str]]
 ) -> str | None:
+    """Find the next user message after a violation, within a 5-minute window.
+
+    Without sessionId in the verdicts table, we use a time gap heuristic:
+    messages more than 5 minutes after the violation likely belong to a
+    different session or context.
+    """
+    cutoff = (
+        violation_ts[:11] + _add_minutes(violation_ts[11:16], 5) + violation_ts[16:]
+    )
     for ts, text in user_msgs:
         if ts > violation_ts:
+            if ts > cutoff:
+                return None
             return text
     return None
+
+
+def _add_minutes(time_str: str, minutes: int) -> str:
+    """Add minutes to a HH:MM time string. Handles hour rollover."""
+    parts = time_str.split(":")
+    h, m = int(parts[0]), int(parts[1])
+    m += minutes
+    h += m // 60
+    m = m % 60
+    return f"{h:02d}:{m:02d}"
 
 
 def build_analysis() -> list[dict]:

--- a/skills/tier-advisor/scripts/ingest.py
+++ b/skills/tier-advisor/scripts/ingest.py
@@ -26,11 +26,11 @@ def read_jsonl(path: Path) -> list[dict]:
     rows = []
     with open(path) as f:
         for line in f:
-            line = line.strip()
-            if not line:
+            stripped = line.strip()
+            if not stripped:
                 continue
             try:
-                rows.append(json.loads(line))
+                rows.append(json.loads(stripped))
             except json.JSONDecodeError:
                 continue
     return rows

--- a/skills/tier-advisor/scripts/ingest.py
+++ b/skills/tier-advisor/scripts/ingest.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Ingest vaudeville JSONL logs into DuckDB for tier-advisor analysis.
+
+Reads ~/.vaudeville/logs/events.jsonl and violations.jsonl,
+deduplicates by (ts, rule, input_snippet_hash), and upserts into
+~/.claude/analytics/sessions.duckdb as table vaudeville_verdicts.
+"""
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+LOGS_DIR = Path(os.path.expanduser("~/.vaudeville/logs"))
+DB_PATH = os.path.expanduser("~/.claude/analytics/sessions.duckdb")
+
+EVENTS_FILE = LOGS_DIR / "events.jsonl"
+VIOLATIONS_FILE = LOGS_DIR / "violations.jsonl"
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    rows = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return rows
+
+
+def snippet_hash(snippet: str | None) -> str:
+    text = snippet or ""
+    return hashlib.sha256(text.encode()).hexdigest()[:16]
+
+
+def build_records() -> list[dict]:
+    records = []
+    seen = set()
+
+    for row in read_jsonl(EVENTS_FILE):
+        key = (row.get("ts", ""), row.get("rule", ""), "")
+        if key in seen:
+            continue
+        seen.add(key)
+        records.append(
+            {
+                "ts": row.get("ts", ""),
+                "rule": row.get("rule", ""),
+                "verdict": row.get("verdict", ""),
+                "confidence": row.get("confidence", 0.0),
+                "latency_ms": row.get("latency_ms", 0.0),
+                "prompt_chars": row.get("prompt_chars", 0),
+                "reason": "",
+                "input_snippet": "",
+                "snippet_hash": "",
+            }
+        )
+
+    for row in read_jsonl(VIOLATIONS_FILE):
+        snippet = row.get("input_snippet", "")
+        shash = snippet_hash(snippet)
+        key = (row.get("ts", ""), row.get("rule", ""), shash)
+        if key in seen:
+            continue
+        seen.add(key)
+        records.append(
+            {
+                "ts": row.get("ts", ""),
+                "rule": row.get("rule", ""),
+                "verdict": row.get("verdict", "violation"),
+                "confidence": row.get("confidence", 0.0),
+                "latency_ms": row.get("latency_ms", 0.0),
+                "prompt_chars": row.get("prompt_chars", 0),
+                "reason": row.get("reason", ""),
+                "input_snippet": snippet[:500],
+                "snippet_hash": shash,
+            }
+        )
+
+    return records
+
+
+def ingest(records: list[dict]) -> int:
+    if not records:
+        print("No records to ingest.")
+        return 0
+
+    tmp = Path("/tmp/vaudeville_verdicts_staging.jsonl")
+    with open(tmp, "w") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+    sql = f"""
+    CREATE TABLE IF NOT EXISTS vaudeville_verdicts (
+        ts VARCHAR,
+        rule VARCHAR,
+        verdict VARCHAR,
+        confidence DOUBLE,
+        latency_ms DOUBLE,
+        prompt_chars INTEGER,
+        reason VARCHAR,
+        input_snippet VARCHAR,
+        snippet_hash VARCHAR
+    );
+
+    DELETE FROM vaudeville_verdicts;
+
+    INSERT INTO vaudeville_verdicts
+    SELECT * FROM read_json('{tmp}',
+        columns={{
+            ts: 'VARCHAR',
+            rule: 'VARCHAR',
+            verdict: 'VARCHAR',
+            confidence: 'DOUBLE',
+            latency_ms: 'DOUBLE',
+            prompt_chars: 'INTEGER',
+            reason: 'VARCHAR',
+            input_snippet: 'VARCHAR',
+            snippet_hash: 'VARCHAR'
+        }}
+    );
+    """
+
+    result = subprocess.run(
+        ["duckdb", DB_PATH, "-c", sql],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    if result.returncode != 0:
+        print(f"ERROR: DuckDB ingest failed: {result.stderr[:300]}", file=sys.stderr)
+        return 0
+
+    tmp.unlink(missing_ok=True)
+
+    count_result = subprocess.run(
+        [
+            "duckdb",
+            DB_PATH,
+            "-json",
+            "-c",
+            "SELECT count(*) as cnt FROM vaudeville_verdicts",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if count_result.returncode == 0:
+        rows = json.loads(count_result.stdout.strip())
+        count = rows[0]["cnt"] if rows else 0
+        print(f"Ingested {count} records into vaudeville_verdicts.")
+        return count
+    return len(records)
+
+
+def main() -> None:
+    if not LOGS_DIR.exists():
+        print(f"No logs directory at {LOGS_DIR}", file=sys.stderr)
+        sys.exit(1)
+
+    records = build_records()
+    count = ingest(records)
+    if count == 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tier-advisor/scripts/report.py
+++ b/skills/tier-advisor/scripts/report.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Generate tier-advisor recommendation report.
+
+Reads analysis output (from analyze.py via stdin or by running it),
+applies promotion/demotion thresholds, and outputs grouped markdown.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+RULES_DEV_DIR = Path(os.environ.get("CLAUDE_PLUGIN_ROOT", ".")) / "rules_dev"
+
+THRESHOLDS = {
+    "shadow_to_warn": {
+        "min_evals": 50,
+        "min_agreement": 0.70,
+        "violation_rate_min": 0.02,
+        "violation_rate_max": 0.40,
+    },
+    "warn_to_block": {
+        "min_evals": 200,
+        "min_agreement": 0.85,
+        "violation_rate_min": 0.05,
+        "violation_rate_max": 0.30,
+        "min_p50_confidence": 0.7,
+    },
+    "demote_warn_to_shadow": {
+        "max_agreement": 0.50,
+        "max_violation_rate": 0.60,
+    },
+}
+
+
+def get_current_tier(rule_name: str) -> str:
+    yaml_path = RULES_DEV_DIR / f"{rule_name}.yaml"
+    if not yaml_path.exists():
+        return "unknown"
+    with open(yaml_path) as f:
+        for line in f:
+            if line.startswith("tier:"):
+                return line.split(":", 1)[1].strip()
+    return "shadow"
+
+
+def classify(rule: dict) -> tuple[str, str]:
+    """Return (recommendation, reason) for a rule."""
+    tier = get_current_tier(rule["rule"])
+    total = rule["total_evals"]
+    vr = rule["violation_rate"]
+    agreement = rule.get("agreement_rate")
+    p50 = rule.get("p50_confidence", 0.0)
+    evaluated = rule.get("agreement_evaluated", 0)
+
+    if total < 10:
+        return "insufficient-data", f"Only {total} evals recorded."
+
+    if tier == "warn":
+        t = THRESHOLDS["demote_warn_to_shadow"]
+        if agreement is not None and agreement < t["max_agreement"]:
+            return (
+                "demote",
+                f"Agreement {agreement:.0%} below {t['max_agreement']:.0%} threshold.",
+            )
+        if vr > t["max_violation_rate"]:
+            return (
+                "demote",
+                f"Violation rate {vr:.0%} exceeds {t['max_violation_rate']:.0%} ceiling.",
+            )
+
+        t = THRESHOLDS["warn_to_block"]
+        if (
+            total >= t["min_evals"]
+            and (agreement is not None and agreement >= t["min_agreement"])
+            and t["violation_rate_min"] <= vr <= t["violation_rate_max"]
+            and p50 >= t["min_p50_confidence"]
+        ):
+            return "promote-to-block", (
+                f"{total} evals, {agreement:.0%} agreement, "
+                f"{vr:.0%} violation rate, p50 confidence {p50:.2f}."
+            )
+
+        return "hold-at-warn", f"{total} evals, {vr:.0%} violation rate."
+
+    if tier == "shadow":
+        t = THRESHOLDS["shadow_to_warn"]
+        if total < t["min_evals"]:
+            return (
+                "insufficient-data",
+                f"{total}/{t['min_evals']} evals needed for promotion.",
+            )
+
+        if agreement is not None and agreement < t["min_agreement"]:
+            return (
+                "hold-at-shadow",
+                f"Agreement {agreement:.0%} below {t['min_agreement']:.0%} threshold.",
+            )
+
+        if not (t["violation_rate_min"] <= vr <= t["violation_rate_max"]):
+            return (
+                "hold-at-shadow",
+                f"Violation rate {vr:.0%} outside [{t['violation_rate_min']:.0%}, {t['violation_rate_max']:.0%}].",
+            )
+
+        return "promote-to-warn", (
+            f"{total} evals, "
+            + (
+                f"{agreement:.0%} agreement, "
+                if agreement is not None
+                else "no agreement data, "
+            )
+            + f"{vr:.0%} violation rate."
+        )
+
+    if evaluated == 0:
+        return "insufficient-data", "No agreement data available."
+
+    return "hold-at-shadow", f"Tier '{tier}' — manual review needed."
+
+
+def format_report(rules: list[dict]) -> str:
+    groups: dict[str, list[tuple[dict, str]]] = {
+        "promote-to-block": [],
+        "promote-to-warn": [],
+        "demote": [],
+        "hold-at-warn": [],
+        "hold-at-shadow": [],
+        "insufficient-data": [],
+    }
+
+    for r in rules:
+        rec, reason = classify(r)
+        groups.setdefault(rec, []).append((r, reason))
+
+    lines = ["# Tier Advisor Report", ""]
+
+    group_labels = {
+        "promote-to-block": "Promote to Block",
+        "promote-to-warn": "Promote to Warn",
+        "demote": "Demote",
+        "hold-at-warn": "Hold at Warn",
+        "hold-at-shadow": "Hold at Shadow",
+        "insufficient-data": "Insufficient Data",
+    }
+
+    for key, label in group_labels.items():
+        entries = groups.get(key, [])
+        if not entries:
+            continue
+        lines.append(f"## {label}")
+        lines.append("")
+        for rule, reason in entries:
+            tier = get_current_tier(rule["rule"])
+            lines.append(
+                f"- **{rule['rule']}** (current: {tier}, "
+                f"evals: {rule['total_evals']}, "
+                f"violations: {rule['violations']}, "
+                f"rate: {rule['violation_rate']:.1%})"
+            )
+            lines.append(f"  {reason}")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    stdin_data = ""
+    if not sys.stdin.isatty():
+        stdin_data = sys.stdin.read().strip()
+
+    if stdin_data:
+        data = json.loads(stdin_data)
+    else:
+        script_dir = Path(__file__).parent
+        result = subprocess.run(
+            [sys.executable, str(script_dir / "analyze.py")],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            print(f"ERROR: analyze.py failed: {result.stderr[:200]}", file=sys.stderr)
+            sys.exit(1)
+        data = json.loads(result.stdout)
+
+    report = format_report(data)
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tier-advisor/scripts/report.py
+++ b/skills/tier-advisor/scripts/report.py
@@ -47,78 +47,85 @@ def get_current_tier(rule_name: str) -> str:
     return "shadow"
 
 
+def _classify_warn(rule: dict, tier_thresholds: dict) -> tuple[str, str]:
+    """Classify a rule currently at warn tier."""
+    vr = rule["violation_rate"]
+    agreement = rule.get("agreement_rate")
+    p50 = rule.get("p50_confidence", 0.0)
+    total = rule["total_evals"]
+
+    t = tier_thresholds["demote_warn_to_shadow"]
+    if agreement is not None and agreement < t["max_agreement"]:
+        return (
+            "demote",
+            f"Agreement {agreement:.0%} below {t['max_agreement']:.0%} threshold.",
+        )
+    if vr > t["max_violation_rate"]:
+        return (
+            "demote",
+            f"Violation rate {vr:.0%} exceeds {t['max_violation_rate']:.0%} ceiling.",
+        )
+
+    t = tier_thresholds["warn_to_block"]
+    if (
+        total >= t["min_evals"]
+        and (agreement is not None and agreement >= t["min_agreement"])
+        and t["violation_rate_min"] <= vr <= t["violation_rate_max"]
+        and p50 >= t["min_p50_confidence"]
+    ):
+        return "promote-to-block", (
+            f"{total} evals, {agreement:.0%} agreement, "
+            f"{vr:.0%} violation rate, p50 confidence {p50:.2f}."
+        )
+
+    return "hold-at-warn", f"{total} evals, {vr:.0%} violation rate."
+
+
+def _classify_shadow(rule: dict, tier_thresholds: dict) -> tuple[str, str]:
+    """Classify a rule currently at shadow tier."""
+    vr = rule["violation_rate"]
+    agreement = rule.get("agreement_rate")
+    total = rule["total_evals"]
+
+    t = tier_thresholds["shadow_to_warn"]
+    if total < t["min_evals"]:
+        return (
+            "insufficient-data",
+            f"{total}/{t['min_evals']} evals needed for promotion.",
+        )
+    if agreement is not None and agreement < t["min_agreement"]:
+        return (
+            "hold-at-shadow",
+            f"Agreement {agreement:.0%} below {t['min_agreement']:.0%} threshold.",
+        )
+    if not (t["violation_rate_min"] <= vr <= t["violation_rate_max"]):
+        return (
+            "hold-at-shadow",
+            f"Violation rate {vr:.0%} outside [{t['violation_rate_min']:.0%}, {t['violation_rate_max']:.0%}].",
+        )
+
+    agreement_str = (
+        f"{agreement:.0%} agreement, "
+        if agreement is not None
+        else "no agreement data, "
+    )
+    return "promote-to-warn", f"{total} evals, {agreement_str}{vr:.0%} violation rate."
+
+
 def classify(rule: dict) -> tuple[str, str]:
     """Return (recommendation, reason) for a rule."""
     tier = get_current_tier(rule["rule"])
     total = rule["total_evals"]
-    vr = rule["violation_rate"]
-    agreement = rule.get("agreement_rate")
-    p50 = rule.get("p50_confidence", 0.0)
-    evaluated = rule.get("agreement_evaluated", 0)
 
     if total < 10:
         return "insufficient-data", f"Only {total} evals recorded."
-
     if tier == "warn":
-        t = THRESHOLDS["demote_warn_to_shadow"]
-        if agreement is not None and agreement < t["max_agreement"]:
-            return (
-                "demote",
-                f"Agreement {agreement:.0%} below {t['max_agreement']:.0%} threshold.",
-            )
-        if vr > t["max_violation_rate"]:
-            return (
-                "demote",
-                f"Violation rate {vr:.0%} exceeds {t['max_violation_rate']:.0%} ceiling.",
-            )
-
-        t = THRESHOLDS["warn_to_block"]
-        if (
-            total >= t["min_evals"]
-            and (agreement is not None and agreement >= t["min_agreement"])
-            and t["violation_rate_min"] <= vr <= t["violation_rate_max"]
-            and p50 >= t["min_p50_confidence"]
-        ):
-            return "promote-to-block", (
-                f"{total} evals, {agreement:.0%} agreement, "
-                f"{vr:.0%} violation rate, p50 confidence {p50:.2f}."
-            )
-
-        return "hold-at-warn", f"{total} evals, {vr:.0%} violation rate."
-
+        return _classify_warn(rule, THRESHOLDS)
     if tier == "shadow":
-        t = THRESHOLDS["shadow_to_warn"]
-        if total < t["min_evals"]:
-            return (
-                "insufficient-data",
-                f"{total}/{t['min_evals']} evals needed for promotion.",
-            )
+        return _classify_shadow(rule, THRESHOLDS)
 
-        if agreement is not None and agreement < t["min_agreement"]:
-            return (
-                "hold-at-shadow",
-                f"Agreement {agreement:.0%} below {t['min_agreement']:.0%} threshold.",
-            )
-
-        if not (t["violation_rate_min"] <= vr <= t["violation_rate_max"]):
-            return (
-                "hold-at-shadow",
-                f"Violation rate {vr:.0%} outside [{t['violation_rate_min']:.0%}, {t['violation_rate_max']:.0%}].",
-            )
-
-        return "promote-to-warn", (
-            f"{total} evals, "
-            + (
-                f"{agreement:.0%} agreement, "
-                if agreement is not None
-                else "no agreement data, "
-            )
-            + f"{vr:.0%} violation rate."
-        )
-
-    if evaluated == 0:
+    if rule.get("agreement_evaluated", 0) == 0:
         return "insufficient-data", "No agreement data available."
-
     return "hold-at-shadow", f"Tier '{tier}' — manual review needed."
 
 

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -23,7 +23,7 @@ import time
 from unittest.mock import MagicMock, patch
 
 from vaudeville.core.paths import VERSION_FILE
-from vaudeville.server.daemon import VaudevilleDaemon, handle_request
+from vaudeville.server import DaemonConfig, VaudevilleDaemon, handle_request
 from conftest import MockBackend
 
 
@@ -34,7 +34,8 @@ def _make_daemon(
 ) -> VaudevilleDaemon:
     plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     return VaudevilleDaemon(
-        socket_path, pid_file, plugin_root, MockBackend(), version_file=version_file
+        MockBackend(),
+        DaemonConfig(socket_path, pid_file, plugin_root, version_file),
     )
 
 
@@ -117,11 +118,8 @@ class TestVersionStampRace:
 
             plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
             daemon2 = VaudevilleDaemon(
-                socket_path2,
-                pid_file,
-                plugin_root,
                 MockBackend(),
-                version_file=version_file,
+                DaemonConfig(socket_path2, pid_file, plugin_root, version_file),
             )
             # serve() should return immediately due to PID lock held by daemon1
             thread2 = threading.Thread(target=daemon2.serve, daemon=True)
@@ -162,11 +160,8 @@ class TestVersionStampRace:
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            socket_path,
-            pid_file,
-            plugin_root,
             TracingBackend(),
-            version_file=version_file,
+            DaemonConfig(socket_path, pid_file, plugin_root, version_file),
         )
 
         original_write = daemon._write_version_stamp
@@ -222,11 +217,8 @@ class TestVersionFilePermissions:
 
             plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
             daemon = VaudevilleDaemon(
-                socket_path,
-                pid_file,
-                plugin_root,
                 MockBackend(),
-                version_file=version_file,
+                DaemonConfig(socket_path, pid_file, plugin_root, version_file),
             )
 
             # Serve should still bind the socket despite write failure
@@ -269,11 +261,13 @@ class TestGitNotAvailable:
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            "/tmp/_test_git_na.sock",
-            "/tmp/_test_git_na.pid",
-            plugin_root,
             MockBackend(),
-            version_file=version_file,
+            DaemonConfig(
+                "/tmp/_test_git_na.sock",
+                "/tmp/_test_git_na.pid",
+                plugin_root,
+                version_file,
+            ),
         )
 
         # Simulate git not found by making the subprocess raise OSError
@@ -294,11 +288,13 @@ class TestGitNotAvailable:
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            "/tmp/_test_git_fail.sock",
-            "/tmp/_test_git_fail.pid",
-            plugin_root,
             MockBackend(),
-            version_file=version_file,
+            DaemonConfig(
+                "/tmp/_test_git_fail.sock",
+                "/tmp/_test_git_fail.pid",
+                plugin_root,
+                version_file,
+            ),
         )
 
         fake_result = MagicMock()
@@ -322,11 +318,13 @@ class TestGitNotAvailable:
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            "/tmp/_test_git_timeout.sock",
-            "/tmp/_test_git_timeout.pid",
-            plugin_root,
             MockBackend(),
-            version_file=version_file,
+            DaemonConfig(
+                "/tmp/_test_git_timeout.sock",
+                "/tmp/_test_git_timeout.pid",
+                plugin_root,
+                version_file,
+            ),
         )
 
         with patch(
@@ -373,11 +371,8 @@ class TestShutdownRace:
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            socket_path,
-            pid_file,
-            plugin_root,
             SlowBackend(),
-            version_file=version_file,
+            DaemonConfig(socket_path, pid_file, plugin_root, version_file),
         )
         thread = threading.Thread(target=daemon.serve, daemon=True)
         thread.start()
@@ -483,11 +478,8 @@ class TestPidFileGarbage:
         try:
             plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
             daemon = VaudevilleDaemon(
-                socket_path,
-                pid_file,
-                plugin_root,
                 MockBackend(),
-                version_file=version_file,
+                DaemonConfig(socket_path, pid_file, plugin_root, version_file),
             )
             thread = threading.Thread(target=daemon.serve, daemon=True)
             thread.start()
@@ -524,11 +516,8 @@ class TestPidFileGarbage:
         # The daemon re-opens and relocks the PID file; garbage content shouldn't matter
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            socket_path,
-            pid_file,
-            plugin_root,
             MockBackend(),
-            version_file=version_file,
+            DaemonConfig(socket_path, pid_file, plugin_root, version_file),
         )
         thread = threading.Thread(target=daemon.serve, daemon=True)
         thread.start()
@@ -562,11 +551,13 @@ class TestCleanupInterrupted:
         """_cleanup() must not raise if socket/pid/version files are already gone."""
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            "/tmp/_nonexistent_test.sock",
-            "/tmp/_nonexistent_test.pid",
-            plugin_root,
             MockBackend(),
-            version_file="/tmp/_nonexistent_test.version",
+            DaemonConfig(
+                "/tmp/_nonexistent_test.sock",
+                "/tmp/_nonexistent_test.pid",
+                plugin_root,
+                "/tmp/_nonexistent_test.version",
+            ),
         )
         # No files exist — must not raise
         daemon._cleanup()
@@ -593,11 +584,8 @@ class TestCleanupInterrupted:
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            socket_path,
-            pid_file,
-            plugin_root,
             MockBackend(),
-            version_file=version_file,
+            DaemonConfig(socket_path, pid_file, plugin_root, version_file),
         )
         thread = threading.Thread(target=daemon.serve, daemon=True)
         thread.start()
@@ -711,11 +699,8 @@ class TestBackendLockContention:
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            socket_path,
-            pid_file,
-            plugin_root,
             TimingBackend(),
-            version_file=version_file,
+            DaemonConfig(socket_path, pid_file, plugin_root, version_file),
         )
         thread = threading.Thread(target=daemon.serve, daemon=True)
         thread.start()
@@ -816,11 +801,13 @@ class TestCleanupWithoutPidLock:
         """_cleanup() with pid_fd=None must not raise AttributeError or OSError."""
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            "/tmp/_skip_test.sock",
-            "/tmp/_skip_test.pid",
-            plugin_root,
             MockBackend(),
-            version_file="/tmp/_skip_test.version",
+            DaemonConfig(
+                "/tmp/_skip_test.sock",
+                "/tmp/_skip_test.pid",
+                plugin_root,
+                "/tmp/_skip_test.version",
+            ),
         )
         assert daemon._pid_fd is None
         # Must not raise

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -6,19 +6,36 @@ import importlib.util
 import json
 import os
 import pathlib
+import sys
 from typing import Any, Callable
 from unittest.mock import patch
 
 import pytest
 
-# Load analyze.py as a module from the skills directory
-_ANALYZE_PATH = os.path.join(
+_SCRIPTS_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     "skills",
     "hook-suggester",
     "scripts",
-    "analyze.py",
 )
+
+# Ensure the scripts directory is on sys.path so relative imports work
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+_ANALYZERS_PATH = os.path.join(_SCRIPTS_DIR, "analyzers.py")
+_ANALYZE_PATH = os.path.join(_SCRIPTS_DIR, "analyze.py")
+
+if "analyzers" not in sys.modules:
+    analyzers_spec = importlib.util.spec_from_file_location(
+        "analyzers", _ANALYZERS_PATH
+    )
+    assert analyzers_spec is not None and analyzers_spec.loader is not None
+    _analyzers_mod = importlib.util.module_from_spec(analyzers_spec)
+    sys.modules["analyzers"] = _analyzers_mod
+    analyzers_spec.loader.exec_module(_analyzers_mod)
+
+analyzers = sys.modules["analyzers"]
 
 spec = importlib.util.spec_from_file_location("analyze", _ANALYZE_PATH)
 assert spec is not None and spec.loader is not None
@@ -29,7 +46,7 @@ spec.loader.exec_module(analyze)
 class TestQuery:
     def test_duckdb_not_found_exits(self, tmp_path: pathlib.Path) -> None:
         db = str(tmp_path / "test.duckdb")
-        with patch.object(analyze, "DB_PATH", db):
+        with patch.object(analyzers, "DB_PATH", db):
             with patch("subprocess.run", side_effect=FileNotFoundError):
                 with pytest.raises(SystemExit) as exc_info:
                     analyze.query("SELECT 1")
@@ -40,7 +57,7 @@ class TestQuery:
     ) -> None:
         db = str(tmp_path / "test.duckdb")
         mock_result = type("R", (), {"returncode": 1, "stdout": "", "stderr": "err!"})()
-        with patch.object(analyze, "DB_PATH", db):
+        with patch.object(analyzers, "DB_PATH", db):
             with patch("subprocess.run", return_value=mock_result):
                 result = analyze.query("SELECT 1")
         assert result == []
@@ -53,7 +70,7 @@ class TestQuery:
         mock_result = type(
             "R", (), {"returncode": 1, "stdout": "", "stderr": "SQL error"}
         )()
-        with patch.object(analyze, "DB_PATH", db):
+        with patch.object(analyzers, "DB_PATH", db):
             with patch("subprocess.run", return_value=mock_result):
                 analyze.query("BAD SQL")
         err = capsys.readouterr().err
@@ -62,7 +79,7 @@ class TestQuery:
     def test_empty_stdout_returns_empty(self, tmp_path: pathlib.Path) -> None:
         db = str(tmp_path / "test.duckdb")
         mock_result = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
-        with patch.object(analyze, "DB_PATH", db):
+        with patch.object(analyzers, "DB_PATH", db):
             with patch("subprocess.run", return_value=mock_result):
                 result = analyze.query("SELECT 1")
         assert result == []
@@ -72,7 +89,7 @@ class TestQuery:
     ) -> None:
         db = str(tmp_path / "test.duckdb")
         mock_result = type("R", (), {"returncode": 0, "stdout": "[{]", "stderr": ""})()
-        with patch.object(analyze, "DB_PATH", db):
+        with patch.object(analyzers, "DB_PATH", db):
             with patch("subprocess.run", return_value=mock_result):
                 result = analyze.query("SELECT 1")
         assert result == []
@@ -84,7 +101,7 @@ class TestQuery:
         mock_result = type(
             "R", (), {"returncode": 0, "stdout": "not-json", "stderr": ""}
         )()
-        with patch.object(analyze, "DB_PATH", db):
+        with patch.object(analyzers, "DB_PATH", db):
             with patch("subprocess.run", return_value=mock_result):
                 result = analyze.query("SELECT 1")
         assert result == []
@@ -96,7 +113,7 @@ class TestQuery:
         mock_result = type(
             "R", (), {"returncode": 0, "stdout": json.dumps(data), "stderr": ""}
         )()
-        with patch.object(analyze, "DB_PATH", db):
+        with patch.object(analyzers, "DB_PATH", db):
             with patch("subprocess.run", return_value=mock_result):
                 result = analyze.query("SELECT 1")
         assert result == data
@@ -104,12 +121,12 @@ class TestQuery:
 
 class TestCheckDangerousBash:
     def test_returns_none_when_no_rows(self) -> None:
-        with patch.object(analyze, "query", return_value=[]):
+        with patch.object(analyzers, "query", return_value=[]):
             assert analyze.check_dangerous_bash(14, 3) is None
 
     def test_returns_suggestion_when_rows_found(self) -> None:
         rows = [{"bash_cmd": "rm -rf /tmp/foo", "uses": "5"}]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_dangerous_bash(14, 3)
         assert result is not None
         assert result["id"] == "dangerous-bash"
@@ -119,7 +136,7 @@ class TestCheckDangerousBash:
 
 class TestCheckToolMisuse:
     def test_returns_none_when_no_rows(self) -> None:
-        with patch.object(analyze, "query", return_value=[]):
+        with patch.object(analyzers, "query", return_value=[]):
             assert analyze.check_tool_misuse(14, 3) is None
 
     def test_returns_suggestion_with_misuse_types(self) -> None:
@@ -127,7 +144,7 @@ class TestCheckToolMisuse:
             {"misuse_type": "grep/rg → Grep tool", "uses": "100"},
             {"misuse_type": "cat/head/tail → Read tool", "uses": "50"},
         ]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_tool_misuse(14, 3)
         assert result is not None
         assert result["id"] == "tool-misuse"
@@ -136,14 +153,14 @@ class TestCheckToolMisuse:
 
 class TestCheckHighErrorTools:
     def test_returns_none_when_no_rows(self) -> None:
-        with patch.object(analyze, "query", return_value=[]):
+        with patch.object(analyzers, "query", return_value=[]):
             assert analyze.check_high_error_tools(14, 3) is None
 
     def test_returns_suggestion_with_tool_names(self) -> None:
         rows = [
             {"tool_name": "mcp__github__create_pr", "error_pct": "100.0", "total": "5"}
         ]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_high_error_tools(14, 3)
         assert result is not None
         assert result["id"] == "high-error-tools"
@@ -152,7 +169,7 @@ class TestCheckHighErrorTools:
 
 class TestCheckPermissionFriction:
     def test_returns_none_when_no_rows(self) -> None:
-        with patch.object(analyze, "query", return_value=[]):
+        with patch.object(analyzers, "query", return_value=[]):
             assert analyze.check_permission_friction(14, 3) is None
 
     def test_returns_suggestion_with_denial_examples(self) -> None:
@@ -160,7 +177,7 @@ class TestCheckPermissionFriction:
             {"denial": "Permission to use Bash has been denied.", "denials": "10"},
             {"denial": "Permission to use Read has been denied.", "denials": "5"},
         ]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_permission_friction(14, 3)
         assert result is not None
         assert result["id"] == "permission-friction"
@@ -182,15 +199,15 @@ class TestCheckMissingQualityHooks:
         return _q
 
     def test_returns_none_when_stop_count_zero(self) -> None:
-        with patch.object(analyze, "query", self._mock_counts(0, 0)):
+        with patch.object(analyzers, "query", self._mock_counts(0, 0)):
             assert analyze.check_missing_quality_hooks(14) is None
 
     def test_returns_none_when_ratio_above_threshold(self) -> None:
-        with patch.object(analyze, "query", self._mock_counts(60, 100)):
+        with patch.object(analyzers, "query", self._mock_counts(60, 100)):
             assert analyze.check_missing_quality_hooks(14) is None
 
     def test_returns_suggestion_when_low_ratio(self) -> None:
-        with patch.object(analyze, "query", self._mock_counts(10, 100)):
+        with patch.object(analyzers, "query", self._mock_counts(10, 100)):
             result = analyze.check_missing_quality_hooks(14)
         assert result is not None
         assert result["id"] == "missing-quality-hooks"
@@ -199,12 +216,12 @@ class TestCheckMissingQualityHooks:
 
 class TestCheckHookFailures:
     def test_returns_none_when_no_errors(self) -> None:
-        with patch.object(analyze, "query", return_value=[]):
+        with patch.object(analyzers, "query", return_value=[]):
             assert analyze.check_hook_failures(14, 3) is None
 
     def test_returns_suggestion_with_error_examples(self) -> None:
         rows = [{"err": "Timeout after 30s", "cnt": "5"}]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_hook_failures(14, 3)
         assert result is not None
         assert result["id"] == "hook-failures"
@@ -213,7 +230,7 @@ class TestCheckHookFailures:
 
 class TestCheckCodeWriteVolume:
     def test_returns_none_when_no_rows(self) -> None:
-        with patch.object(analyze, "query", return_value=[]):
+        with patch.object(analyzers, "query", return_value=[]):
             assert analyze.check_code_write_volume(14, 3) is None
 
     def test_returns_suggestion_with_language_breakdown(self) -> None:
@@ -221,7 +238,7 @@ class TestCheckCodeWriteVolume:
             {"lang": "Python", "writes": "500"},
             {"lang": "Rust", "writes": "200"},
         ]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_code_write_volume(14, 3)
         assert result is not None
         assert result["id"] == "auto-format"
@@ -230,7 +247,7 @@ class TestCheckCodeWriteVolume:
 
 class TestCheckRepeatedBashPatterns:
     def test_returns_none_when_no_rows(self) -> None:
-        with patch.object(analyze, "query", return_value=[]):
+        with patch.object(analyzers, "query", return_value=[]):
             assert analyze.check_repeated_bash_patterns(14, 3) is None
 
     def test_returns_suggestion_with_commands(self) -> None:
@@ -238,7 +255,7 @@ class TestCheckRepeatedBashPatterns:
             {"cmd": "git merge origin/main --no-edit", "uses": "50"},
             {"cmd": "git remote get-url origin", "uses": "30"},
         ]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_repeated_bash_patterns(14, 3)
         assert result is not None
         assert result["id"] == "repeated-commands"
@@ -247,7 +264,7 @@ class TestCheckRepeatedBashPatterns:
     def test_long_commands_truncated_in_display(self) -> None:
         long_cmd = "x" * 100
         rows = [{"cmd": long_cmd, "uses": "20"}]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_repeated_bash_patterns(14, 3)
         assert result is not None
         assert len(result["examples"][0].split(" (")[0]) <= 80
@@ -255,7 +272,7 @@ class TestCheckRepeatedBashPatterns:
 
 class TestCheckCorrectionPatterns:
     def test_returns_none_when_no_rows(self) -> None:
-        with patch.object(analyze, "query", return_value=[]):
+        with patch.object(analyzers, "query", return_value=[]):
             assert analyze.check_correction_patterns(14, 3) is None
 
     def test_returns_suggestion_with_correction_examples(self) -> None:
@@ -263,7 +280,7 @@ class TestCheckCorrectionPatterns:
             {"user_msg": "no, that's not what I meant", "occurrences": "5"},
             {"user_msg": "wrong approach, use the Grep tool", "occurrences": "3"},
         ]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_correction_patterns(14, 3)
         assert result is not None
         assert result["id"] == "correction-patterns"
@@ -276,7 +293,7 @@ class TestCheckCorrectionPatterns:
             {"user_msg": "no, wrong", "occurrences": "7"},
             {"user_msg": "that's not right", "occurrences": "3"},
         ]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_correction_patterns(14, 3)
         assert result is not None
         assert "10" in result["description"]
@@ -284,7 +301,7 @@ class TestCheckCorrectionPatterns:
     def test_long_messages_truncated(self) -> None:
         long_msg = "no, " + "x" * 200
         rows = [{"user_msg": long_msg, "occurrences": "3"}]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_correction_patterns(14, 3)
         assert result is not None
         assert len(result["examples"][0]) <= 100
@@ -292,7 +309,7 @@ class TestCheckCorrectionPatterns:
 
 class TestCheckRetryLoops:
     def test_returns_none_when_no_rows(self) -> None:
-        with patch.object(analyze, "query", return_value=[]):
+        with patch.object(analyzers, "query", return_value=[]):
             assert analyze.check_retry_loops(14, 3) is None
 
     def test_returns_suggestion_with_tool_retries(self) -> None:
@@ -300,7 +317,7 @@ class TestCheckRetryLoops:
             {"tool_name": "Bash", "retry_count": "15"},
             {"tool_name": "Edit", "retry_count": "8"},
         ]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_retry_loops(14, 3)
         assert result is not None
         assert result["id"] == "retry-loops"
@@ -313,7 +330,7 @@ class TestCheckRetryLoops:
             {"tool_name": "Bash", "retry_count": "10"},
             {"tool_name": "Edit", "retry_count": "5"},
         ]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_retry_loops(14, 3)
         assert result is not None
         assert "15" in result["description"]
@@ -321,7 +338,7 @@ class TestCheckRetryLoops:
 
 class TestCheckPermissionToolWaste:
     def test_returns_none_when_no_rows(self) -> None:
-        with patch.object(analyze, "query", return_value=[]):
+        with patch.object(analyzers, "query", return_value=[]):
             assert analyze.check_permission_tool_waste(14, 3) is None
 
     def test_returns_suggestion_with_permission_failures(self) -> None:
@@ -329,7 +346,7 @@ class TestCheckPermissionToolWaste:
             {"tool_name": "Bash", "failures": "20"},
             {"tool_name": "Write", "failures": "5"},
         ]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_permission_tool_waste(14, 3)
         assert result is not None
         assert result["id"] == "permission-tool-waste"
@@ -339,7 +356,7 @@ class TestCheckPermissionToolWaste:
 
     def test_total_count_sums_failures(self) -> None:
         rows = [{"tool_name": "Bash", "failures": "10"}]
-        with patch.object(analyze, "query", return_value=rows):
+        with patch.object(analyzers, "query", return_value=rows):
             result = analyze.check_permission_tool_waste(14, 3)
         assert result is not None
         assert "10" in result["description"]

--- a/tests/test_analyze_main.py
+++ b/tests/test_analyze_main.py
@@ -11,15 +11,31 @@ from unittest.mock import patch
 
 import pytest
 
-_ANALYZE_PATH = os.path.join(
+_SCRIPTS_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     "skills",
     "hook-suggester",
     "scripts",
-    "analyze.py",
 )
 
-spec = importlib.util.spec_from_file_location("analyze", _ANALYZE_PATH)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+_ANALYZERS_PATH = os.path.join(_SCRIPTS_DIR, "analyzers.py")
+_ANALYZE_PATH = os.path.join(_SCRIPTS_DIR, "analyze.py")
+
+if "analyzers" not in sys.modules:
+    analyzers_spec = importlib.util.spec_from_file_location(
+        "analyzers", _ANALYZERS_PATH
+    )
+    assert analyzers_spec is not None and analyzers_spec.loader is not None
+    _analyzers_mod = importlib.util.module_from_spec(analyzers_spec)
+    sys.modules["analyzers"] = _analyzers_mod
+    analyzers_spec.loader.exec_module(_analyzers_mod)
+
+analyzers = sys.modules["analyzers"]
+
+spec = importlib.util.spec_from_file_location("analyze_main", _ANALYZE_PATH)
 assert spec is not None and spec.loader is not None
 analyze = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(analyze)
@@ -40,7 +56,7 @@ class TestMain:
         open(fake_db, "w").close()
         with (
             patch.object(analyze, "DB_PATH", fake_db),
-            patch.object(analyze, "query", return_value=[]),
+            patch.object(analyzers, "query", return_value=[]),
             patch.object(sys, "argv", ["analyze.py", "--json"]),
         ):
             analyze.main()
@@ -55,7 +71,7 @@ class TestMain:
         open(fake_db, "w").close()
         with (
             patch.object(analyze, "DB_PATH", fake_db),
-            patch.object(analyze, "query", return_value=[]),
+            patch.object(analyzers, "query", return_value=[]),
             patch.object(sys, "argv", ["analyze.py"]),
         ):
             analyze.main()
@@ -69,7 +85,7 @@ class TestMain:
         rows = [{"bash_cmd": "rm -rf /tmp/x", "uses": "5"}]
         with (
             patch.object(analyze, "DB_PATH", fake_db),
-            patch.object(analyze, "query", return_value=rows),
+            patch.object(analyzers, "query", return_value=rows),
             patch.object(sys, "argv", ["analyze.py", "--days", "7"]),
         ):
             analyze.main()
@@ -84,7 +100,7 @@ class TestMain:
         rows = [{"bash_cmd": "rm -rf /tmp/x", "uses": "5"}]
         with (
             patch.object(analyze, "DB_PATH", fake_db),
-            patch.object(analyze, "query", return_value=rows),
+            patch.object(analyzers, "query", return_value=rows),
             patch.object(sys, "argv", ["analyze.py"]),
         ):
             analyze.main()
@@ -102,7 +118,7 @@ class TestMain:
 
         with (
             patch.object(analyze, "DB_PATH", fake_db),
-            patch.object(analyze, "query", side_effect=_boom),
+            patch.object(analyzers, "query", side_effect=_boom),
             patch.object(sys, "argv", ["analyze.py"]),
         ):
             analyze.main()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -415,18 +415,20 @@ class TestClientSocket:
 
 class TestDaemonExtras:
     def test_cleanup_tolerates_missing_files(self) -> None:
-        from vaudeville.server.daemon import VaudevilleDaemon
+        from vaudeville.server.daemon import DaemonConfig, VaudevilleDaemon
 
         daemon = VaudevilleDaemon(
-            socket_path="/tmp/nonexistent-vd.sock",
-            pid_file="/tmp/nonexistent-vd.pid",
-            plugin_root=PROJECT_ROOT,
-            backend=MockBackend(),
+            MockBackend(),
+            DaemonConfig(
+                socket_path="/tmp/nonexistent-vd.sock",
+                pid_file="/tmp/nonexistent-vd.pid",
+                plugin_root=PROJECT_ROOT,
+            ),
         )
         daemon._cleanup()  # should not raise
 
     def test_accept_loop_stops_on_stop_event(self) -> None:
-        from vaudeville.server.daemon import VaudevilleDaemon
+        from vaudeville.server.daemon import DaemonConfig, VaudevilleDaemon
 
         with tempfile.NamedTemporaryFile(suffix=".sock", dir="/tmp", delete=False) as f:
             sock_path = f.name
@@ -434,17 +436,20 @@ class TestDaemonExtras:
             pid_path = f.name
         os.unlink(sock_path)
 
-        daemon = VaudevilleDaemon(sock_path, pid_path, PROJECT_ROOT, MockBackend())
+        daemon = VaudevilleDaemon(
+            MockBackend(), DaemonConfig(sock_path, pid_path, PROJECT_ROOT)
+        )
         mock_server = MagicMock()
         mock_server.accept.side_effect = socket.timeout
         daemon._stop_event.set()
         daemon._accept_loop(mock_server)  # should return immediately
 
     def test_handle_client_exception_logged(self) -> None:
-        from vaudeville.server.daemon import VaudevilleDaemon
+        from vaudeville.server.daemon import DaemonConfig, VaudevilleDaemon
 
         daemon = VaudevilleDaemon(
-            "/tmp/x.sock", "/tmp/x.pid", PROJECT_ROOT, MockBackend()
+            MockBackend(),
+            DaemonConfig("/tmp/x.sock", "/tmp/x.pid", PROJECT_ROOT),
         )
         broken_conn = MagicMock()
         broken_conn.recv.side_effect = OSError("connection reset")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,122 +2,63 @@
 
 from __future__ import annotations
 
-import os
-from argparse import Namespace
 from unittest.mock import patch
 
 import pytest
 
 
-class TestFindLogFiles:
-    def test_returns_logs_with_live_daemon(self) -> None:
-        # Use the real /tmp/vaudeville-<id>.log prefix so removeprefix correctly
-        # derives session_id="abc123" and pid_file="/tmp/vaudeville-abc123.pid".
-        log_path = "/tmp/vaudeville-abc123.log"
+class TestCmdWatch:
+    def test_watch_calls_watch_function(self) -> None:
+        from argparse import Namespace
 
-        with patch("vaudeville.__main__.glob.glob", return_value=[log_path]):
-            with patch(
-                "vaudeville.__main__.Path.read_text",
-                return_value=str(os.getpid()),
-            ):
-                from vaudeville.__main__ import _find_log_files
+        with patch("vaudeville.server.watch") as mock_watch:
+            from vaudeville.__main__ import cmd_watch
 
-                result = _find_log_files()
+            cmd_watch(Namespace(log_path="/tmp/test.jsonl"))
 
-        assert result == [log_path]
-
-    def test_skips_logs_with_dead_daemon(self) -> None:
-        log_path = "/tmp/vaudeville-dead.log"
-
-        with patch("vaudeville.__main__.glob.glob", return_value=[log_path]):
-            with patch(
-                "vaudeville.__main__.Path.read_text",
-                side_effect=FileNotFoundError,
-            ):
-                from vaudeville.__main__ import _find_log_files
-
-                result = _find_log_files()
-
-        assert result == []
-
-    def test_skips_stale_pid(self) -> None:
-        log_path = "/tmp/vaudeville-stale.log"
-
-        with patch("vaudeville.__main__.glob.glob", return_value=[log_path]):
-            with patch(
-                "vaudeville.__main__.Path.read_text",
-                return_value="99999999",
-            ):
-                with patch(
-                    "vaudeville.__main__.os.kill",
-                    side_effect=ProcessLookupError,
-                ):
-                    from vaudeville.__main__ import _find_log_files
-
-                    result = _find_log_files()
-
-        assert result == []
+        mock_watch.assert_called_once_with(log_path="/tmp/test.jsonl")
 
 
-class TestCmdTail:
-    def _make_args(self, session: str | None = None, all: bool = False) -> Namespace:
-        return Namespace(session=session, all=all)
+class TestCmdStats:
+    def test_stats_json_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from argparse import Namespace
 
-    def test_no_active_daemons_exits(self) -> None:
-        with patch("vaudeville.__main__._find_log_files", return_value=[]):
-            from vaudeville.__main__ import cmd_tail
+        mock_result = {
+            "total": 1,
+            "time_range": {"earliest": "t0", "latest": "t1"},
+            "rules": {},
+            "latency": {
+                "p50_ms": 1.0,
+                "p95_ms": 2.0,
+                "mean_ms": 1.5,
+                "histogram": {},
+            },
+        }
+        with patch("vaudeville.server.aggregate_events", return_value=mock_result):
+            from vaudeville.__main__ import cmd_stats
+
+            cmd_stats(Namespace(log_path="/tmp/test.jsonl", json=True))
+
+        out = capsys.readouterr().out
+        assert '"total": 1' in out
+
+    def test_stats_no_events(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from argparse import Namespace
+
+        mock_result = {"total": 0}
+        with patch("vaudeville.server.aggregate_events", return_value=mock_result):
+            from vaudeville.__main__ import cmd_stats
+
+            cmd_stats(Namespace(log_path="/tmp/test.jsonl", json=False))
+
+        out = capsys.readouterr().out
+        assert "No events recorded" in out
+
+
+class TestMain:
+    def test_no_command_prints_help_and_exits(self) -> None:
+        with patch("sys.argv", ["vaudeville"]):
+            from vaudeville.__main__ import main
 
             with pytest.raises(SystemExit, match="1"):
-                cmd_tail(self._make_args())
-
-    def test_single_session_tails(self) -> None:
-        with patch(
-            "vaudeville.__main__._find_log_files",
-            return_value=["/tmp/vaudeville-abc.log"],
-        ):
-            with patch("vaudeville.__main__.subprocess.run") as mock_run:
-                from vaudeville.__main__ import cmd_tail
-
-                cmd_tail(self._make_args())
-
-        mock_run.assert_called_once_with(["tail", "-f", "/tmp/vaudeville-abc.log"])
-
-    def test_multiple_sessions_without_all_exits(self) -> None:
-        logs = ["/tmp/vaudeville-a.log", "/tmp/vaudeville-b.log"]
-        with patch("vaudeville.__main__._find_log_files", return_value=logs):
-            from vaudeville.__main__ import cmd_tail
-
-            with pytest.raises(SystemExit, match="1"):
-                cmd_tail(self._make_args())
-
-    def test_multiple_sessions_with_all_tails_all(self) -> None:
-        logs = ["/tmp/vaudeville-a.log", "/tmp/vaudeville-b.log"]
-        with patch("vaudeville.__main__._find_log_files", return_value=logs):
-            with patch("vaudeville.__main__.subprocess.run") as mock_run:
-                from vaudeville.__main__ import cmd_tail
-
-                cmd_tail(self._make_args(all=True))
-
-        mock_run.assert_called_once_with(["tail", "-f"] + logs)
-
-    def test_session_flag_overrides_discovery(self) -> None:
-        logs = ["/tmp/vaudeville-a.log", "/tmp/vaudeville-b.log"]
-        with patch("vaudeville.__main__._find_log_files", return_value=logs):
-            with patch("vaudeville.__main__.os.path.exists", return_value=True):
-                with patch("vaudeville.__main__.subprocess.run") as mock_run:
-                    from vaudeville.__main__ import cmd_tail
-
-                    cmd_tail(self._make_args(session="b"))
-
-        mock_run.assert_called_once_with(["tail", "-f", "/tmp/vaudeville-b.log"])
-
-    def test_session_flag_missing_log_exits(self) -> None:
-        with patch(
-            "vaudeville.__main__._find_log_files",
-            return_value=["/tmp/vaudeville-a.log"],
-        ):
-            with patch("vaudeville.__main__.os.path.exists", return_value=False):
-                from vaudeville.__main__ import cmd_tail
-
-                with pytest.raises(SystemExit, match="1"):
-                    cmd_tail(self._make_args(session="missing"))
+                main()

--- a/tests/test_cli_stats.py
+++ b/tests/test_cli_stats.py
@@ -122,24 +122,24 @@ class TestPrintStatsHuman:
 class TestCmdWatch:
     def test_calls_watch_with_log_path(self) -> None:
         args = Namespace(log_path="/fake/events.jsonl")
-        with patch("vaudeville.server.watch.watch") as mock_watch:
+        with patch("vaudeville.server.watch") as mock_watch:
             cmd_watch(args)
         mock_watch.assert_called_once_with(log_path="/fake/events.jsonl")
 
     def test_catches_keyboard_interrupt(self) -> None:
         args = Namespace(log_path="/fake/events.jsonl")
-        with patch("vaudeville.server.watch.watch", side_effect=KeyboardInterrupt):
+        with patch("vaudeville.server.watch", side_effect=KeyboardInterrupt):
             cmd_watch(args)  # should not raise
 
     def test_main_dispatches_watch(self) -> None:
         with patch("sys.argv", ["vaudeville", "watch"]):
-            with patch("vaudeville.server.watch.watch") as mock_watch:
+            with patch("vaudeville.server.watch") as mock_watch:
                 mock_watch.side_effect = KeyboardInterrupt
                 main()
                 mock_watch.assert_called_once()
 
     def test_main_watch_custom_log_path(self) -> None:
         with patch("sys.argv", ["vaudeville", "watch", "--log-path", "/custom.jsonl"]):
-            with patch("vaudeville.server.watch.watch") as mock_watch:
+            with patch("vaudeville.server.watch") as mock_watch:
                 main()
                 mock_watch.assert_called_once_with(log_path="/custom.jsonl")

--- a/tests/test_condense.py
+++ b/tests/test_condense.py
@@ -14,7 +14,7 @@ from vaudeville.server.condense import (
     _split_into_chunks,
     condense_text,
 )
-from vaudeville.server.daemon import handle_request
+from vaudeville.server import handle_request
 
 
 class TestBuildCondensePrompt:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 import pytest
 
 from vaudeville.core.protocol import ClassifyResult
-from vaudeville.server.daemon import handle_request, VaudevilleDaemon
+from vaudeville.server import DaemonConfig, VaudevilleDaemon, handle_request
 from vaudeville.server.event_log import EventLogger
 from vaudeville.server.log_config import LogConfig
 from vaudeville.server.inference import LogprobBackend
@@ -172,10 +172,8 @@ class TestDaemonEventLoggerWiring:
         el = EventLogger(config=LogConfig(), logs_dir=logs_dir)
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            "/tmp/test.sock",
-            "/tmp/test.pid",
-            plugin_root,
             MockBackend(),
+            DaemonConfig("/tmp/test.sock", "/tmp/test.pid", plugin_root),
             event_logger=el,
         )
         assert daemon._event_logger is el
@@ -194,10 +192,8 @@ class TestDaemonEventLoggerWiring:
         pid = str(Path(tmp_path) / "test.pid")
         Path(pid).touch()
         daemon = VaudevilleDaemon(
-            sock,
-            pid,
-            plugin_root,
             MockBackend(),
+            DaemonConfig(sock, pid, plugin_root),
             event_logger=el,
         )
         daemon._cleanup()
@@ -208,10 +204,8 @@ class TestDaemonEventLoggerWiring:
         """Daemon defaults to None event_logger."""
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            "/tmp/test.sock",
-            "/tmp/test.pid",
-            plugin_root,
             MockBackend(),
+            DaemonConfig("/tmp/test.sock", "/tmp/test.pid", plugin_root),
         )
         assert daemon._event_logger is None
 
@@ -237,7 +231,8 @@ class TestDaemonSocketProtocol:
         ) as vf:
             version_file = vf.name
         daemon = VaudevilleDaemon(
-            socket_path, pid_file, plugin_root, backend, version_file=version_file
+            backend,
+            DaemonConfig(socket_path, pid_file, plugin_root, version_file),
         )
 
         thread = threading.Thread(target=daemon.serve, daemon=True)
@@ -295,7 +290,8 @@ class TestDaemonSocketProtocol:
         ) as vf:
             version_file = vf.name
         daemon = VaudevilleDaemon(
-            socket_path, pid_file, plugin_root, backend, version_file=version_file
+            backend,
+            DaemonConfig(socket_path, pid_file, plugin_root, version_file),
         )
 
         thread = threading.Thread(target=daemon.serve, daemon=True)
@@ -366,7 +362,8 @@ class TestBackendLockSerialization:
         ) as vf:
             version_file = vf.name
         daemon = VaudevilleDaemon(
-            socket_path, pid_file, plugin_root, SlowBackend(), version_file=version_file
+            SlowBackend(),
+            DaemonConfig(socket_path, pid_file, plugin_root, version_file),
         )
 
         thread = threading.Thread(target=daemon.serve, daemon=True)
@@ -427,7 +424,9 @@ class TestSignalHandlers:
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         backend = MockBackend()
-        daemon = VaudevilleDaemon(socket_path, pid_file, plugin_root, backend)
+        daemon = VaudevilleDaemon(
+            backend, DaemonConfig(socket_path, pid_file, plugin_root)
+        )
 
         # Install handlers (normally done by serve())
         daemon._install_signal_handlers()
@@ -447,7 +446,8 @@ class TestVersionStamp:
     ) -> "VaudevilleDaemon":
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         return VaudevilleDaemon(
-            socket_path, pid_file, plugin_root, MockBackend(), version_file=version_file
+            MockBackend(),
+            DaemonConfig(socket_path, pid_file, plugin_root, version_file),
         )
 
     def test_version_file_written_after_serve(self) -> None:

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -46,6 +46,7 @@ def rules() -> dict[str, Rule]:
             context=[{"field": "last_assistant_message"}],
             action="block",
             message="{reason}",
+            threshold=0.0,
         ),
     }
 
@@ -153,6 +154,68 @@ class TestClassifyCase:
         classify_case(case, rules["violation-detector"], backend, results)
         assert results.fn == 1
         assert results.misclassified[0]["actual"] == "violation"
+
+    def test_threshold_downgrades_low_confidence_violation(self) -> None:
+        """A violation with confidence below the rule threshold becomes clean."""
+        rule = Rule(
+            name="test-rule",
+            event="Stop",
+            prompt="Classify:\n{text}\nVERDICT:",
+            context=[],
+            action="block",
+            message="{reason}",
+            threshold=0.7,
+        )
+        backend = MockBackend(
+            verdict="violation",
+            reason="found issue",
+            logprobs={"violation": -1.5, "clean": -0.5},
+        )
+        results = EvalResults(rule="test-rule")
+        case = EvalCase(text="borderline text", label="clean")
+        cr = classify_case(case, rule, backend, results)
+        assert cr.predicted == "clean"
+        assert results.tn == 1
+        assert results.fp == 0
+
+    def test_threshold_keeps_high_confidence_violation(self) -> None:
+        """A violation with confidence above the rule threshold stays violation."""
+        rule = Rule(
+            name="test-rule",
+            event="Stop",
+            prompt="Classify:\n{text}\nVERDICT:",
+            context=[],
+            action="block",
+            message="{reason}",
+            threshold=0.5,
+        )
+        backend = MockBackend(
+            verdict="violation",
+            reason="found issue",
+            logprobs={"violation": -0.05, "clean": -5.0},
+        )
+        results = EvalResults(rule="test-rule")
+        case = EvalCase(text="hedging text", label="violation")
+        cr = classify_case(case, rule, backend, results)
+        assert cr.predicted == "violation"
+        assert results.tp == 1
+
+    def test_threshold_zero_disables_downgrade(self) -> None:
+        """threshold=0.0 means no downgrading even with zero confidence."""
+        rule = Rule(
+            name="test-rule",
+            event="Stop",
+            prompt="Classify:\n{text}\nVERDICT:",
+            context=[],
+            action="block",
+            message="{reason}",
+            threshold=0.0,
+        )
+        backend = MockBackend(verdict="violation", reason="found issue")
+        results = EvalResults(rule="test-rule")
+        case = EvalCase(text="test text", label="violation")
+        classify_case(case, rule, backend, results)
+        assert results.tp == 1
 
 
 class TestEvaluateRule:
@@ -351,6 +414,7 @@ class TestMain:
                         context=[{"field": "last_assistant_message"}],
                         action="block",
                         message="{reason}",
+                        threshold=0.0,
                     ),
                 },
             ),
@@ -380,6 +444,7 @@ class TestMain:
                         context=[{"field": "last_assistant_message"}],
                         action="block",
                         message="{reason}",
+                        threshold=0.0,
                     ),
                 },
             ),
@@ -411,6 +476,7 @@ class TestMain:
                         context=[{"field": "last_assistant_message"}],
                         action="block",
                         message="{reason}",
+                        threshold=0.0,
                     ),
                 },
             ),
@@ -446,6 +512,7 @@ class TestMain:
                         context=[{"field": "last_assistant_message"}],
                         action="block",
                         message="{reason}",
+                        threshold=0.0,
                     ),
                 },
             ),

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -25,6 +25,7 @@ from vaudeville.eval_report import (
     MIN_CALIBRATION_CASES,
     _find_best_threshold,
     _git_head,
+    CalibrateTarget,
     calibrate_rule,
     cross_validate_rule,
     find_rule_file,
@@ -382,6 +383,21 @@ class TestThresholdSweep:
         assert "0.90" in out
 
 
+class TestRunInference:
+    def test_non_logprob_backend_uses_classify(self) -> None:
+        """A backend without classify_with_logprobs falls back to classify()."""
+        from vaudeville.eval import _run_inference
+
+        class PlainBackend:
+            def classify(self, prompt: str, max_tokens: int = 50) -> str:  # noqa: ARG002
+                return "VERDICT: clean\nREASON: ok"
+
+        backend = PlainBackend()
+        result = _run_inference(backend, "test prompt")
+        assert result.text == "VERDICT: clean\nREASON: ok"
+        assert result.logprobs == {}
+
+
 class TestBuildBackend:
     def test_returns_mlx_backend(self) -> None:
         import argparse
@@ -733,9 +749,8 @@ class TestCalibrateRule:
             yaml.dump({"name": "violation-detector", "threshold": 0.5})
         )
         cases = [EvalCase(f"text {i}", "violation") for i in range(19)]
-        result = calibrate_rule(
-            "violation-detector", cases, rules, MockBackend(), str(rule_file)
-        )
+        target = CalibrateTarget("violation-detector", str(rule_file))
+        result = calibrate_rule(target, cases, rules, MockBackend())
         assert result is None
         out = capsys.readouterr().out
         assert "minimum" in out
@@ -793,9 +808,8 @@ class TestCalibrateRule:
             "vaudeville.eval.evaluate_rule",
             return_value=(mock_results, case_results),
         ):
-            result = calibrate_rule(
-                "violation-detector", cases, rules, MockBackend(), str(rule_file)
-            )
+            target = CalibrateTarget("violation-detector", str(rule_file))
+            result = calibrate_rule(target, cases, rules, MockBackend())
 
         assert result == 0.45
         with open(rule_file) as f:
@@ -832,9 +846,8 @@ class TestCalibrateRule:
             "vaudeville.eval.evaluate_rule",
             return_value=(mock_results, case_results),
         ):
-            result = calibrate_rule(
-                "violation-detector", cases, rules, MockBackend(), str(rule_file)
-            )
+            target = CalibrateTarget("violation-detector", str(rule_file))
+            result = calibrate_rule(target, cases, rules, MockBackend())
 
         assert result is None
         out = capsys.readouterr().out

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -122,6 +122,46 @@ class TestLoadTestCases:
         assert len(result["test-rule"]) == 1
 
 
+class TestCondenseIntegration:
+    """Verify condense_text is called for Stop+long, skipped otherwise."""
+
+    def test_condense_called_for_stop_long_text(self, rules: dict[str, Rule]) -> None:
+        long_text = "x" * 250
+        backend = MockBackend(verdict="clean", reason="ok")
+        results = EvalResults(rule="violation-detector")
+        case = EvalCase(text=long_text, label="clean")
+        with patch("vaudeville.eval.condense_text", return_value="condensed") as mock:
+            classify_case(case, rules["violation-detector"], backend, results)
+        mock.assert_called_once_with(long_text, backend)
+
+    def test_condense_skipped_for_stop_short_text(self, rules: dict[str, Rule]) -> None:
+        short_text = "short text"
+        backend = MockBackend(verdict="clean", reason="ok")
+        results = EvalResults(rule="violation-detector")
+        case = EvalCase(text=short_text, label="clean")
+        with patch("vaudeville.eval.condense_text") as mock:
+            classify_case(case, rules["violation-detector"], backend, results)
+        mock.assert_not_called()
+
+    def test_condense_skipped_for_pretooluse(self) -> None:
+        rule = Rule(
+            name="tool-rule",
+            event="PreToolUse",
+            prompt="Classify:\n{text}\nVERDICT:",
+            context=[],
+            action="block",
+            message="{reason}",
+            threshold=0.0,
+        )
+        long_text = "x" * 250
+        backend = MockBackend(verdict="clean", reason="ok")
+        results = EvalResults(rule="tool-rule")
+        case = EvalCase(text=long_text, label="clean")
+        with patch("vaudeville.eval.condense_text") as mock:
+            classify_case(case, rule, backend, results)
+        mock.assert_not_called()
+
+
 class TestClassifyCase:
     def test_true_positive(self, rules: dict[str, Rule]) -> None:
         backend = MockBackend(verdict="violation", reason="found issue")

--- a/tests/test_eval_main.py
+++ b/tests/test_eval_main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 from unittest.mock import MagicMock, patch
 
@@ -72,6 +73,69 @@ class TestMain:
 
                 main()
         assert exc_info.value.code == 1
+
+    def test_rules_dir_loads_from_specified_directory(self) -> None:
+        """--rules-dir loads rules only from the given directory."""
+        with tempfile.TemporaryDirectory() as rules_dir:
+            rule_path = os.path.join(rules_dir, "test-rule.yaml")
+            with open(rule_path, "w") as f:
+                yaml.dump(
+                    {
+                        "name": "test-rule",
+                        "event": "Stop",
+                        "prompt": "Classify:\n{text}\nVERDICT:",
+                        "action": "block",
+                        "message": "{reason}",
+                    },
+                    f,
+                )
+            mock_backend = MockBackend(verdict="clean")
+            mock_mlx_cls = MagicMock(return_value=mock_backend)
+            with (
+                patch(
+                    "sys.argv",
+                    ["eval", "--rules-dir", rules_dir, "--rule", "test-rule"],
+                ),
+                patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+                patch("vaudeville.eval.load_test_cases", return_value={}),
+            ):
+                with pytest.raises(SystemExit) as exc_info:
+                    from vaudeville.eval import main
+
+                    main()
+            # Exits 1 because no test suite, but load_rules_layered not called
+            assert exc_info.value.code == 1
+
+    def test_rules_dir_skips_layered_resolution(self) -> None:
+        """--rules-dir bypasses load_rules_layered entirely."""
+        with tempfile.TemporaryDirectory() as rules_dir:
+            rule_path = os.path.join(rules_dir, "violation-detector.yaml")
+            with open(rule_path, "w") as f:
+                yaml.dump(
+                    {
+                        "name": "violation-detector",
+                        "event": "Stop",
+                        "prompt": "Classify:\n{text}\nVERDICT:",
+                        "action": "block",
+                        "message": "{reason}",
+                    },
+                    f,
+                )
+            mock_backend = MockBackend(verdict="clean")
+            mock_mlx_cls = MagicMock(return_value=mock_backend)
+            mock_layered = MagicMock(side_effect=AssertionError("should not be called"))
+            with (
+                patch("sys.argv", ["eval", "--rules-dir", rules_dir]),
+                patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+                patch("vaudeville.eval.load_rules_layered", mock_layered),
+                patch("vaudeville.eval.load_test_cases", return_value={}),
+            ):
+                with pytest.raises(SystemExit) as exc_info:
+                    from vaudeville.eval import main
+
+                    main()
+            assert exc_info.value.code == 0
+            mock_layered.assert_not_called()
 
     def test_test_file_with_wrong_rule_exits_1(self) -> None:
         mock_mlx_cls = MagicMock(return_value=MockBackend())

--- a/tests/test_eval_main.py
+++ b/tests/test_eval_main.py
@@ -159,3 +159,215 @@ class TestMain:
 
                 main()
         assert exc_info.value.code == 1
+
+    def test_test_file_matching_rule_merges_cases(self) -> None:
+        """--test-file with matching --rule merges extra cases into the suite."""
+        from vaudeville.eval import EvalCase
+        from vaudeville.core.rules import Rule
+
+        zero_threshold_rule = Rule(
+            name="violation-detector",
+            event="Stop",
+            prompt="Classify:\n{text}\nVERDICT:",
+            context=[{"field": "last_assistant_message"}],
+            action="block",
+            message="{reason}",
+            threshold=0.0,
+        )
+        mock_mlx_cls = MagicMock(return_value=MockBackend(verdict="violation"))
+        with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
+            yaml.dump(
+                {
+                    "rule": "violation-detector",
+                    "cases": [{"text": "extra text", "label": "violation"}],
+                },
+                f,
+            )
+            tf = f.name
+        merged_suites: dict[str, list[object]] = {}
+
+        def capture_suites(args, rules, suites, backend):  # type: ignore[no-untyped-def]
+            merged_suites.update(suites)
+            from vaudeville.eval import EvalResults
+
+            return True, {
+                "violation-detector": EvalResults(rule="violation-detector", tp=2)
+            }
+
+        with (
+            patch(
+                "sys.argv",
+                ["eval", "--rule", "violation-detector", "--test-file", tf],
+            ),
+            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch(
+                "vaudeville.eval.load_rules_layered",
+                return_value={"violation-detector": zero_threshold_rule},
+            ),
+            patch(
+                "vaudeville.eval.load_test_cases",
+                return_value={
+                    "violation-detector": [EvalCase("existing text", "violation")]
+                },
+            ),
+            patch("vaudeville.eval_report.run_evaluations", side_effect=capture_suites),
+        ):
+            with pytest.raises(SystemExit):
+                from vaudeville.eval import main
+
+                main()
+        # Both the existing case and the extra case should be in the merged suite
+        assert len(merged_suites.get("violation-detector", [])) == 2
+
+    def test_eval_log_writes_log_when_results_exist(self) -> None:
+        """--eval-log causes write_eval_log to be called when results exist."""
+        from vaudeville.eval import EvalCase
+
+        mock_mlx_cls = MagicMock(return_value=MockBackend(verdict="violation"))
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            log_path = f.name
+        with (
+            patch(
+                "sys.argv",
+                ["eval", "--rule", "violation-detector", "--eval-log", log_path],
+            ),
+            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
+            patch(
+                "vaudeville.eval.load_test_cases",
+                return_value={"violation-detector": [EvalCase("text", "violation")]},
+            ),
+        ):
+            with pytest.raises(SystemExit):
+                from vaudeville.eval import main
+
+                main()
+        import os
+
+        assert os.path.getsize(log_path) > 0
+        os.unlink(log_path)
+
+    def test_threshold_sweep_flag_calls_sweep(self) -> None:
+        """--threshold-sweep invokes threshold_sweep."""
+        from vaudeville.eval import EvalCase
+
+        mock_mlx_cls = MagicMock(return_value=MockBackend(verdict="violation"))
+        mock_sweep = MagicMock()
+        with (
+            patch(
+                "sys.argv",
+                ["eval", "--rule", "violation-detector", "--threshold-sweep"],
+            ),
+            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
+            patch(
+                "vaudeville.eval.load_test_cases",
+                return_value={"violation-detector": [EvalCase("text", "violation")]},
+            ),
+            patch("vaudeville.eval_report.threshold_sweep", mock_sweep),
+        ):
+            with pytest.raises(SystemExit):
+                from vaudeville.eval import main
+
+                main()
+        mock_sweep.assert_called_once()
+
+    def test_calibrate_no_test_suite_exits_1(self) -> None:
+        """--calibrate exits 1 when no test suite exists for the rule."""
+        mock_mlx_cls = MagicMock(return_value=MockBackend())
+        with (
+            patch("sys.argv", ["eval", "--calibrate", "violation-detector"]),
+            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
+            patch("vaudeville.eval.load_test_cases", return_value={}),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                from vaudeville.eval import main
+
+                main()
+        assert exc_info.value.code == 1
+
+    def test_calibrate_no_rule_definition_exits_1(self) -> None:
+        """--calibrate exits 1 when rule is in test_suites but not in rules dict."""
+        from vaudeville.eval import EvalCase
+
+        mock_mlx_cls = MagicMock(return_value=MockBackend())
+        with (
+            patch("sys.argv", ["eval", "--calibrate", "violation-detector"]),
+            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.eval.load_rules_layered", return_value={}),
+            patch(
+                "vaudeville.eval.load_test_cases",
+                return_value={"violation-detector": [EvalCase("t", "clean")]},
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                from vaudeville.eval import main
+
+                main()
+        assert exc_info.value.code == 1
+
+    def test_calibrate_rule_file_not_found_exits_1(self) -> None:
+        """--calibrate exits 1 when the rule YAML file cannot be located."""
+        from vaudeville.eval import EvalCase
+
+        mock_mlx_cls = MagicMock(return_value=MockBackend())
+        with (
+            patch("sys.argv", ["eval", "--calibrate", "violation-detector"]),
+            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
+            patch(
+                "vaudeville.eval.load_test_cases",
+                return_value={"violation-detector": [EvalCase("t", "clean")]},
+            ),
+            patch("vaudeville.eval_report.find_rule_file", return_value=None),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                from vaudeville.eval import main
+
+                main()
+        assert exc_info.value.code == 1
+
+    def test_calibrate_success_exits_0(self) -> None:
+        """--calibrate exits 0 when calibrate_rule returns a threshold."""
+        import os
+        from vaudeville.eval import EvalCase
+
+        mock_mlx_cls = MagicMock(return_value=MockBackend())
+        with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
+            yaml.dump(
+                {
+                    "name": "violation-detector",
+                    "event": "Stop",
+                    "prompt": "Classify:\n{text}\nVERDICT:",
+                    "action": "block",
+                    "message": "{reason}",
+                    "threshold": 0.5,
+                },
+                f,
+            )
+            rule_file = f.name
+
+        with (
+            patch("sys.argv", ["eval", "--calibrate", "violation-detector"]),
+            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
+            patch(
+                "vaudeville.eval.load_test_cases",
+                return_value={"violation-detector": [EvalCase("t", "clean")]},
+            ),
+            patch(
+                "vaudeville.eval_report.find_rule_file",
+                return_value=rule_file,
+            ),
+            patch(
+                "vaudeville.eval_report.calibrate_rule",
+                return_value=0.5,
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                from vaudeville.eval import main
+
+                main()
+        os.unlink(rule_file)
+        assert exc_info.value.code == 0

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -235,7 +235,7 @@ class TestMLXCachedMethods:
         )
         # _warm_prefix uses generate_step, then classify_cached uses stream_generate
         mock_gen_step.return_value = iter([])
-        response = self._make_stream_response("VERDICT: clean")
+        response = self._make_stream_response(" clean")
         mock_stream_gen.return_value = iter([response])
 
         with self._patch_mlx_cache(backend):

--- a/tests/test_prompt_tuning.py
+++ b/tests/test_prompt_tuning.py
@@ -533,7 +533,7 @@ class TestEventDiscovery:
             ),
         }
 
-        with patch("vaudeville.core.rules.load_rules_layered", return_value=mock_rules):
+        with patch("vaudeville.core.load_rules_layered", return_value=mock_rules):
             stop_rules = runner._load_rules_for_event("Stop")
             assert len(stop_rules) == 1
             assert stop_rules[0].name == "stop-rule"

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -83,6 +83,7 @@ class TestEvaluateRule:
                 context=[{"field": "last_assistant_message"}],
                 action="block",
                 message="{reason}",
+                threshold=0.0,
             ),
         }
 

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -12,7 +12,7 @@ import threading
 import time
 from typing import Any
 
-from vaudeville.server.daemon import VaudevilleDaemon
+from vaudeville.server.daemon import DaemonConfig, VaudevilleDaemon
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +161,9 @@ class TestVersionStamp:
         from conftest import MockBackend
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        return VaudevilleDaemon(socket_path, pid_file, plugin_root, MockBackend())
+        return VaudevilleDaemon(
+            MockBackend(), DaemonConfig(socket_path, pid_file, plugin_root)
+        )
 
     def test_version_file_written_after_pid_lock(self) -> None:
         """serve() must write VERSION_FILE once the PID lock is acquired."""
@@ -291,15 +293,15 @@ class TestVersionStamp:
 
     def test_cleanup_removes_version_file_even_if_missing(self) -> None:
         """_cleanup() must not raise if VERSION_FILE does not exist."""
-        from vaudeville.server.daemon import VaudevilleDaemon
+        from vaudeville.server.daemon import DaemonConfig, VaudevilleDaemon
         from conftest import MockBackend
 
         plugin_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         daemon = VaudevilleDaemon(
-            "/tmp/_test_cleanup.sock",
-            "/tmp/_test_cleanup.pid",
-            plugin_root,
             MockBackend(),
+            DaemonConfig(
+                "/tmp/_test_cleanup.sock", "/tmp/_test_cleanup.pid", plugin_root
+            ),
         )
 
         # Ensure file absent

--- a/tests/test_tier_advisor.py
+++ b/tests/test_tier_advisor.py
@@ -123,19 +123,93 @@ class TestIngest:
 
 
 class TestAnalyze:
-    def test_find_next_user_message(self, analyze_mod: Any) -> None:
+    def test_find_next_user_message_within_window(self, analyze_mod: Any) -> None:
         msgs = [
             ("2026-04-10T09:00:00Z", "earlier"),
-            ("2026-04-10T10:05:00Z", "after violation"),
+            ("2026-04-10T10:02:00Z", "after violation"),
             ("2026-04-10T10:10:00Z", "later"),
         ]
         result = analyze_mod._find_next_user_message("2026-04-10T10:00:00Z", msgs)
         assert result == "after violation"
 
-    def test_find_next_user_message_none(self, analyze_mod: Any) -> None:
+    def test_find_next_user_message_none_before(self, analyze_mod: Any) -> None:
         msgs = [("2026-04-10T09:00:00Z", "earlier")]
         result = analyze_mod._find_next_user_message("2026-04-10T10:00:00Z", msgs)
         assert result is None
+
+    def test_find_next_user_message_none_beyond_window(self, analyze_mod: Any) -> None:
+        """Messages >5 minutes after the violation are ignored (cross-session)."""
+        msgs = [("2026-04-10T10:06:00Z", "too late")]
+        result = analyze_mod._find_next_user_message("2026-04-10T10:00:00Z", msgs)
+        assert result is None
+
+    def test_find_next_user_message_boundary(self, analyze_mod: Any) -> None:
+        msgs = [("2026-04-10T10:05:00Z", "just in time")]
+        result = analyze_mod._find_next_user_message("2026-04-10T10:00:00Z", msgs)
+        assert result == "just in time"
+
+    def test_add_minutes_rollover(self, analyze_mod: Any) -> None:
+        assert analyze_mod._add_minutes("23:58", 5) == "24:03"
+        assert analyze_mod._add_minutes("10:55", 10) == "11:05"
+        assert analyze_mod._add_minutes("10:00", 5) == "10:05"
+
+
+class TestKeywordMatching:
+    """Word-boundary matching prevents short keywords from matching inside words."""
+
+    def test_no_does_not_match_know(self, analyze_mod: Any) -> None:
+        assert not analyze_mod._CORRECTION_RE.search("I know that")
+
+    def test_no_does_not_match_another(self, analyze_mod: Any) -> None:
+        assert not analyze_mod._CORRECTION_RE.search("another thing entirely")
+
+    def test_no_matches_standalone(self, analyze_mod: Any) -> None:
+        assert analyze_mod._CORRECTION_RE.search("no, that's wrong")
+
+    def test_no_matches_at_start(self, analyze_mod: Any) -> None:
+        assert analyze_mod._CORRECTION_RE.search("No way")
+
+    def test_yes_does_not_match_yesterday(self, analyze_mod: Any) -> None:
+        assert not analyze_mod._ACK_RE.search("yesterday I tried")
+
+    def test_yes_matches_standalone(self, analyze_mod: Any) -> None:
+        assert analyze_mod._ACK_RE.search("yes, that's right")
+
+    def test_right_does_not_match_copyright(self, analyze_mod: Any) -> None:
+        assert not analyze_mod._ACK_RE.search("copyright notice")
+
+    def test_right_matches_standalone(self, analyze_mod: Any) -> None:
+        assert analyze_mod._ACK_RE.search("right, agreed")
+
+    def test_stop_does_not_match_unstoppable(self, analyze_mod: Any) -> None:
+        assert not analyze_mod._CORRECTION_RE.search("unstoppable force")
+
+    def test_stop_matches_standalone(self, analyze_mod: Any) -> None:
+        assert analyze_mod._CORRECTION_RE.search("stop doing that")
+
+    def test_long_keyword_still_uses_substring(self, analyze_mod: Any) -> None:
+        assert analyze_mod._CORRECTION_RE.search("that's not what I expected")
+
+    def test_pushback_false_positive_matches(self, analyze_mod: Any) -> None:
+        assert analyze_mod._PUSHBACK_RE.search("no that's fine, leave it")
+
+    def test_pushback_checked_case_insensitive(self, analyze_mod: Any) -> None:
+        assert analyze_mod._PUSHBACK_RE.search("FALSE POSITIVE detected")
+
+    def test_ack_good_catch(self, analyze_mod: Any) -> None:
+        assert analyze_mod._ACK_RE.search("good catch, thanks!")
+
+    def test_compile_keywords_boundary_for_single_words(self, analyze_mod: Any) -> None:
+        """Single-word keywords use word boundaries, multi-word use substring."""
+        import re
+
+        pattern = analyze_mod._compile_keywords(["no", "right", "longer phrase"])
+        assert pattern.flags & re.IGNORECASE
+        assert not pattern.search("know")
+        assert not pattern.search("copyright")
+        assert pattern.search("no way")
+        assert pattern.search("that's right")
+        assert pattern.search("a longer phrase here")
 
 
 class TestReport:

--- a/tests/test_tier_advisor.py
+++ b/tests/test_tier_advisor.py
@@ -1,0 +1,254 @@
+"""Tests for tier-advisor scripts: ingest, analyze, report."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent.parent / "skills" / "tier-advisor" / "scripts"
+
+
+def _load_module(name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / f"{name}.py")
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def ingest_mod() -> Any:
+    return _load_module("ingest")
+
+
+@pytest.fixture
+def analyze_mod() -> Any:
+    return _load_module("analyze")
+
+
+@pytest.fixture
+def report_mod() -> Any:
+    return _load_module("report")
+
+
+@pytest.fixture
+def tmp_logs(tmp_path: Path) -> Path:
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    return logs_dir
+
+
+@pytest.fixture
+def events_data() -> list[dict[str, Any]]:
+    return [
+        {
+            "ts": "2026-04-10T10:00:00+00:00",
+            "rule": "violation-detector",
+            "verdict": "clean",
+            "confidence": 0.85,
+            "latency_ms": 120.0,
+            "prompt_chars": 500,
+        },
+        {
+            "ts": "2026-04-10T10:01:00+00:00",
+            "rule": "violation-detector",
+            "verdict": "violation",
+            "confidence": 0.92,
+            "latency_ms": 130.0,
+            "prompt_chars": 600,
+        },
+    ]
+
+
+class TestIngest:
+    def test_read_jsonl(
+        self, ingest_mod: Any, tmp_logs: Path, events_data: list[dict[str, Any]]
+    ) -> None:
+        events_file = tmp_logs / "events.jsonl"
+        with open(events_file, "w") as f:
+            for row in events_data:
+                f.write(json.dumps(row) + "\n")
+
+        result = ingest_mod.read_jsonl(events_file)
+        assert len(result) == 2
+        assert result[0]["rule"] == "violation-detector"
+
+    def test_read_jsonl_missing_file(self, ingest_mod: Any, tmp_logs: Path) -> None:
+        result = ingest_mod.read_jsonl(tmp_logs / "nonexistent.jsonl")
+        assert result == []
+
+    def test_read_jsonl_malformed_lines(self, ingest_mod: Any, tmp_logs: Path) -> None:
+        f = tmp_logs / "bad.jsonl"
+        f.write_text('{"valid": true}\nnot json\n{"also": "valid"}\n')
+        result = ingest_mod.read_jsonl(f)
+        assert len(result) == 2
+
+    def test_snippet_hash_deterministic(self, ingest_mod: Any) -> None:
+        h1 = ingest_mod.snippet_hash("test input")
+        h2 = ingest_mod.snippet_hash("test input")
+        assert h1 == h2
+        assert len(h1) == 16
+
+    def test_snippet_hash_none(self, ingest_mod: Any) -> None:
+        h = ingest_mod.snippet_hash(None)
+        assert len(h) == 16
+
+    def test_build_records_deduplicates(
+        self, ingest_mod: Any, tmp_logs: Path, events_data: list[dict[str, Any]]
+    ) -> None:
+        events_file = tmp_logs / "events.jsonl"
+        with open(events_file, "w") as f:
+            for row in events_data:
+                f.write(json.dumps(row) + "\n")
+            for row in events_data:
+                f.write(json.dumps(row) + "\n")
+
+        violations_file = tmp_logs / "violations.jsonl"
+        violations_file.write_text("")
+
+        with (
+            patch.object(ingest_mod, "EVENTS_FILE", events_file),
+            patch.object(ingest_mod, "VIOLATIONS_FILE", violations_file),
+        ):
+            records = ingest_mod.build_records()
+        assert len(records) == 2
+
+
+class TestAnalyze:
+    def test_find_next_user_message(self, analyze_mod: Any) -> None:
+        msgs = [
+            ("2026-04-10T09:00:00Z", "earlier"),
+            ("2026-04-10T10:05:00Z", "after violation"),
+            ("2026-04-10T10:10:00Z", "later"),
+        ]
+        result = analyze_mod._find_next_user_message("2026-04-10T10:00:00Z", msgs)
+        assert result == "after violation"
+
+    def test_find_next_user_message_none(self, analyze_mod: Any) -> None:
+        msgs = [("2026-04-10T09:00:00Z", "earlier")]
+        result = analyze_mod._find_next_user_message("2026-04-10T10:00:00Z", msgs)
+        assert result is None
+
+
+class TestReport:
+    def _make_rule(self, **overrides: Any) -> dict[str, Any]:
+        base: dict[str, Any] = {
+            "rule": "test-rule",
+            "total_evals": 100,
+            "violations": 15,
+            "cleans": 85,
+            "violation_rate": 0.15,
+            "avg_confidence": 0.85,
+            "p50_confidence": 0.80,
+            "first_seen": "2026-04-01T00:00:00Z",
+            "last_seen": "2026-04-13T00:00:00Z",
+            "agreement_rate": 0.80,
+            "agreement_evaluated": 10,
+            "agreement_agreed": 8,
+            "agreement_disagreed": 2,
+            "agreement_uncertain": 5,
+        }
+        base.update(overrides)
+        return base
+
+    def test_classify_insufficient_data(self, report_mod: Any) -> None:
+        with patch.object(report_mod, "get_current_tier", return_value="shadow"):
+            rec, reason = report_mod.classify(self._make_rule(total_evals=5))
+        assert rec == "insufficient-data"
+        assert "5 evals" in reason
+
+    def test_classify_shadow_to_warn(self, report_mod: Any) -> None:
+        with patch.object(report_mod, "get_current_tier", return_value="shadow"):
+            rec, _ = report_mod.classify(
+                self._make_rule(
+                    total_evals=60, violation_rate=0.15, agreement_rate=0.75
+                )
+            )
+        assert rec == "promote-to-warn"
+
+    def test_classify_shadow_low_agreement(self, report_mod: Any) -> None:
+        with patch.object(report_mod, "get_current_tier", return_value="shadow"):
+            rec, _ = report_mod.classify(
+                self._make_rule(
+                    total_evals=60, violation_rate=0.15, agreement_rate=0.50
+                )
+            )
+        assert rec == "hold-at-shadow"
+
+    def test_classify_warn_demote_low_agreement(self, report_mod: Any) -> None:
+        with patch.object(report_mod, "get_current_tier", return_value="warn"):
+            rec, _ = report_mod.classify(self._make_rule(agreement_rate=0.30))
+        assert rec == "demote"
+
+    def test_classify_warn_demote_high_violation_rate(self, report_mod: Any) -> None:
+        with patch.object(report_mod, "get_current_tier", return_value="warn"):
+            rec, _ = report_mod.classify(
+                self._make_rule(violation_rate=0.70, agreement_rate=0.80)
+            )
+        assert rec == "demote"
+
+    def test_classify_warn_to_block(self, report_mod: Any) -> None:
+        with patch.object(report_mod, "get_current_tier", return_value="warn"):
+            rec, _ = report_mod.classify(
+                self._make_rule(
+                    total_evals=250,
+                    violation_rate=0.15,
+                    agreement_rate=0.90,
+                    p50_confidence=0.80,
+                )
+            )
+        assert rec == "promote-to-block"
+
+    def test_classify_hold_at_warn(self, report_mod: Any) -> None:
+        with patch.object(report_mod, "get_current_tier", return_value="warn"):
+            rec, _ = report_mod.classify(
+                self._make_rule(
+                    total_evals=80,
+                    violation_rate=0.15,
+                    agreement_rate=0.75,
+                )
+            )
+        assert rec == "hold-at-warn"
+
+    def test_classify_violation_rate_too_high_for_shadow(self, report_mod: Any) -> None:
+        with patch.object(report_mod, "get_current_tier", return_value="shadow"):
+            rec, _ = report_mod.classify(
+                self._make_rule(
+                    total_evals=60, violation_rate=0.50, agreement_rate=0.80
+                )
+            )
+        assert rec == "hold-at-shadow"
+
+    def test_format_report_produces_markdown(self, report_mod: Any) -> None:
+        rules = [
+            self._make_rule(rule="my-rule", total_evals=60, violation_rate=0.15),
+        ]
+        with patch.object(report_mod, "get_current_tier", return_value="shadow"):
+            report = report_mod.format_report(rules)
+        assert "# Tier Advisor Report" in report
+        assert "my-rule" in report
+        assert "Promote to Warn" in report
+
+    def test_get_current_tier_reads_yaml(self, report_mod: Any, tmp_path: Path) -> None:
+        rules_dir = tmp_path / "rules_dev"
+        rules_dir.mkdir()
+        (rules_dir / "test-rule.yaml").write_text("name: test-rule\ntier: warn\n")
+
+        with patch.object(report_mod, "RULES_DEV_DIR", rules_dir):
+            tier = report_mod.get_current_tier("test-rule")
+        assert tier == "warn"
+
+    def test_get_current_tier_missing_file(
+        self, report_mod: Any, tmp_path: Path
+    ) -> None:
+        with patch.object(report_mod, "RULES_DEV_DIR", tmp_path):
+            tier = report_mod.get_current_tier("nonexistent")
+        assert tier == "unknown"

--- a/vaudeville/__main__.py
+++ b/vaudeville/__main__.py
@@ -6,62 +6,10 @@ Usage: uv run python -m vaudeville <command>
 from __future__ import annotations
 
 import argparse
-import glob
 import json
 import os
-import subprocess
 import sys
-from pathlib import Path
 from typing import Any
-
-
-def _find_log_files() -> list[str]:
-    """Find active vaudeville log files with a running daemon."""
-    logs: list[str] = []
-    for log_path in sorted(glob.glob("/tmp/vaudeville-*.log")):
-        session_id = log_path.removeprefix("/tmp/vaudeville-").removesuffix(".log")
-        pid_file = f"/tmp/vaudeville-{session_id}.pid"
-        try:
-            pid = int(Path(pid_file).read_text().strip())
-            os.kill(pid, 0)  # check if alive
-            logs.append(log_path)
-        except (FileNotFoundError, ValueError, ProcessLookupError, PermissionError):
-            continue
-    return logs
-
-
-def cmd_tail(args: argparse.Namespace) -> None:
-    """Tail active vaudeville daemon logs."""
-    logs = _find_log_files()
-
-    if not logs:
-        print("[vaudeville] No active daemon found.", file=sys.stderr)
-        print(
-            "Start a Claude Code session with vaudeville hooks to spawn a daemon.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    if args.session:
-        target = f"/tmp/vaudeville-{args.session}.log"
-        if not os.path.exists(target):
-            print(f"[vaudeville] Log not found: {target}", file=sys.stderr)
-            sys.exit(1)
-        logs = [target]
-    elif len(logs) > 1 and not args.all:
-        print(f"[vaudeville] {len(logs)} active sessions found:", file=sys.stderr)
-        for log in logs:
-            print(f"  {log}", file=sys.stderr)
-        print(
-            "Use --all to tail all, or specify --session <id>.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    try:
-        subprocess.run(["tail", "-f"] + logs)
-    except KeyboardInterrupt:
-        pass
 
 
 _EVENTS_LOG = os.path.join(
@@ -71,7 +19,7 @@ _EVENTS_LOG = os.path.join(
 
 def cmd_watch(args: argparse.Namespace) -> None:
     """Launch the live watch TUI."""
-    from vaudeville.server.watch import watch
+    from vaudeville.server import watch
 
     try:
         watch(log_path=args.log_path)
@@ -105,7 +53,6 @@ def _print_stats_human(result: dict[str, Any]) -> None:
 
     rules = result["rules"]
     if rules:
-        # Column headers
         hdr = (
             f"{'Rule':<30} {'Total':>6} {'Violations':>11} {'Pass %':>7} {'Avg ms':>7}"
         )
@@ -154,16 +101,6 @@ def main() -> None:
         default=_EVENTS_LOG,
         help="Path to events.jsonl (default: ~/.vaudeville/logs/events.jsonl)",
     )
-
-    # Hidden — superseded by `watch`, kept as fallback
-    if sys.argv[1:2] == ["tail"]:
-        tail_parser = argparse.ArgumentParser(prog="vaudeville tail")
-        tail_group = tail_parser.add_mutually_exclusive_group()
-        tail_group.add_argument("--all", action="store_true")
-        tail_group.add_argument("--session")
-        tail_args = tail_parser.parse_args(sys.argv[2:])
-        cmd_tail(argparse.Namespace(command="tail", **vars(tail_args)))
-        return
 
     args = parser.parse_args()
     if args.command is None:

--- a/vaudeville/eval.py
+++ b/vaudeville/eval.py
@@ -19,7 +19,7 @@ import yaml
 from .core.protocol import ClassifyResult, compute_confidence, parse_verdict
 from .core.rules import Rule, load_rules, load_rules_layered
 from .server import InferenceBackend, LogprobBackend
-from .server.condense import condense_text
+from .server import condense_text
 
 
 def _find_project_root() -> str | None:
@@ -129,6 +129,24 @@ def _run_inference(backend: InferenceBackend, prompt: str) -> ClassifyResult:
     return ClassifyResult(text=text)
 
 
+def _update_results(results: EvalResults, case: EvalCase, predicted: str) -> None:
+    positive, negative = "violation", "clean"
+    if case.label == positive and predicted == positive:
+        results.tp += 1
+    elif case.label == negative and predicted == negative:
+        results.tn += 1
+    elif case.label == negative and predicted == positive:
+        results.fp += 1
+        results.misclassified.append(
+            {"text": case.text, "actual": negative, "predicted": positive}
+        )
+    else:
+        results.fn += 1
+        results.misclassified.append(
+            {"text": case.text, "actual": positive, "predicted": negative}
+        )
+
+
 def classify_case(
     case: EvalCase,
     rule: Rule,
@@ -136,7 +154,6 @@ def classify_case(
     results: EvalResults,
 ) -> CaseResult:
     """Classify a single case and update results. Returns CaseResult."""
-    positive, negative = "violation", "clean"
     text = case.text
     if rule.event == "Stop" and len(text) >= 200:
         text = condense_text(text, backend)
@@ -146,34 +163,11 @@ def classify_case(
     predicted = response.verdict
     confidence = compute_confidence(result.logprobs, predicted)
 
-    # Apply rule threshold: low-confidence violations are downgraded to clean
     if predicted == "violation" and rule.threshold > 0 and confidence < rule.threshold:
         predicted = "clean"
 
     results.confidences.append(confidence)
-
-    if case.label == positive and predicted == positive:
-        results.tp += 1
-    elif case.label == negative and predicted == negative:
-        results.tn += 1
-    elif case.label == negative and predicted == positive:
-        results.fp += 1
-        results.misclassified.append(
-            {
-                "text": case.text,
-                "actual": negative,
-                "predicted": positive,
-            }
-        )
-    else:
-        results.fn += 1
-        results.misclassified.append(
-            {
-                "text": case.text,
-                "actual": positive,
-                "predicted": negative,
-            }
-        )
+    _update_results(results, case, predicted)
 
     return CaseResult(
         text=case.text,
@@ -250,44 +244,6 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _run_calibrate(
-    args: argparse.Namespace,
-    rules: dict[str, Rule],
-    test_suites: dict[str, list[EvalCase]],
-    backend: InferenceBackend,
-) -> None:
-    """Run --calibrate subcommand and exit."""
-    from .core.rules import rules_search_path
-    from .eval_report import calibrate_rule, find_rule_file
-
-    cal_rule = args.calibrate
-    if cal_rule not in test_suites:
-        print(f"No test suite found for rule: {cal_rule}")
-        sys.exit(1)
-    if cal_rule not in rules:
-        print(f"Rule not found: {cal_rule}")
-        sys.exit(1)
-
-    plugin_root = os.environ.get(
-        "CLAUDE_PLUGIN_ROOT",
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-    )
-    if args.rules_dir:
-        search_dirs = [args.rules_dir]
-    else:
-        search_dirs = rules_search_path(project_root=_find_project_root())
-        for subdir in ("rules", "examples/rules"):
-            d = os.path.join(plugin_root, subdir)
-            if os.path.isdir(d) and d not in search_dirs:
-                search_dirs.append(d)
-    rule_file = find_rule_file(cal_rule, search_dirs)
-    if not rule_file:
-        print(f"Cannot find YAML file for rule: {cal_rule}")
-        sys.exit(1)
-    result = calibrate_rule(cal_rule, test_suites[cal_rule], rules, backend, rule_file)
-    sys.exit(0 if result is not None else 1)
-
-
 def main() -> None:
     args = _build_parser().parse_args()
 
@@ -315,7 +271,9 @@ def main() -> None:
         test_suites[args.rule] = existing + extra_cases
 
     if args.calibrate:
-        _run_calibrate(args, rules, test_suites, backend)
+        from .eval_report import run_calibrate
+
+        run_calibrate(args, rules, test_suites, backend, _find_project_root())
 
     if args.rule:
         test_suites = {k: v for k, v in test_suites.items() if k == args.rule}

--- a/vaudeville/eval.py
+++ b/vaudeville/eval.py
@@ -142,6 +142,10 @@ def classify_case(
     predicted = response.verdict
     confidence = compute_confidence(result.logprobs, predicted)
 
+    # Apply rule threshold: low-confidence violations are downgraded to clean
+    if predicted == "violation" and rule.threshold > 0 and confidence < rule.threshold:
+        predicted = "clean"
+
     results.confidences.append(confidence)
 
     if case.label == positive and predicted == positive:

--- a/vaudeville/eval.py
+++ b/vaudeville/eval.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 import yaml
 
 from .core.protocol import ClassifyResult, compute_confidence, parse_verdict
-from .core.rules import Rule, load_rules_layered
+from .core.rules import Rule, load_rules, load_rules_layered
 from .server import InferenceBackend, LogprobBackend
 
 
@@ -232,6 +232,10 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Path to JSONL file for regression tracking (appends one line per run)",
     )
     parser.add_argument(
+        "--rules-dir",
+        help="Load rules from this directory only (skip layered resolution)",
+    )
+    parser.add_argument(
         "--backend", default="mlx", choices=["mlx"], help="Inference backend"
     )
     parser.add_argument(
@@ -264,11 +268,14 @@ def _run_calibrate(
         "CLAUDE_PLUGIN_ROOT",
         os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     )
-    search_dirs = rules_search_path(project_root=_find_project_root())
-    for subdir in ("rules", "examples/rules"):
-        d = os.path.join(plugin_root, subdir)
-        if os.path.isdir(d) and d not in search_dirs:
-            search_dirs.append(d)
+    if args.rules_dir:
+        search_dirs = [args.rules_dir]
+    else:
+        search_dirs = rules_search_path(project_root=_find_project_root())
+        for subdir in ("rules", "examples/rules"):
+            d = os.path.join(plugin_root, subdir)
+            if os.path.isdir(d) and d not in search_dirs:
+                search_dirs.append(d)
     rule_file = find_rule_file(cal_rule, search_dirs)
     if not rule_file:
         print(f"Cannot find YAML file for rule: {cal_rule}")
@@ -287,7 +294,10 @@ def main() -> None:
     tests_dir = os.path.join(plugin_root, "tests")
 
     backend = _build_backend(args)
-    rules = load_rules_layered(project_root=_find_project_root())
+    if args.rules_dir:
+        rules = load_rules(args.rules_dir)
+    else:
+        rules = load_rules_layered(project_root=_find_project_root())
     test_suites = load_test_cases(tests_dir)
 
     if args.test_file and args.rule:

--- a/vaudeville/eval.py
+++ b/vaudeville/eval.py
@@ -19,6 +19,7 @@ import yaml
 from .core.protocol import ClassifyResult, compute_confidence, parse_verdict
 from .core.rules import Rule, load_rules, load_rules_layered
 from .server import InferenceBackend, LogprobBackend
+from .server.condense import condense_text
 
 
 def _find_project_root() -> str | None:
@@ -136,7 +137,10 @@ def classify_case(
 ) -> CaseResult:
     """Classify a single case and update results. Returns CaseResult."""
     positive, negative = "violation", "clean"
-    prompt = rule.format_prompt(case.text)
+    text = case.text
+    if rule.event == "Stop" and len(text) >= 200:
+        text = condense_text(text, backend)
+    prompt = rule.format_prompt(text)
     result = _run_inference(backend, prompt)
     response = parse_verdict(result.text)
     predicted = response.verdict

--- a/vaudeville/eval_report.py
+++ b/vaudeville/eval_report.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import subprocess
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from typing import TYPE_CHECKING
@@ -241,29 +242,86 @@ def find_rule_file(rule_name: str, search_dirs: list[str]) -> str | None:
     for d in search_dirs:
         try:
             for filename in os.listdir(d):
-                if not (filename.endswith(".yaml") or filename.endswith(".yml")):
-                    continue
-                path = os.path.join(d, filename)
-                with open(path) as f:
-                    data = yaml.safe_load(f)
-                if isinstance(data, dict) and data.get("name") == rule_name:
-                    return path
+                match = _check_file_for_rule(os.path.join(d, filename), rule_name)
+                if match:
+                    return match
         except OSError:
             continue
     return None
 
 
+def _check_file_for_rule(path: str, rule_name: str) -> str | None:
+    """Return path if the file is a YAML rule matching rule_name, else None."""
+    if not (path.endswith(".yaml") or path.endswith(".yml")):
+        return None
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    if isinstance(data, dict) and data.get("name") == rule_name:
+        return path
+    return None
+
+
+def run_calibrate(
+    args: argparse.Namespace,
+    rules: dict[str, Rule],
+    test_suites: dict[str, list["EvalCase"]],
+    backend: InferenceBackend,
+    project_root: str | None,
+) -> None:
+    """Run --calibrate subcommand and exit."""
+    import sys
+
+    from .core.rules import rules_search_path
+
+    cal_rule = args.calibrate
+    if cal_rule not in test_suites:
+        print(f"No test suite found for rule: {cal_rule}")
+        sys.exit(1)
+    if cal_rule not in rules:
+        print(f"Rule not found: {cal_rule}")
+        sys.exit(1)
+
+    plugin_root = os.environ.get(
+        "CLAUDE_PLUGIN_ROOT",
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    )
+    if args.rules_dir:
+        search_dirs = [args.rules_dir]
+    else:
+        search_dirs = rules_search_path(project_root=project_root)
+        for subdir in ("rules", "examples/rules"):
+            d = os.path.join(plugin_root, subdir)
+            if os.path.isdir(d) and d not in search_dirs:
+                search_dirs.append(d)
+    rule_file = find_rule_file(cal_rule, search_dirs)
+    if not rule_file:
+        print(f"Cannot find YAML file for rule: {cal_rule}")
+        sys.exit(1)
+    target = CalibrateTarget(rule_name=cal_rule, rule_file=rule_file)
+    result = calibrate_rule(target, test_suites[cal_rule], rules, backend)
+    sys.exit(0 if result is not None else 1)
+
+
 MIN_CALIBRATION_CASES = 20
 
 
+@dataclass
+class CalibrateTarget:
+    """Bundle identifying a rule to calibrate and where its YAML lives."""
+
+    rule_name: str
+    rule_file: str
+
+
 def calibrate_rule(
-    rule_name: str,
+    target: CalibrateTarget,
     cases: list[EvalCase],
     rules: dict[str, Rule],
     backend: InferenceBackend,
-    rule_file: str,
 ) -> float | None:
     """Run threshold sweep, pick F1-optimal, write to rule YAML. Returns threshold or None."""
+    rule_name = target.rule_name
+    rule_file = target.rule_file
     if len(cases) < MIN_CALIBRATION_CASES:
         print(
             f"ERROR: {rule_name} has {len(cases)} labeled cases"

--- a/vaudeville/server/__init__.py
+++ b/vaudeville/server/__init__.py
@@ -1,5 +1,6 @@
 from .condense import condense_text
-from .daemon import VaudevilleDaemon
+from ._handlers import handle_request
+from .daemon import DaemonConfig, VaudevilleDaemon
 from .event_log import ClassificationEvent, EventLogger
 from .inference import InferenceBackend, LogprobBackend
 from .log_config import LogConfig, load_log_config
@@ -9,6 +10,7 @@ from .watch import watch
 
 __all__ = [
     "ClassificationEvent",
+    "DaemonConfig",
     "EventLogger",
     "InferenceBackend",
     "LogConfig",
@@ -18,6 +20,7 @@ __all__ = [
     "aggregate_events",
     "condense_text",
     "empty_result",
+    "handle_request",
     "load_log_config",
     "watch",
 ]

--- a/vaudeville/server/__main__.py
+++ b/vaudeville/server/__main__.py
@@ -103,7 +103,7 @@ def main() -> None:
     backend = _init_backend(backend_name, args.model)
     logging.info("Backend ready")
 
-    from .daemon import VaudevilleDaemon
+    from .daemon import DaemonConfig, VaudevilleDaemon
     from .event_log import EventLogger
 
     try:
@@ -114,11 +114,14 @@ def main() -> None:
         )
         event_logger = None
 
-    daemon = VaudevilleDaemon(
+    config = DaemonConfig(
         socket_path=args.socket,
         pid_file=args.pid_file,
         plugin_root=plugin_root,
+    )
+    daemon = VaudevilleDaemon(
         backend=backend,
+        config=config,
         pid_fd=pid_fd,
         event_logger=event_logger,
     )

--- a/vaudeville/server/condense.py
+++ b/vaudeville/server/condense.py
@@ -60,7 +60,7 @@ def _split_into_chunks(text: str, max_chars: int) -> list[str]:
     current_len = 0
 
     for line in lines:
-        line_len = len(line) + 1  # +1 for the newline we'll rejoin with
+        line_len = len(line) + 1
         if current and current_len + line_len > max_chars:
             chunks.append("\n".join(current))
             current = []

--- a/vaudeville/server/daemon.py
+++ b/vaudeville/server/daemon.py
@@ -15,13 +15,23 @@ import socket
 import subprocess
 import threading
 import time
+from dataclasses import dataclass
 
 from ..core.paths import VERSION_FILE, ensure_runtime_dir
 from ._handlers import handle_request
 from .event_log import EventLogger
 from .inference import InferenceBackend
 
-__all__ = ["VaudevilleDaemon", "acquire_pid_lock", "handle_request"]
+__all__ = ["DaemonConfig", "VaudevilleDaemon", "acquire_pid_lock"]
+
+
+@dataclass
+class DaemonConfig:
+    socket_path: str
+    pid_file: str
+    plugin_root: str
+    version_file: str = VERSION_FILE
+
 
 IDLE_TIMEOUT = 60 * 60  # 60 minutes
 RECV_CHUNK = 4096
@@ -88,19 +98,13 @@ def _read_message(conn: socket.socket) -> bytes:
 class VaudevilleDaemon:
     def __init__(
         self,
-        socket_path: str,
-        pid_file: str,
-        plugin_root: str,
         backend: InferenceBackend,
-        version_file: str = VERSION_FILE,
+        config: DaemonConfig,
         pid_fd: int | None = None,
         event_logger: EventLogger | None = None,
     ) -> None:
-        self._socket_path = socket_path
-        self._pid_file = pid_file
-        self._plugin_root = plugin_root
         self._backend = backend
-        self._version_file = version_file
+        self.config = config
         self._backend_lock = threading.Lock()
         self._last_request = time.monotonic()
         self._stop_event = threading.Event()
@@ -123,7 +127,7 @@ class VaudevilleDaemon:
 
         # Acquire PID lock if not pre-acquired by __main__
         if self._pid_fd is None:
-            pid_fd = acquire_pid_lock(self._pid_file)
+            pid_fd = acquire_pid_lock(self.config.pid_file)
             if pid_fd is None:
                 logger.info("Another instance holds PID lock — exiting")
                 return
@@ -133,15 +137,15 @@ class VaudevilleDaemon:
 
         server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
-            os.unlink(self._socket_path)
+            os.unlink(self.config.socket_path)
         except (FileNotFoundError, PermissionError):
             pass
-        server_socket.bind(self._socket_path)
+        server_socket.bind(self.config.socket_path)
         server_socket.listen(16)
         server_socket.settimeout(1.0)
 
         threading.Thread(target=self._watch_threads, daemon=True).start()
-        logger.info("Listening on %s", self._socket_path)
+        logger.info("Listening on %s", self.config.socket_path)
 
         try:
             self._accept_loop(server_socket)
@@ -199,7 +203,7 @@ class VaudevilleDaemon:
         try:
             result = subprocess.run(
                 ["git", "rev-parse", "HEAD"],
-                cwd=self._plugin_root,
+                cwd=self.config.plugin_root,
                 capture_output=True,
                 text=True,
                 timeout=5,
@@ -208,7 +212,7 @@ class VaudevilleDaemon:
         except (OSError, subprocess.TimeoutExpired):
             stamp = "unknown"
         try:
-            with open(self._version_file, "w") as f:
+            with open(self.config.version_file, "w") as f:
                 f.write(stamp + "\n")
         except OSError:
             logger.warning("Could not write version stamp")
@@ -219,7 +223,11 @@ class VaudevilleDaemon:
         if self._pid_fd is not None:
             os.close(self._pid_fd)
             self._pid_fd = None
-        for path in (self._socket_path, self._pid_file, self._version_file):
+        for path in (
+            self.config.socket_path,
+            self.config.pid_file,
+            self.config.version_file,
+        ):
             try:
                 os.unlink(path)
             except FileNotFoundError:

--- a/vaudeville/server/mlx_backend.py
+++ b/vaudeville/server/mlx_backend.py
@@ -68,7 +68,7 @@ class MLXBackend:
             prompt_tokens,
             max_tokens,
         )
-        text: str = "VERDICT:" + self._tokenizer.decode(tokens)
+        text = "VERDICT:" + self._tokenizer.decode(tokens)
         return ClassifyResult(text=text, logprobs=first_logprobs)
 
     def classify_cached(
@@ -95,7 +95,7 @@ class MLXBackend:
             parts.append(response.text)
             if response.finish_reason is not None:
                 break
-        return "".join(parts)
+        return "VERDICT:" + "".join(parts)
 
     def _get_or_warm_cache(self, user_prefix: str) -> list[Any]:
         """Return a deepcopy of the KV cache for a prefix, warming on first call.


### PR DESCRIPTION
## Summary

Ships two independent slices of the rule-tuning-v0.2 work:

**(a) Eval harness improvements**
- `fix(eval)`: apply rule YAML thresholds when scoring cases (previously ignored, all rules effectively ran at 0.5)
- `feat(eval)`: `--rules-dir` flag to load rules from an arbitrary directory (enables shadow/dev rule sets)
- `feat(eval)`: auto-condense Stop-rule inputs >=200 chars via `condense_text()` so eval mirrors daemon runtime behavior

**(c) Tier-advisor skill**
- New `skills/tier-advisor/` with three scripts:
  - `ingest.py` — loads `~/.vaudeville/logs/*.jsonl` into DuckDB
  - `analyze.py` — per-rule metrics + next-message user-agreement proxy
  - `report.py` — grouped markdown output (promote / demote / insufficient-data)
- Fixed promotion thresholds: shadow→warn needs >=50 evals + agreement >=70% + violation rate 2-40%; warn→block needs >=200 evals + agreement >=85% + violation rate 5-30% + confidence p50 >=0.7; warn→shadow demotion on agreement <50% or violation rate >60%

Rule changes and hard-hooks from the same branch are **not** included here — they will ship as separate PRs.

## Test plan

- [x] `just check` — format + lint + mypy clean
- [x] `just test` — 627 passed, 3 skipped
- [ ] Manual: run `/tier-advisor` against a log dir once merged to verify end-to-end