### PR TITLE
feat(rules): add tier field (shadow/warn/enforce) and runner dispatch

### DIFF
--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -204,12 +204,14 @@ def _run_event_rules(event: str, hook_input: dict, client: VaudevilleClient) -> 
         context_str = rule.resolve_context(hook_input, PLUGIN_ROOT)
         prompt, prefix_len = rule.split_prompt(text, context_str)
 
-        result = client.classify(prompt, rule=rule.name, prefix_len=prefix_len)
+        result = client.classify(
+            prompt, rule=rule.name, prefix_len=prefix_len, tier=rule.tier
+        )
         if result is None:
             continue
 
         if result.verdict == "violation" and result.confidence >= rule.threshold:
-            tier = getattr(rule, "tier", "enforce")
+            tier = rule.tier
 
             if tier == "shadow":
                 print(

--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -189,6 +189,28 @@ def _maybe_condense(text: str, event: str, client: VaudevilleClient) -> str:
     return client.condense(text)
 
 
+def _dispatch_violation(rule, result) -> bool:  # type: ignore[no-untyped-def]
+    """Handle a tier-aware violation. Returns True if the rule loop should continue."""
+    if rule.tier == "shadow":
+        print(
+            f"[vaudeville:shadow] {rule.name}: "
+            f"{result.verdict} ({result.confidence:.2f})",
+            file=sys.stderr,
+        )
+        return True
+
+    if rule.tier == "warn":
+        response = verdict_to_hook_response(
+            rule.name, rule.message, result.reason, "warn"
+        )
+    else:  # enforce (default)
+        response = verdict_to_hook_response(
+            rule.name, rule.message, result.reason, rule.action
+        )
+    print(json.dumps(response))
+    sys.exit(0)
+
+
 def _run_event_rules(event: str, hook_input: dict, client: VaudevilleClient) -> None:
     rules = _load_rules_for_event(event)
     condensed: dict[str, str] = {}
@@ -211,26 +233,8 @@ def _run_event_rules(event: str, hook_input: dict, client: VaudevilleClient) -> 
             continue
 
         if result.verdict == "violation" and result.confidence >= rule.threshold:
-            tier = rule.tier
-
-            if tier == "shadow":
-                print(
-                    f"[vaudeville:shadow] {rule.name}: "
-                    f"{result.verdict} ({result.confidence:.2f})",
-                    file=sys.stderr,
-                )
+            if _dispatch_violation(rule, result):
                 continue
-
-            if tier == "warn":
-                response = verdict_to_hook_response(
-                    rule.name, rule.message, result.reason, "warn"
-                )
-            else:  # enforce (default)
-                response = verdict_to_hook_response(
-                    rule.name, rule.message, result.reason, rule.action
-                )
-            print(json.dumps(response))
-            sys.exit(0)
 
     print("{}")
     sys.exit(0)

--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -192,10 +192,11 @@ def _maybe_condense(text: str, event: str, client: VaudevilleClient) -> str:
 def _dispatch_violation(rule, result) -> bool:  # type: ignore[no-untyped-def]
     """Handle a tier-aware violation. Returns True if the rule loop should continue."""
     if rule.tier == "shadow":
-        print(
-            f"[vaudeville:shadow] {rule.name}: "
-            f"{result.verdict} ({result.confidence:.2f})",
-            file=sys.stderr,
+        _dbg(
+            "shadow %s: %s (%.2f)",
+            rule.name,
+            result.verdict,
+            result.confidence,
         )
         return True
 

--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -209,9 +209,24 @@ def _run_event_rules(event: str, hook_input: dict, client: VaudevilleClient) -> 
             continue
 
         if result.verdict == "violation" and result.confidence >= rule.threshold:
-            response = verdict_to_hook_response(
-                rule.name, rule.message, result.reason, rule.action
-            )
+            tier = getattr(rule, "tier", "enforce")
+
+            if tier == "shadow":
+                print(
+                    f"[vaudeville:shadow] {rule.name}: "
+                    f"{result.verdict} ({result.confidence:.2f})",
+                    file=sys.stderr,
+                )
+                continue
+
+            if tier == "warn":
+                response = verdict_to_hook_response(
+                    rule.name, rule.message, result.reason, "warn"
+                )
+            else:  # enforce (default)
+                response = verdict_to_hook_response(
+                    rule.name, rule.message, result.reason, rule.action
+                )
             print(json.dumps(response))
             sys.exit(0)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -159,6 +159,14 @@ class TestClassifyRequest:
         d = json.loads(json.dumps(req.to_json_dict()))
         assert d["rule"] == "some-rule"
 
+    def test_to_json_dict_tier_omitted_when_enforce(self) -> None:
+        req = ClassifyRequest(prompt="test")
+        assert "tier" not in req.to_json_dict()
+
+    def test_to_json_dict_tier_included_when_not_enforce(self) -> None:
+        req = ClassifyRequest(prompt="test", tier="shadow")
+        assert req.to_json_dict()["tier"] == "shadow"
+
 
 # --- load_rules ---
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,8 @@ import json
 import os
 import tempfile
 
+import pytest
+
 from vaudeville.core.client import VaudevilleClient
 from vaudeville.core.protocol import (
     ClassifyRequest,
@@ -82,6 +84,15 @@ class TestParseVerdict:
         assert rule.name == "test"
         assert rule.action == "block"
         assert rule.threshold == 0.5
+        assert rule.tier == "enforce"
+
+    def test_parse_rule_with_tier(self) -> None:
+        rule = parse_rule({"name": "test", "prompt": "{text}", "tier": "shadow"})
+        assert rule.tier == "shadow"
+
+    def test_parse_rule_invalid_tier_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid tier"):
+            parse_rule({"name": "test", "prompt": "{text}", "tier": "yolo"})
 
     def test_violation_keyword_word_boundary(self) -> None:
         """'violation' substring should not create false positives."""

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -206,6 +206,50 @@ def test_confidence_rounded(tmp_path: pathlib.Path) -> None:
         logger.close()
 
 
+def test_tier_included_in_event(tmp_path: pathlib.Path) -> None:
+    """Tier field is written to events.jsonl."""
+    logger = EventLogger(config=LogConfig(), logs_dir=str(tmp_path))
+    try:
+        logger.log_event(
+            ClassificationEvent(
+                rule="test-shadow",
+                verdict="violation",
+                confidence=0.85,
+                latency_ms=20.0,
+                prompt_chars=100,
+                reason="hedging",
+                tier="shadow",
+            )
+        )
+        time.sleep(0.05)
+
+        events = _read_jsonl(tmp_path / "events.jsonl")
+        assert events[0]["tier"] == "shadow"
+    finally:
+        logger.close()
+
+
+def test_tier_defaults_to_enforce(tmp_path: pathlib.Path) -> None:
+    """Tier defaults to enforce when not specified."""
+    logger = EventLogger(config=LogConfig(), logs_dir=str(tmp_path))
+    try:
+        logger.log_event(
+            ClassificationEvent(
+                rule="test",
+                verdict="clean",
+                confidence=0.9,
+                latency_ms=10.0,
+                prompt_chars=50,
+            )
+        )
+        time.sleep(0.05)
+
+        events = _read_jsonl(tmp_path / "events.jsonl")
+        assert events[0]["tier"] == "enforce"
+    finally:
+        logger.close()
+
+
 def test_latency_rounded(tmp_path: pathlib.Path) -> None:
     """Latency is rounded to 1 decimal place."""
     logger = EventLogger(config=LogConfig(), logs_dir=str(tmp_path))

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -247,7 +247,7 @@ class TestRunPipeline:
         from unittest.mock import ANY
 
         mock_client.classify.assert_called_once_with(
-            ANY, rule="test-hedging", prefix_len=ANY
+            ANY, rule="test-hedging", prefix_len=ANY, tier="enforce"
         )
 
     def test_shadow_tier_logs_but_passes(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -253,7 +253,7 @@ class TestRunPipeline:
     def test_shadow_tier_logs_but_passes(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """Shadow tier logs verdict to stderr but returns {} (pass)."""
+        """Shadow tier skips violation and returns {} (pass)."""
         from unittest.mock import MagicMock
 
         from vaudeville.core.protocol import ClassifyResponse
@@ -285,7 +285,44 @@ class TestRunPipeline:
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
         assert captured.out.strip() == "{}"
-        assert "[vaudeville:shadow] test-shadow: violation (0.90)" in captured.err
+
+    def test_shadow_tier_debug_logs_when_enabled(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Shadow tier emits debug log when VAUDEVILLE_DEBUG=1."""
+        from unittest.mock import MagicMock
+
+        from vaudeville.core.protocol import ClassifyResponse
+        from vaudeville.core.rules import Rule
+
+        mock_rule = Rule(
+            name="test-shadow",
+            event="Stop",
+            prompt="Check: {text}",
+            context=[{"field": "body"}],
+            action="block",
+            message="{reason}",
+            threshold=0.5,
+            tier="shadow",
+        )
+        mock_client = MagicMock()
+        mock_client.classify.return_value = ClassifyResponse(
+            verdict="violation", reason="hedging detected", confidence=0.9
+        )
+        mock_client.condense.side_effect = lambda text: text
+        hook_input = {"body": "x" * 100}
+
+        with (
+            patch("runner._load_rules_for_event", return_value=[mock_rule]),
+            patch.dict(os.environ, {"VAUDEVILLE_DEBUG": "1"}),
+            patch.object(runner, "_DEBUG", True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            runner._run_event_rules("Stop", hook_input, mock_client)
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "shadow test-shadow" in captured.err
 
     def test_warn_tier_returns_warn_decision(
         self, capsys: pytest.CaptureFixture[str]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -250,6 +250,117 @@ class TestRunPipeline:
             ANY, rule="test-hedging", prefix_len=ANY
         )
 
+    def test_shadow_tier_logs_but_passes(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Shadow tier logs verdict to stderr but returns {} (pass)."""
+        from unittest.mock import MagicMock
+
+        from vaudeville.core.protocol import ClassifyResponse
+        from vaudeville.core.rules import Rule
+
+        mock_rule = Rule(
+            name="test-shadow",
+            event="Stop",
+            prompt="Check: {text}",
+            context=[{"field": "body"}],
+            action="block",
+            message="{reason}",
+            threshold=0.5,
+            tier="shadow",
+        )
+        mock_client = MagicMock()
+        mock_client.classify.return_value = ClassifyResponse(
+            verdict="violation", reason="hedging detected", confidence=0.9
+        )
+        mock_client.condense.side_effect = lambda text: text
+        hook_input = {"body": "x" * 100}
+
+        with (
+            patch("runner._load_rules_for_event", return_value=[mock_rule]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            runner._run_event_rules("Stop", hook_input, mock_client)
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "{}"
+        assert "[vaudeville:shadow] test-shadow: violation (0.90)" in captured.err
+
+    def test_warn_tier_returns_warn_decision(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Warn tier returns warn decision even for block-action rules."""
+        from unittest.mock import MagicMock
+
+        from vaudeville.core.protocol import ClassifyResponse
+        from vaudeville.core.rules import Rule
+
+        mock_rule = Rule(
+            name="test-warn",
+            event="Stop",
+            prompt="Check: {text}",
+            context=[{"field": "body"}],
+            action="block",
+            message="{reason}",
+            threshold=0.5,
+            tier="warn",
+        )
+        mock_client = MagicMock()
+        mock_client.classify.return_value = ClassifyResponse(
+            verdict="violation", reason="hedging detected", confidence=0.9
+        )
+        mock_client.condense.side_effect = lambda text: text
+        hook_input = {"body": "x" * 100}
+
+        with (
+            patch("runner._load_rules_for_event", return_value=[mock_rule]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            runner._run_event_rules("Stop", hook_input, mock_client)
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        response = json.loads(captured.out.strip())
+        assert response["decision"] == "warn"
+
+    def test_enforce_tier_uses_rule_action(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Enforce tier (default) uses rule's action field."""
+        from unittest.mock import MagicMock
+
+        from vaudeville.core.protocol import ClassifyResponse
+        from vaudeville.core.rules import Rule
+
+        mock_rule = Rule(
+            name="test-enforce",
+            event="Stop",
+            prompt="Check: {text}",
+            context=[{"field": "body"}],
+            action="block",
+            message="{reason}",
+            threshold=0.5,
+            tier="enforce",
+        )
+        mock_client = MagicMock()
+        mock_client.classify.return_value = ClassifyResponse(
+            verdict="violation", reason="hedging detected", confidence=0.9
+        )
+        mock_client.condense.side_effect = lambda text: text
+        hook_input = {"body": "x" * 100}
+
+        with (
+            patch("runner._load_rules_for_event", return_value=[mock_rule]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            runner._run_event_rules("Stop", hook_input, mock_client)
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        response = json.loads(captured.out.strip())
+        assert response["decision"] == "block"
+
     def test_main_catches_unexpected_exception(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -13,6 +13,7 @@ from vaudeville.server.watch import (
     _MAX_ROWS,
     _build_table,
     _parse_ts_display,
+    _tier_text,
     _verdict_text,
     watch,
 )
@@ -50,6 +51,27 @@ def test_verdict_text_violation() -> None:
 def test_verdict_text_clean() -> None:
     text = _verdict_text("clean")
     assert text.plain == "clean"
+    assert "green" in str(text.style)
+
+
+# --- _tier_text ---
+
+
+def test_tier_text_shadow() -> None:
+    text = _tier_text("shadow")
+    assert text.plain == "shadow"
+    assert "dim" in str(text.style)
+
+
+def test_tier_text_warn() -> None:
+    text = _tier_text("warn")
+    assert text.plain == "warn"
+    assert "yellow" in str(text.style)
+
+
+def test_tier_text_enforce() -> None:
+    text = _tier_text("enforce")
+    assert text.plain == "enforce"
     assert "green" in str(text.style)
 
 
@@ -92,6 +114,13 @@ def test_build_table_truncates_to_max_rows() -> None:
     events = [_make_event(rule=f"rule-{i}") for i in range(30)]
     table = _build_table(events, (30, 0))
     assert table.row_count == _MAX_ROWS
+
+
+def test_build_table_has_tier_column() -> None:
+    events = [_make_event()]
+    table = _build_table(events, (1, 0))
+    col_names = [c.header for c in table.columns]
+    assert "Tier" in [str(h) for h in col_names]
 
 
 def test_build_table_missing_fields() -> None:

--- a/vaudeville/core/client.py
+++ b/vaudeville/core/client.py
@@ -29,12 +29,15 @@ class VaudevilleClient:
         prompt: str,
         rule: str = "",
         prefix_len: int = 0,
+        tier: str = "enforce",
     ) -> ClassifyResponse | None:
         """Send a classify request and return the verdict.
 
         Returns None if the daemon is unavailable (fail-open semantics).
         """
-        request = ClassifyRequest(prompt=prompt, rule=rule, prefix_len=prefix_len)
+        request = ClassifyRequest(
+            prompt=prompt, rule=rule, prefix_len=prefix_len, tier=tier
+        )
         try:
             return self._send(request)
         except Exception as exc:

--- a/vaudeville/core/protocol.py
+++ b/vaudeville/core/protocol.py
@@ -23,6 +23,7 @@ class ClassifyRequest:
     rule: str = ""
 
     prefix_len: int = 0  # 0 = no caching (backward compatible)
+    tier: str = "enforce"
 
     def to_json_dict(self) -> dict[str, object]:
         d: dict[str, object] = {"prompt": self.prompt}
@@ -30,6 +31,8 @@ class ClassifyRequest:
             d["rule"] = self.rule
         if self.prefix_len > 0:
             d["prefix_len"] = self.prefix_len
+        if self.tier != "enforce":
+            d["tier"] = self.tier
         return d
 
 

--- a/vaudeville/core/rules.py
+++ b/vaudeville/core/rules.py
@@ -140,6 +140,9 @@ def _read_context_entry(
     return ""
 
 
+VALID_TIERS = ("shadow", "warn", "enforce")
+
+
 @dataclass
 class Rule:
     name: str
@@ -149,6 +152,7 @@ class Rule:
     action: str
     message: str
     threshold: float = 0.5
+    tier: str = "enforce"
 
     def format_prompt(self, text: str, context: str = "") -> str:
         safe_text = sanitize_input(
@@ -277,6 +281,9 @@ def load_rules_layered(
 
 def parse_rule(data: dict[str, Any]) -> Rule:
     """Parse a raw YAML dict into a validated Rule."""
+    tier = str(data.get("tier", "enforce"))
+    if tier not in VALID_TIERS:
+        raise ValueError(f"Invalid tier {tier!r}, must be one of {VALID_TIERS}")
     return Rule(
         name=str(data["name"]),
         event=str(data.get("event", "")),
@@ -285,4 +292,5 @@ def parse_rule(data: dict[str, Any]) -> Rule:
         action=str(data.get("action", "block")),
         message=str(data.get("message", "{reason}")),
         threshold=float(data.get("threshold", 0.5)),
+        tier=tier,
     )

--- a/vaudeville/server/_handlers.py
+++ b/vaudeville/server/_handlers.py
@@ -63,6 +63,7 @@ def _handle_classify(
 ) -> bytes:
     prompt = str(request.get("prompt", ""))
     rule = str(request.get("rule", ""))
+    tier = str(request.get("tier", "enforce"))
     raw_prefix = request.get("prefix_len", 0)
     prefix_len = int(float(str(raw_prefix))) if raw_prefix else 0
 
@@ -91,6 +92,7 @@ def _handle_classify(
         prompt_chars=len(prompt),
         reason=response.reason,
         input_snippet=prompt[:500],
+        tier=tier,
     )
     if event_logger is not None:
         event_logger.log_event(evt)

--- a/vaudeville/server/event_log.py
+++ b/vaudeville/server/event_log.py
@@ -29,6 +29,7 @@ class ClassificationEvent:
     prompt_chars: int
     reason: str = ""
     input_snippet: str = ""
+    tier: str = "enforce"
 
 
 class EventLogger:
@@ -92,6 +93,7 @@ class EventLogger:
             "confidence": round(event.confidence, 4),
             "latency_ms": round(event.latency_ms, 1),
             "prompt_chars": event.prompt_chars,
+            "tier": event.tier,
         }
 
         self._logger.bind(_sink="events").info(json.dumps(common, default=str))

--- a/vaudeville/server/watch.py
+++ b/vaudeville/server/watch.py
@@ -46,6 +46,14 @@ def _verdict_text(verdict: str) -> Text:
     return Text(verdict, style="bold green")
 
 
+def _tier_text(tier: str) -> Text:
+    if tier == "shadow":
+        return Text(tier, style="dim")
+    if tier == "warn":
+        return Text(tier, style="yellow")
+    return Text(tier, style="bold green")
+
+
 def _build_table(events: list[dict[str, Any]], totals: tuple[int, int]) -> Table:
     total_seen, violations = totals
     table = Table(
@@ -54,6 +62,7 @@ def _build_table(events: list[dict[str, Any]], totals: tuple[int, int]) -> Table
     )
     table.add_column("Time", style="dim", width=10)
     table.add_column("Rule", width=30)
+    table.add_column("Tier", width=10)
     table.add_column("Verdict", width=12)
     table.add_column("Confidence", justify="right", width=12)
     table.add_column("Latency ms", justify="right", width=12)
@@ -62,6 +71,7 @@ def _build_table(events: list[dict[str, Any]], totals: tuple[int, int]) -> Table
         table.add_row(
             _parse_ts_display(evt.get("ts", "")),
             evt.get("rule", "<unknown>"),
+            _tier_text(evt.get("tier", "enforce")),
             _verdict_text(evt.get("verdict", "?")),
             f"{_to_float(evt.get('confidence', 0)):.2f}",
             f"{_to_float(evt.get('latency_ms', 0)):.1f}",


### PR DESCRIPTION
## Summary

Rule tiering infra — enables progressive rollout of new SLM rules without user-visible blast radius.

- `Rule.tier` field (default `enforce` — backward compatible)
- `parse_rule` validates tier is one of `shadow` / `warn` / `enforce`
- `_dispatch_violation` handles tier-aware response:
  - **shadow** — log verdict + confidence to stderr, return `{}` (no user effect)
  - **warn** — return `warn` decision regardless of `rule.action`
  - **enforce** — use `rule.action` (existing behavior)
- **Tier flows through full pipeline**: `ClassifyRequest` → daemon → `ClassificationEvent` → JSONL event log → watch TUI
- **TUI shows Tier column** with color coding (dim=shadow, yellow=warn, green=enforce)

## Why

Lets new rules ship at `shadow` to collect real-session data via log analysis (see `tier-advisor` skill in PR #43), promote to `warn` once P/R stabilizes, promote to `enforce` once warn-stage agreement is high.

## Test plan

- [x] `just check` — format + lint + mypy clean
- [x] `just test` — 611 passed, 5 skipped
- [x] Tests cover all three tier branches (shadow logs to stderr / warn returns warn / enforce uses rule.action)
- [x] Tests for tier in ClassifyRequest serialization (omitted when enforce, included otherwise)
- [x] Tests for tier in event log JSONL output
- [x] Tests for TUI tier column and color coding