### PR TITLE
feat(cli): add vaudeville command entry point and install-cli recipe

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -42,10 +42,14 @@ case "$arch" in
 esac
 ```
 
-3. **Download the model** (~2.4 GB, one-time):
+3. **Download the model** (~2.4 GB, one-time) — prefer the installed CLI shim, fall back to the module:
 
 ```bash
-uv run --project "${CLAUDE_PLUGIN_ROOT}" python -m vaudeville.setup
+if command -v vaudeville &>/dev/null; then
+  vaudeville setup
+else
+  uv run --project "${CLAUDE_PLUGIN_ROOT}" python -m vaudeville setup
+fi
 ```
 
 4. **Verify the daemon starts** — restart the session or run the session-start hook manually:

--- a/justfile
+++ b/justfile
@@ -55,6 +55,42 @@ fmt-check:
 type-check:
     uv run mypy --strict vaudeville/ tests/
 
+# Install `vaudeville` CLI to ~/.local/bin (via uv tool). Does NOT modify shell rc files.
+install-cli:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    arch=$(uname -m)
+    case "$arch" in
+        arm64|aarch64)
+            backend="mlx"
+            with_args=(--with "mlx-lm>=0.31.0,<0.32")
+            ;;
+        *)
+            backend="gguf"
+            with_args=(--with "llama-cpp-python>=0.3.4" --with "huggingface-hub>=0.24.0")
+            ;;
+    esac
+    echo "Installing vaudeville CLI (backend: $backend)..."
+    uv tool install --force "${with_args[@]}" .
+    bin_dir="${HOME}/.local/bin"
+    if [[ ":${PATH}:" == *":${bin_dir}:"* ]]; then
+        echo "✓ vaudeville installed. ${bin_dir} is already on PATH."
+        exit 0
+    fi
+    echo ""
+    echo "⚠  ${bin_dir} is NOT on your PATH."
+    echo "   Add it to your shell rc yourself (we don't touch dotfiles):"
+    echo ""
+    shell_name=$(basename "${SHELL:-}")
+    case "$shell_name" in
+        zsh)  echo "     echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.zshrc" ;;
+        bash) echo "     echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc" ;;
+        fish) echo "     fish_add_path ~/.local/bin" ;;
+        *)    echo "     export PATH=\"\$HOME/.local/bin:\$PATH\"   # add to your shell rc" ;;
+    esac
+    echo ""
+    echo "   Or run \`uv tool update-shell\` to let uv patch it for you."
+
 # Download the inference model (one-time setup, ~2.4 GB, arch-aware backend)
 setup:
     #!/usr/bin/env bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ dependencies = [
     "rich>=13.0",
 ]
 
+[project.scripts]
+vaudeville = "vaudeville.__main__:main"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,18 @@ class TestCmdStats:
         assert "No events recorded" in out
 
 
+class TestCmdSetup:
+    def test_setup_calls_setup_main(self) -> None:
+        from argparse import Namespace
+
+        with patch("vaudeville.setup.main") as mock_setup:
+            from vaudeville.__main__ import cmd_setup
+
+            cmd_setup(Namespace())
+
+        mock_setup.assert_called_once_with()
+
+
 class TestMain:
     def test_no_command_prints_help_and_exits(self) -> None:
         with patch("sys.argv", ["vaudeville"]):
@@ -62,3 +74,14 @@ class TestMain:
 
             with pytest.raises(SystemExit, match="1"):
                 main()
+
+    def test_setup_command_dispatches(self) -> None:
+        with (
+            patch("sys.argv", ["vaudeville", "setup"]),
+            patch("vaudeville.setup.main") as mock_setup,
+        ):
+            from vaudeville.__main__ import main
+
+            main()
+
+        mock_setup.assert_called_once_with()

--- a/vaudeville/__main__.py
+++ b/vaudeville/__main__.py
@@ -27,6 +27,13 @@ def cmd_watch(args: argparse.Namespace) -> None:
         pass
 
 
+def cmd_setup(_args: argparse.Namespace) -> None:
+    """Run model download and verification."""
+    from vaudeville.setup import main as setup_main
+
+    setup_main()
+
+
 def cmd_stats(args: argparse.Namespace) -> None:
     """Print aggregated classification statistics."""
     from vaudeville.server import aggregate_events
@@ -94,6 +101,8 @@ def main() -> None:
         help="Path to events.jsonl (default: ~/.vaudeville/logs/events.jsonl)",
     )
 
+    sub.add_parser("setup", help="Download model and verify inference")
+
     stats_parser = sub.add_parser("stats", help="Show classification statistics")
     stats_parser.add_argument("--json", action="store_true", help="Output raw JSON")
     stats_parser.add_argument(
@@ -109,6 +118,8 @@ def main() -> None:
 
     if args.command == "watch":
         cmd_watch(args)
+    elif args.command == "setup":
+        cmd_setup(args)
     elif args.command == "stats":
         cmd_stats(args)
 


### PR DESCRIPTION
## Summary

Wire the vaudeville setup command into the CLI as a subcommand, add a [project.scripts] entry point for `uv tool install`, and create an `install-cli` justfile recipe.

- **Architecture-aware backend selection**: Detects ARM64 vs x86_64 and installs appropriate backend (MLX vs llama-cpp)
- **CLI-first execution path**: Prefers installed `vaudeville` command shim with fallback to module invocation
- **Developer autonomy**: Detects if `~/.local/bin` is on PATH but does NOT auto-modify shell rc files — prints shell-specific one-liners so developers can decide
- **Explicit dependencies**: Fixed silent failures from previous approach by making backend dependencies explicit in install command

## Test plan

- [ ] Run `just install-cli` to install the CLI
- [ ] Verify `vaudeville --help` shows the setup subcommand
- [ ] Run `vaudeville setup` to download and verify the model
- [ ] Verify all quality gates pass: `just check` and `just test`