### PR TITLE
fix(mlx): stop generation at REASON newline to prevent run-on output

### DIFF
--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -139,7 +139,8 @@ class TestMLXBackend:
 
     def test_apply_chat_template_fallback_when_no_method(self) -> None:
         class BareTokenizer:
-            pass
+            def encode(self, s: str, **_kw: Any) -> list[int]:
+                return list(range(len(s)))
 
         mock_model = MagicMock()
         mock_load = MagicMock(return_value=(mock_model, BareTokenizer()))
@@ -163,7 +164,9 @@ class TestMLXBackend:
 class TestMLXCachedMethods:
     """Tests for KV cache prefix reuse in MLXBackend."""
 
-    def _make_stream_response(self, text: str, finish_reason: str = "stop") -> Any:
+    def _make_stream_response(
+        self, text: str, finish_reason: str | None = "stop"
+    ) -> Any:
         resp = MagicMock()
         resp.text = text
         resp.finish_reason = finish_reason
@@ -454,6 +457,50 @@ class TestMLXCachedMethods:
 
         # Should have decoded only [42, 2] (stopped at eos)
         assert result.text.startswith("VERDICT:")
+
+    # -- newline stop in classify_cached and _collect_tokens --
+
+    def test_classify_cached_stops_at_second_newline(self) -> None:
+        """classify_cached() stops generation at the REASON newline threshold."""
+        backend, mock_stream_gen, mock_gen_step, _ = self._build_backend()
+        mock_gen_step.return_value = iter([])  # warm returns no tokens
+
+        chunks = [" violation", "\n", "REASON: done.", "\n", "run-on text"]
+        responses = [self._make_stream_response(c, finish_reason=None) for c in chunks]
+        mock_stream_gen.return_value = iter(responses)
+
+        with self._patch_mlx_cache(backend):
+            result = backend.classify_cached("rule prefix text", prefix_len=12)
+
+        assert result == "VERDICT: violation\nREASON: done.\n"
+        assert "run-on" not in result
+
+    def test_collect_tokens_stops_at_newline_threshold(self) -> None:
+        """_collect_tokens halts after REASON_NEWLINE_STOP newline token IDs."""
+
+        def make_token(val: int) -> Any:
+            t = MagicMock()
+            t.item.return_value = val
+            return t
+
+        mock_logprobs = MagicMock()
+        # encode("\n") → [0] via the mock's lambda (len("\n") == 1)
+        # so _newline_token_ids = frozenset({0})
+        # Stream: [42, 0, 43, 0, 44] — stop after second 0, collect [42, 0, 43, 0]
+        token_ids = [42, 0, 43, 0, 44]
+        gen_pairs = [(make_token(tid), mock_logprobs) for tid in token_ids]
+
+        backend, _, mock_gen_step, _ = self._build_backend(
+            generate_step_tokens=gen_pairs,
+        )
+        mock_gen_step.return_value = iter(gen_pairs)
+
+        mock_mx = MagicMock()
+        with patch.dict("sys.modules", {"mlx": MagicMock(), "mlx.core": mock_mx}):
+            result_tokens, _ = backend._collect_tokens(MagicMock(), max_tokens=50)
+
+        assert result_tokens == [42, 0, 43, 0]
+        assert 44 not in result_tokens
 
     # -- helpers --
 

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -5,7 +5,9 @@ from unittest.mock import MagicMock, patch
 
 
 class TestMLXBackend:
-    def _make_stream_response(self, text: str, finish_reason: str = "stop") -> Any:
+    def _make_stream_response(
+        self, text: str, finish_reason: str | None = "stop"
+    ) -> Any:
         resp = MagicMock()
         resp.text = text
         resp.finish_reason = finish_reason
@@ -43,6 +45,64 @@ class TestMLXBackend:
         _, _, mock_load, mock_stream_generate, mock_generate_step = self._make_mocks(
             "VERDICT: clean"
         )
