### PR TITLE
docs: add open-source community files and package metadata

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+* Respecting the purpose of our community, our activities, and our ways of gathering.
+* Engaging kindly and honestly with others.
+* Respecting different viewpoints and experiences.
+* Taking responsibility for our actions and contributions.
+* Gracefully giving and accepting constructive feedback.
+* Committing to repairing harm when it occurs.
+* Behaving in other ways that promote and sustain the well-being of our community.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+* **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+* **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+* **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the basis of immutable identities or traits.
+* **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+* **Violating confidentiality.** Sharing or acting on someone's personal or private information without their permission.
+* **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+* Behaving in other ways that threaten the well-being of our community.
+
+### Other Restrictions
+
+* **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+* **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+* **Promotional materials.** Sharing marketing or other commercial content in a way that is outside the norms of the community.
+* **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, please open a [GitHub issue](https://github.com/paulnsorensen/vaudeville/issues) or contact the maintainer directly via GitHub.
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+* **Warning**
+  * *Event:* A violation involving a single incident or series of incidents.
+  * *Consequence:* A private, written warning from the Community Moderators.
+  * *Repair:* Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+
+* **Temporarily Limited Activities**
+  * *Event:* A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+  * *Consequence:* A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident.
+  * *Repair:* Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+
+* **Temporary Suspension**
+  * *Event:* A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+  * *Consequence:* A private written warning with conditions for return from suspension.
+  * *Repair:* Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+
+* **Permanent Ban**
+  * *Event:* A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+  * *Consequence:* Access to all community spaces, tools, and communication channels is removed.
+  * *Repair:* There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 3.0, permanently available at https://www.contributor-covenant.org/version/3/0/.
+
+Contributor Covenant is stewarded by the [Organization for Ethical Source](https://ethicalsource.dev) and licensed under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/). For answers to common questions about Contributor Covenant, see the FAQ at https://www.contributor-covenant.org/faq.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to Vaudeville
+
+Contributions are welcome — bugs, rules, docs, or features. Open an issue before starting significant work to avoid building something that doesn't fit.
+
+## Development Setup
+
+Requires Python 3.11+, [uv](https://docs.astral.sh/uv/), and [just](https://github.com/casey/just).
+
+```bash
+git clone https://github.com/paulnsorensen/vaudeville
+cd vaudeville
+just install    # installs deps (auto-detects MLX for Apple Silicon or GGUF for x86_64)
+just setup      # downloads Phi-4-mini model (~2.4 GB, one-time)
+```
+
+## Dev Workflow
+
+```bash
+just check      # lint + format check + typecheck — must pass before committing
+just test       # run tests
+just coverage   # tests with coverage report (90%+ required for new code)
+just eval       # evaluate rules against bundled test cases
+just fmt        # auto-format code
+```
+
+## Before Opening a PR
+
+1. `just check` must pass — no lint, format, or typecheck failures
+2. `just coverage` must pass — 90%+ line coverage on new code
+3. Update `CHANGELOG.md` under the `[Unreleased]` section
+4. Keep PRs focused — one concern per PR
+
+## Submitting a PR
+
+- Reference the relevant issue in your PR description
+- CI runs lint + typecheck + tests on macOS (MLX backend) and Linux (GGUF backend) — both need to pass
+- Smaller PRs get reviewed faster
+
+## Writing Rules
+
+Rules live in `examples/rules/`. New bundled rules need:
+- A `.yaml` rule file following the existing format
+- Test cases in `examples/tests/` covering at least the positive (fires) and negative (doesn't fire) cases
+- `just eval-rule <rule-name>` passing cleanly
+
+See the existing rules as templates. The `examples/README.md` covers the full rule schema.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant 3.0](CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Do not open a public GitHub issue for security vulnerabilities.
+
+Use [GitHub's private vulnerability reporting](https://github.com/paulnsorensen/vaudeville/security/advisories/new) to report issues confidentially. Include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (optional)
+
+## Response Timeline
+
+- **Acknowledgment**: within 72 hours
+- **Initial assessment**: within 1 week
+- **Fix or mitigation plan**: communicated after assessment
+
+## Scope
+
+In scope:
+- Arbitrary code execution via rule YAML parsing
+- Prompt injection in the SLM inference pipeline
+- Path traversal or unsafe file handling in the daemon or hook runner
+- Privilege escalation via the Unix socket interface
+
+Out of scope:
+- Vulnerabilities in upstream Phi-4-mini model weights
+- Issues requiring physical access to the local machine
+- Denial-of-service against the local daemon

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,28 @@
 [project]
 name = "vaudeville"
 version = "0.1.0"
+description = "SLM-powered semantic hook enforcement for Claude Code"
+readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [
+    { name = "Paul Sorensen" },
+]
+keywords = ["claude-code", "hooks", "llm", "phi-4", "slm", "ai-safety", "quality-enforcement"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Utilities",
+]
 requires-python = ">=3.11"
 dependencies = [
     "loguru>=0.7.0",
@@ -10,6 +32,11 @@ dependencies = [
 
 [project.scripts]
 vaudeville = "vaudeville.__main__:main"
+
+[project.urls]
+Repository = "https://github.com/paulnsorensen/vaudeville"
+Changelog = "https://github.com/paulnsorensen/vaudeville/blob/main/CHANGELOG.md"
+"Bug Tracker" = "https://github.com/paulnsorensen/vaudeville/issues"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary

Adds the community infrastructure files needed before open-sourcing:

- **CONTRIBUTING.md** — dev setup, workflow, testing gates, PR process
- **SECURITY.md** — private vulnerability reporting via GitHub Security Advisories
- **CODE_OF_CONDUCT.md** — Contributor Covenant 3.0 (verbatim from contributor-covenant.org)
- **pyproject.toml** — fills in `description`, `authors`, `license`, `keywords`, `classifiers`, and `[project.urls]` for PyPI discoverability

## Test plan

- [ ] Verify `just check` still passes (no functional code changes)
- [ ] Confirm pyproject.toml metadata renders correctly on a test PyPI upload
- [ ] Review CODE_OF_CONDUCT.md reporting section points to correct GitHub URL

🤖 Generated with [Claude Code](https://claude.ai/claude-code)