+        modules = self._patch_mlx_modules(
+            mock_load, mock_stream_generate, mock_generate_step
+        )
+        with patch.dict("sys.modules", modules):
+            from vaudeville.server.mlx_backend import MLXBackend
+
+            backend = MLXBackend("test-model")
+            result = backend.classify("test prompt")
+        assert result == "VERDICT: clean"
+
+    def test_classify_stops_at_second_newline(self) -> None:
+        """Generation halts after REASON line; prompt-echo run-on is dropped."""
+        _, _, mock_load, _, mock_generate_step = self._make_mocks()
+        chunks = [
+            "VERDICT: violation",
+            "\n",
+            "REASON: work done.",
+            "\n",
+            "Classify this response",
+        ]
+        responses = [self._make_stream_response(c, finish_reason=None) for c in chunks]
+        mock_stream_generate = MagicMock(return_value=iter(responses))
+        modules = self._patch_mlx_modules(
+            mock_load, mock_stream_generate, mock_generate_step
+        )
+        with patch.dict("sys.modules", modules):
+            from vaudeville.server.mlx_backend import MLXBackend
+
+            backend = MLXBackend("test-model")
+            result = backend.classify("test prompt")
+        assert result == "VERDICT: violation\nREASON: work done.\n"
+        assert "Classify" not in result
+
+    def test_classify_stops_when_newlines_in_single_chunk(self) -> None:
+        """A single chunk containing both newlines still terminates generation."""
+        _, _, mock_load, _, mock_generate_step = self._make_mocks()
+        responses = [
+            self._make_stream_response(
+                "VERDICT: clean\nREASON: ok.\n", finish_reason=None
+            ),
+            self._make_stream_response("run-on text", finish_reason=None),
+        ]
+        mock_stream_generate = MagicMock(return_value=iter(responses))
+        modules = self._patch_mlx_modules(
+            mock_load, mock_stream_generate, mock_generate_step
+        )
+        with patch.dict("sys.modules", modules):
+            from vaudeville.server.mlx_backend import MLXBackend
+
+            backend = MLXBackend("test-model")
+            result = backend.classify("test prompt")
+        assert result == "VERDICT: clean\nREASON: ok.\n"
+
+    def test_classify_respects_finish_reason_before_newlines(self) -> None:
+        """finish_reason still wins — no artificial wait for two newlines."""
+        _, _, mock_load, _, mock_generate_step = self._make_mocks()
+        responses = [self._make_stream_response("VERDICT: clean", finish_reason="stop")]
+        mock_stream_generate = MagicMock(return_value=iter(responses))
         modules = self._patch_mlx_modules(
             mock_load, mock_stream_generate, mock_generate_step
         )

--- a/vaudeville/server/mlx_backend.py
+++ b/vaudeville/server/mlx_backend.py
@@ -16,6 +16,10 @@ from ..core.protocol import ClassifyResult
 DEFAULT_MODEL = "mlx-community/Phi-4-mini-instruct-4bit"
 TOP_K_LOGPROBS = 10
 MAX_PREFIX_CACHES = 16
+# The system prompt pins output to `VERDICT: x\nREASON: <sentence>` — two
+# newlines mark the end of the reason. mlx_lm has no GBNF/stop-sequence
+# equivalent to the llama.cpp grammar, so we stop the stream ourselves.
+REASON_NEWLINE_STOP = 2
 SYSTEM_PROMPT = (
     "You are a binary classifier. Respond with exactly `VERDICT: violation` "
     "or `VERDICT: clean` followed by `REASON: <one sentence>`. No other text."
@@ -41,6 +45,7 @@ class MLXBackend:
         """Run inference on prompt, return raw text output."""
         formatted = self._apply_chat_template(prompt)
         parts: list[str] = []
+        newlines = 0
         for response in self._stream_generate(
             self._model,
             self._tokenizer,
@@ -48,7 +53,8 @@ class MLXBackend:
             max_tokens=max_tokens,
         ):
             parts.append(response.text)
-            if response.finish_reason is not None:
+            newlines += response.text.count("\n")
+            if response.finish_reason is not None or newlines >= REASON_NEWLINE_STOP:
                 break
         return "".join(parts)
 
@@ -85,6 +91,7 @@ class MLXBackend:
             add_special_tokens=False,
         )
         parts: list[str] = []
+        newlines = 0
         for response in self._stream_generate(
             self._model,
             self._tokenizer,
@@ -93,7 +100,8 @@ class MLXBackend:
             prompt_cache=request_cache,
         ):
             parts.append(response.text)
-            if response.finish_reason is not None:
+            newlines += response.text.count("\n")
+            if response.finish_reason is not None or newlines >= REASON_NEWLINE_STOP:
                 break
         return "VERDICT:" + "".join(parts)
 
@@ -168,6 +176,7 @@ class MLXBackend:
         """Run generate_step collecting token IDs and first-token logprobs."""
         tokens: list[int] = []
         first_logprobs: dict[str, float] = {}
+        newlines = 0
         kwargs: dict[str, Any] = {"max_tokens": max_tokens}
         if cache is not None:
             kwargs["prompt_cache"] = cache
@@ -185,6 +194,9 @@ class MLXBackend:
                 break
             eos = getattr(self._tokenizer, "eos_token_id", None)
             if eos is not None and token_id == eos:
+                break
+            newlines += self._tokenizer.decode([token_id]).count("\n")
+            if newlines >= REASON_NEWLINE_STOP:
                 break
         return tokens, first_logprobs
 

--- a/vaudeville/server/mlx_backend.py
+++ b/vaudeville/server/mlx_backend.py
@@ -16,9 +16,10 @@ from ..core.protocol import ClassifyResult
 DEFAULT_MODEL = "mlx-community/Phi-4-mini-instruct-4bit"
 TOP_K_LOGPROBS = 10
 MAX_PREFIX_CACHES = 16
-# The system prompt pins output to `VERDICT: x\nREASON: <sentence>` — two
-# newlines mark the end of the reason. mlx_lm has no GBNF/stop-sequence
-# equivalent to the llama.cpp grammar, so we stop the stream ourselves.
+# The system prompt constrains output to `VERDICT: x\nREASON: <sentence>`.
+# We count newlines in generated output and halt after two (one following
+# the VERDICT line, one following the REASON line). mlx_lm has no native
+# stop-sequence or GBNF equivalent to the llama.cpp grammar.
 REASON_NEWLINE_STOP = 2
 SYSTEM_PROMPT = (
     "You are a binary classifier. Respond with exactly `VERDICT: violation` "
@@ -40,6 +41,11 @@ class MLXBackend:
             collections.OrderedDict()
         )
         self._chat_template_parts: tuple[str, str] | None = None
+        # Cache newline token IDs once so _collect_tokens can use a set
+        # membership check instead of per-token decode.
+        self._newline_token_ids: frozenset[int] = frozenset(
+            self._tokenizer.encode("\n", add_special_tokens=False)
+        )
 
     def classify(self, prompt: str, max_tokens: int = 50) -> str:
         """Run inference on prompt, return raw text output."""
@@ -195,7 +201,8 @@ class MLXBackend:
             eos = getattr(self._tokenizer, "eos_token_id", None)
             if eos is not None and token_id == eos:
                 break
-            newlines += self._tokenizer.decode([token_id]).count("\n")
+            if token_id in self._newline_token_ids:
+                newlines += 1
             if newlines >= REASON_NEWLINE_STOP:
                 break
         return tokens, first_logprobs


### PR DESCRIPTION
## Summary
- MLX backend had no stop criterion equivalent to the GGUF backend's GBNF `reason ::= [^\n]{1,200}` grammar, so Phi-4-mini continued past its single-sentence REASON line and concatenated prompt-echo text (e.g. `"...work done.Classify this response"`).
- Count newlines in accumulated output and break at `REASON_NEWLINE_STOP=2` in `classify()`, `classify_cached()`, and `_collect_tokens()`. Fix lives at the generation layer, not as post-hoc regex sanitization.
- Reverted the cosmetic `_truncate_runon` hack previously introduced in `vaudeville/core/protocol.py` (not in this branch's history — it was discarded from the working tree before the fix).

## Test plan
- [x] `just check` (ruff + ruff format + mypy strict) passes
- [x] `just test` — 667 passed / 3 skipped
- [x] New tests in `tests/test_mlx_backend.py` cover: multi-chunk stream halts after second newline, single-chunk with embedded newlines halts, and `finish_reason` still wins before two newlines arrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)