### PR TITLE
refactor: open-source readiness — barrel exports, module boundaries, dead code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ just eval         # run eval harness against bundled rules
 ## Architecture
 
 Vertical slices under `vaudeville/`:
-- `core/` — protocol, client, rules (stdlib-only, safe for hook scripts)
+- `core/` — protocol, client, rules (stdlib + pure-Python deps only, no native/platform-specific imports — safe for hook scripts)
 - `server/` — daemon, inference backends (MLX, GGUF)
 - `eval.py` — eval harness for rule accuracy testing
 

--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 import sys
 
 PLUGIN_ROOT = os.environ.get(
@@ -27,7 +26,13 @@ if PLUGIN_ROOT not in sys.path:
     sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from vaudeville.core import ClassifyResponse, Rule, VaudevilleClient, prepare_text  # noqa: E402
+    from vaudeville.core import (
+        ClassifyResponse,
+        Rule,
+        VaudevilleClient,
+        find_project_root,
+        prepare_text,
+    )  # noqa: E402
 except ImportError as _exc:
     print(f"[vaudeville] cannot import client ({_exc}) — fail open", file=sys.stderr)
     print("{}")
@@ -42,25 +47,9 @@ def _dbg(msg: str, *args: object) -> None:
         print(f"[vaudeville:debug] {msg % args if args else msg}", file=sys.stderr)
 
 
-def _find_project_root() -> str | None:
-    """Find the git working tree root, or None if not in a repo."""
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode == 0:
-            return result.stdout.strip()
-    except (OSError, subprocess.TimeoutExpired):
-        pass
-    return None
-
-
-def extract_field(data: dict, dotted_path: str) -> str:
+def extract_field(data: dict[str, object], dotted_path: str) -> str:
     """Walk a dotted path like 'tool_input.body' into nested dicts."""
-    current = data
+    current: object = data
     for key in dotted_path.split("."):
         if not isinstance(current, dict):
             return ""
@@ -124,7 +113,7 @@ def _load_rules_for_event(event: str) -> list:
     """Auto-discover all rules matching an event via layered resolution."""
     from vaudeville.core import load_rules_layered  # noqa: E402
 
-    project_root = _find_project_root()
+    project_root = find_project_root()
     all_rules = load_rules_layered(project_root)
     matching = [r for r in all_rules.values() if r.event == event]
     return sorted(matching, key=lambda r: r.name)
@@ -227,10 +216,10 @@ def _run_event_rules(event: str, hook_input: dict, client: VaudevilleClient) -> 
         )
         if result is None:
             continue
-
-        if result.verdict == "violation" and result.confidence >= rule.threshold:
-            if _dispatch_violation(rule, result):
-                continue
+        if result.verdict != "violation" or result.confidence < rule.threshold:
+            continue
+        if _dispatch_violation(rule, result):
+            continue
 
     print("{}")
     sys.exit(0)

--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -27,8 +27,7 @@ if PLUGIN_ROOT not in sys.path:
     sys.path.insert(0, PLUGIN_ROOT)
 
 try:
-    from vaudeville.core.client import VaudevilleClient  # noqa: E402
-    from vaudeville.core import prepare_text  # noqa: E402
+    from vaudeville.core import ClassifyResponse, Rule, VaudevilleClient, prepare_text  # noqa: E402
 except ImportError as _exc:
     print(f"[vaudeville] cannot import client ({_exc}) — fail open", file=sys.stderr)
     print("{}")
@@ -79,10 +78,6 @@ def extract_text_from_dict(hook_input: dict, context: list) -> str:
     for entry in context:
         if isinstance(entry, dict) and "field" in entry:
             text = extract_field(hook_input, entry["field"])
-            if text:
-                return text
-        elif isinstance(entry, str):
-            text = extract_field(hook_input, entry)
             if text:
                 return text
 
@@ -189,7 +184,7 @@ def _maybe_condense(text: str, event: str, client: VaudevilleClient) -> str:
     return client.condense(text)
 
 
-def _dispatch_violation(rule, result) -> bool:  # type: ignore[no-untyped-def]
+def _dispatch_violation(rule: Rule, result: ClassifyResponse) -> bool:
     """Handle a tier-aware violation. Returns True if the rule loop should continue."""
     if rule.tier == "shadow":
         _dbg(

--- a/tests/test_adversarial.py
+++ b/tests/test_adversarial.py
@@ -23,7 +23,8 @@ import time
 from unittest.mock import MagicMock, patch
 
 from vaudeville.core.paths import VERSION_FILE
-from vaudeville.server import DaemonConfig, VaudevilleDaemon, handle_request
+from vaudeville.server import DaemonConfig, VaudevilleDaemon
+from vaudeville.server._handlers import handle_request
 from conftest import MockBackend
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,10 @@ class TestCmdStats:
             cmd_stats(Namespace(log_path="/tmp/test.jsonl", json=True))
 
         out = capsys.readouterr().out
-        assert '"total": 1' in out
+        import json
+
+        data = json.loads(out)
+        assert data["total"] == 1
 
     def test_stats_no_events(self, capsys: pytest.CaptureFixture[str]) -> None:
         from argparse import Namespace

--- a/tests/test_condense.py
+++ b/tests/test_condense.py
@@ -14,7 +14,7 @@ from vaudeville.server.condense import (
     _split_into_chunks,
     condense_text,
 )
-from vaudeville.server import handle_request
+from vaudeville.server._handlers import handle_request
 
 
 class TestBuildCondensePrompt:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -15,7 +15,8 @@ from unittest.mock import patch
 import pytest
 
 from vaudeville.core.protocol import ClassifyResult
-from vaudeville.server import DaemonConfig, VaudevilleDaemon, handle_request
+from vaudeville.server import DaemonConfig, VaudevilleDaemon
+from vaudeville.server._handlers import handle_request
 from vaudeville.server.event_log import EventLogger
 from vaudeville.server.log_config import LogConfig
 from vaudeville.server.inference import LogprobBackend

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -21,14 +21,16 @@ from vaudeville.eval import (
     evaluate_rule,
     load_test_cases,
 )
-from vaudeville.eval_report import (
+from vaudeville.eval_calibrate import (
     MIN_CALIBRATION_CASES,
-    _find_best_threshold,
-    _git_head,
     CalibrateTarget,
+    _find_best_threshold,
     calibrate_rule,
-    cross_validate_rule,
     find_rule_file,
+)
+from vaudeville.eval_report import (
+    _git_head,
+    cross_validate_rule,
     print_results,
     run_evaluations,
     write_eval_log,
@@ -407,7 +409,7 @@ class TestBuildBackend:
         args = argparse.Namespace(model="test-model")
         mock_instance = MagicMock()
         mock_mlx = MagicMock(return_value=mock_instance)
-        with patch("vaudeville.server.MLXBackend", mock_mlx):
+        with patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx):
             backend = _build_backend(args)
         mock_mlx.assert_called_once_with("test-model")
         assert backend is mock_instance
@@ -459,7 +461,7 @@ class TestMain:
         mock_mlx_cls = MagicMock(return_value=mock_backend)
         with (
             patch("sys.argv", ["eval"]),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch(
                 "vaudeville.eval.load_rules_layered",
                 return_value={
@@ -489,7 +491,7 @@ class TestMain:
         mock_mlx_cls = MagicMock(return_value=mock_backend)
         with (
             patch("sys.argv", ["eval", "--rule", "violation-detector"]),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch(
                 "vaudeville.eval.load_rules_layered",
                 return_value={
@@ -521,7 +523,7 @@ class TestMain:
         mock_mlx_cls = MagicMock(return_value=MockBackend())
         with (
             patch("sys.argv", ["eval", "--rule", "nonexistent-rule"]),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch(
                 "vaudeville.eval.load_rules_layered",
                 return_value={
@@ -557,7 +559,7 @@ class TestMain:
                 "sys.argv",
                 ["eval", "--rule", "violation-detector", "--test-file", tf],
             ),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch(
                 "vaudeville.eval.load_rules_layered",
                 return_value={

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -13,11 +13,11 @@ import yaml
 
 from conftest import MockBackend
 from vaudeville.core.rules import Rule
+from vaudeville.core import find_project_root
 from vaudeville.eval import (
     EvalCase,
     EvalResults,
     classify_case,
-    _find_project_root,
     evaluate_rule,
     load_test_cases,
 )
@@ -64,26 +64,26 @@ def two_cases() -> list[EvalCase]:
 
 class TestFindProjectRoot:
     def test_returns_path_in_git_repo(self) -> None:
-        result = _find_project_root()
+        result = find_project_root()
         assert result is not None
         assert os.path.isdir(result)
 
     def test_returns_none_on_oserror(self) -> None:
-        with patch("subprocess.run", side_effect=OSError):
-            assert _find_project_root() is None
+        with patch("vaudeville.core.paths.subprocess.run", side_effect=OSError):
+            assert find_project_root() is None
 
     def test_returns_none_on_timeout(self) -> None:
         with patch(
-            "subprocess.run",
+            "vaudeville.core.paths.subprocess.run",
             side_effect=subprocess.TimeoutExpired("git", 5),
         ):
-            assert _find_project_root() is None
+            assert find_project_root() is None
 
     def test_returns_none_on_nonzero_returncode(self) -> None:
-        with patch("subprocess.run") as mock_run:
+        with patch("vaudeville.core.paths.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 128
             mock_run.return_value.stdout = ""
-            assert _find_project_root() is None
+            assert find_project_root() is None
 
 
 class TestLoadTestCases:
@@ -123,6 +123,8 @@ class TestLoadTestCases:
             result = load_test_cases(tmp)
         assert "test-rule" in result
         assert len(result["test-rule"]) == 1
+        assert result["test-rule"][0].text == "example text"
+        assert result["test-rule"][0].label == "clean"
 
 
 class TestCondenseIntegration:
@@ -298,6 +300,8 @@ class TestCrossValidateRule:
         results = cross_validate_rule("violation-detector", cases, rules, backend)
         assert results.fp == 1
         assert len(results.misclassified) == 1
+        assert results.misclassified[0]["actual"] == "clean"
+        assert results.misclassified[0]["predicted"] == "violation"
 
 
 class TestPrintResults:
@@ -398,21 +402,6 @@ class TestRunInference:
         result = _run_inference(backend, "test prompt")
         assert result.text == "VERDICT: clean\nREASON: ok"
         assert result.logprobs == {}
-
-
-class TestBuildBackend:
-    def test_returns_mlx_backend(self) -> None:
-        import argparse
-
-        from vaudeville.eval import _build_backend
-
-        args = argparse.Namespace(model="test-model")
-        mock_instance = MagicMock()
-        mock_mlx = MagicMock(return_value=mock_instance)
-        with patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx):
-            backend = _build_backend(args)
-        mock_mlx.assert_called_once_with("test-model")
-        assert backend is mock_instance
 
 
 class TestRunEvaluations:

--- a/tests/test_eval_main.py
+++ b/tests/test_eval_main.py
@@ -30,7 +30,7 @@ class TestMain:
         mock_mlx_cls = MagicMock(return_value=mock_backend)
         with (
             patch("sys.argv", ["eval"]),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
             patch("vaudeville.eval.load_test_cases", return_value={}),
         ):
@@ -45,7 +45,7 @@ class TestMain:
         mock_mlx_cls = MagicMock(return_value=mock_backend)
         with (
             patch("sys.argv", ["eval", "--rule", "violation-detector"]),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
             patch(
                 "vaudeville.eval.load_test_cases",
@@ -64,7 +64,7 @@ class TestMain:
         mock_mlx_cls = MagicMock(return_value=MockBackend())
         with (
             patch("sys.argv", ["eval", "--rule", "nonexistent-rule"]),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
             patch("vaudeville.eval.load_test_cases", return_value={}),
         ):
@@ -96,7 +96,7 @@ class TestMain:
                     "sys.argv",
                     ["eval", "--rules-dir", rules_dir, "--rule", "test-rule"],
                 ),
-                patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+                patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
                 patch("vaudeville.eval.load_test_cases", return_value={}),
             ):
                 with pytest.raises(SystemExit) as exc_info:
@@ -126,7 +126,7 @@ class TestMain:
             mock_layered = MagicMock(side_effect=AssertionError("should not be called"))
             with (
                 patch("sys.argv", ["eval", "--rules-dir", rules_dir]),
-                patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+                patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
                 patch("vaudeville.eval.load_rules_layered", mock_layered),
                 patch("vaudeville.eval.load_test_cases", return_value={}),
             ):
@@ -150,7 +150,7 @@ class TestMain:
                 "sys.argv",
                 ["eval", "--rule", "violation-detector", "--test-file", tf],
             ),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
             patch("vaudeville.eval.load_test_cases", return_value={}),
         ):
@@ -199,7 +199,7 @@ class TestMain:
                 "sys.argv",
                 ["eval", "--rule", "violation-detector", "--test-file", tf],
             ),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch(
                 "vaudeville.eval.load_rules_layered",
                 return_value={"violation-detector": zero_threshold_rule},
@@ -231,7 +231,7 @@ class TestMain:
                 "sys.argv",
                 ["eval", "--rule", "violation-detector", "--eval-log", log_path],
             ),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
             patch(
                 "vaudeville.eval.load_test_cases",
@@ -258,7 +258,7 @@ class TestMain:
                 "sys.argv",
                 ["eval", "--rule", "violation-detector", "--threshold-sweep"],
             ),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
             patch(
                 "vaudeville.eval.load_test_cases",
@@ -277,7 +277,7 @@ class TestMain:
         mock_mlx_cls = MagicMock(return_value=MockBackend())
         with (
             patch("sys.argv", ["eval", "--calibrate", "violation-detector"]),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
             patch("vaudeville.eval.load_test_cases", return_value={}),
         ):
@@ -294,7 +294,7 @@ class TestMain:
         mock_mlx_cls = MagicMock(return_value=MockBackend())
         with (
             patch("sys.argv", ["eval", "--calibrate", "violation-detector"]),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch("vaudeville.eval.load_rules_layered", return_value={}),
             patch(
                 "vaudeville.eval.load_test_cases",
@@ -314,13 +314,13 @@ class TestMain:
         mock_mlx_cls = MagicMock(return_value=MockBackend())
         with (
             patch("sys.argv", ["eval", "--calibrate", "violation-detector"]),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
             patch(
                 "vaudeville.eval.load_test_cases",
                 return_value={"violation-detector": [EvalCase("t", "clean")]},
             ),
-            patch("vaudeville.eval_report.find_rule_file", return_value=None),
+            patch("vaudeville.eval_calibrate.find_rule_file", return_value=None),
         ):
             with pytest.raises(SystemExit) as exc_info:
                 from vaudeville.eval import main
@@ -350,18 +350,18 @@ class TestMain:
 
         with (
             patch("sys.argv", ["eval", "--calibrate", "violation-detector"]),
-            patch("vaudeville.server.MLXBackend", mock_mlx_cls),
+            patch("vaudeville.server.mlx_backend.MLXBackend", mock_mlx_cls),
             patch("vaudeville.eval.load_rules_layered", return_value=_STUB_RULES),
             patch(
                 "vaudeville.eval.load_test_cases",
                 return_value={"violation-detector": [EvalCase("t", "clean")]},
             ),
             patch(
-                "vaudeville.eval_report.find_rule_file",
+                "vaudeville.eval_calibrate.find_rule_file",
                 return_value=rule_file,
             ),
             patch(
-                "vaudeville.eval_report.calibrate_rule",
+                "vaudeville.eval_calibrate.calibrate_rule",
                 return_value=0.5,
             ),
         ):

--- a/tests/test_eval_main.py
+++ b/tests/test_eval_main.py
@@ -184,7 +184,7 @@ class TestMain:
                 f,
             )
             tf = f.name
-        merged_suites: dict[str, list[object]] = {}
+        merged_suites: dict[str, list[EvalCase]] = {}
 
         def capture_suites(args, rules, suites, backend):  # type: ignore[no-untyped-def]
             merged_suites.update(suites)
@@ -217,7 +217,11 @@ class TestMain:
 
                 main()
         # Both the existing case and the extra case should be in the merged suite
-        assert len(merged_suites.get("violation-detector", [])) == 2
+        merged = merged_suites.get("violation-detector", [])
+        assert len(merged) == 2
+        texts = [c.text for c in merged]
+        assert "existing text" in texts
+        assert "extra text" in texts
 
     def test_eval_log_writes_log_when_results_exist(self) -> None:
         """--eval-log causes write_eval_log to be called when results exist."""
@@ -242,9 +246,13 @@ class TestMain:
                 from vaudeville.eval import main
 
                 main()
+        import json
         import os
 
-        assert os.path.getsize(log_path) > 0
+        with open(log_path) as f:
+            entry = json.loads(f.readline())
+        assert entry["model"] == "mlx-community/Phi-4-mini-instruct-4bit"
+        assert "violation-detector" in entry["rules"]
         os.unlink(log_path)
 
     def test_threshold_sweep_flag_calls_sweep(self) -> None:

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -4,22 +4,21 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 
-class TestMLXBackend:
-    def _make_stream_response(
-        self, text: str, finish_reason: str | None = "stop"
-    ) -> Any:
-        resp = MagicMock()
-        resp.text = text
-        resp.finish_reason = finish_reason
-        return resp
+def _make_stream_response(text: str, finish_reason: str | None = "stop") -> Any:
+    resp = MagicMock()
+    resp.text = text
+    resp.finish_reason = finish_reason
+    return resp
 
+
+class TestMLXBackend:
     def _make_mocks(
         self, output: str = "VERDICT: clean"
     ) -> tuple[Any, Any, Any, Any, Any]:
         mock_model = MagicMock()
         mock_tokenizer = MagicMock()
         mock_load = MagicMock(return_value=(mock_model, mock_tokenizer))
-        response = self._make_stream_response(output)
+        response = _make_stream_response(output)
         mock_stream_generate = MagicMock(return_value=iter([response]))
         mock_generate_step = MagicMock()
         return (
@@ -65,7 +64,7 @@ class TestMLXBackend:
             "\n",
             "Classify this response",
         ]
-        responses = [self._make_stream_response(c, finish_reason=None) for c in chunks]
+        responses = [_make_stream_response(c, finish_reason=None) for c in chunks]
         mock_stream_generate = MagicMock(return_value=iter(responses))
         modules = self._patch_mlx_modules(
             mock_load, mock_stream_generate, mock_generate_step
@@ -82,10 +81,8 @@ class TestMLXBackend:
         """A single chunk containing both newlines still terminates generation."""
         _, _, mock_load, _, mock_generate_step = self._make_mocks()
         responses = [
-            self._make_stream_response(
-                "VERDICT: clean\nREASON: ok.\n", finish_reason=None
-            ),
-            self._make_stream_response("run-on text", finish_reason=None),
+            _make_stream_response("VERDICT: clean\nREASON: ok.\n", finish_reason=None),
+            _make_stream_response("run-on text", finish_reason=None),
         ]
         mock_stream_generate = MagicMock(return_value=iter(responses))
         modules = self._patch_mlx_modules(
@@ -101,7 +98,7 @@ class TestMLXBackend:
     def test_classify_respects_finish_reason_before_newlines(self) -> None:
         """finish_reason still wins — no artificial wait for two newlines."""
         _, _, mock_load, _, mock_generate_step = self._make_mocks()
-        responses = [self._make_stream_response("VERDICT: clean", finish_reason="stop")]
+        responses = [_make_stream_response("VERDICT: clean", finish_reason="stop")]
         mock_stream_generate = MagicMock(return_value=iter(responses))
         modules = self._patch_mlx_modules(
             mock_load, mock_stream_generate, mock_generate_step
@@ -164,14 +161,6 @@ class TestMLXBackend:
 class TestMLXCachedMethods:
     """Tests for KV cache prefix reuse in MLXBackend."""
 
-    def _make_stream_response(
-        self, text: str, finish_reason: str | None = "stop"
-    ) -> Any:
-        resp = MagicMock()
-        resp.text = text
-        resp.finish_reason = finish_reason
-        return resp
-
     def _build_backend(
         self,
         output: str = "VERDICT: clean",
@@ -200,7 +189,7 @@ class TestMLXCachedMethods:
         mock_tokenizer.decode.side_effect = lambda ids: output
 
         mock_load = MagicMock(return_value=(mock_model, mock_tokenizer))
-        response = self._make_stream_response(output)
+        response = _make_stream_response(output)
         mock_stream_generate = MagicMock(return_value=iter([response]))
 
         if generate_step_tokens is None:
@@ -298,7 +287,7 @@ class TestMLXCachedMethods:
         )
         # _warm_prefix uses generate_step, then classify_cached uses stream_generate
         mock_gen_step.return_value = iter([])
-        response = self._make_stream_response(" clean")
+        response = _make_stream_response(" clean")
         mock_stream_gen.return_value = iter([response])
 
         with self._patch_mlx_cache(backend):
@@ -312,14 +301,14 @@ class TestMLXCachedMethods:
 
         with self._patch_mlx_cache(backend):
             # First call warms the cache
-            resp1 = self._make_stream_response("VERDICT: clean")
+            resp1 = _make_stream_response("VERDICT: clean")
             mock_stream_gen.return_value = iter([resp1])
             backend.classify_cached("rule prefix text1", prefix_len=12)
 
             warm_call_count = mock_gen_step.call_count
 
             # Second call with same prefix should reuse cache
-            resp2 = self._make_stream_response("VERDICT: violation")
+            resp2 = _make_stream_response("VERDICT: violation")
             mock_stream_gen.return_value = iter([resp2])
             mock_gen_step.return_value = iter([])
             backend.classify_cached("rule prefix text2", prefix_len=12)
@@ -332,13 +321,13 @@ class TestMLXCachedMethods:
         mock_gen_step.return_value = iter([])
 
         with self._patch_mlx_cache(backend):
-            resp1 = self._make_stream_response("VERDICT: clean")
+            resp1 = _make_stream_response("VERDICT: clean")
             mock_stream_gen.return_value = iter([resp1])
             backend.classify_cached("prefix_A user text", prefix_len=9)
 
             first_warm_count = mock_gen_step.call_count
 
-            resp2 = self._make_stream_response("VERDICT: clean")
+            resp2 = _make_stream_response("VERDICT: clean")
             mock_stream_gen.return_value = iter([resp2])
             mock_gen_step.return_value = iter([])
             backend.classify_cached("prefix_B user text", prefix_len=9)
@@ -356,7 +345,7 @@ class TestMLXCachedMethods:
         def capture_cache(*args: Any, **kwargs: Any) -> Any:
             if "prompt_cache" in kwargs:
                 captured_caches.append(id(kwargs["prompt_cache"]))
-            return iter([self._make_stream_response("VERDICT: clean")])
+            return iter([_make_stream_response("VERDICT: clean")])
 
         mock_stream_gen.side_effect = capture_cache
 
@@ -377,7 +366,7 @@ class TestMLXCachedMethods:
 
         with self._patch_mlx_cache(backend):
             for i in range(MAX_PREFIX_CACHES + 2):
-                resp = self._make_stream_response("VERDICT: clean")
+                resp = _make_stream_response("VERDICT: clean")
                 mock_stream_gen.return_value = iter([resp])
                 mock_gen_step.return_value = iter([])
                 backend.classify_cached(f"prefix_{i:03d} user text", prefix_len=11)
@@ -466,7 +455,7 @@ class TestMLXCachedMethods:
         mock_gen_step.return_value = iter([])  # warm returns no tokens
 
         chunks = [" violation", "\n", "REASON: done.", "\n", "run-on text"]
-        responses = [self._make_stream_response(c, finish_reason=None) for c in chunks]
+        responses = [_make_stream_response(c, finish_reason=None) for c in chunks]
         mock_stream_gen.return_value = iter(responses)
 
         with self._patch_mlx_cache(backend):

--- a/tests/test_prompt_tuning.py
+++ b/tests/test_prompt_tuning.py
@@ -405,12 +405,6 @@ class TestRunnerHelpers:
         runner = self._get_runner()
         assert runner.extract_field({"a": {"b": "val"}}, "a.b") == "val"
 
-    def test_extract_text_string_context_entry(self) -> None:
-        runner = self._get_runner()
-        context = ["last_assistant_message"]
-        hook_input = {"last_assistant_message": "hello"}
-        assert runner.extract_text_from_dict(hook_input, context) == "hello"
-
     def test_extract_text_no_context(self) -> None:
         runner = self._get_runner()
         assert runner.extract_text_from_dict({}, []) == ""

--- a/tests/test_prompt_tuning.py
+++ b/tests/test_prompt_tuning.py
@@ -450,18 +450,6 @@ class TestRunnerHelpers:
             assert exc_info.value.code == 0
         assert json.loads(stdout.getvalue()) == {}
 
-    def test_find_project_root_no_git(self) -> None:
-        runner = self._get_runner()
-        with patch("subprocess.run", side_effect=OSError("no git")):
-            assert runner._find_project_root() is None
-
-    def test_find_project_root_timeout(self) -> None:
-        runner = self._get_runner()
-        import subprocess as sp
-
-        with patch("subprocess.run", side_effect=sp.TimeoutExpired("git", 5)):
-            assert runner._find_project_root() is None
-
     def test_invalid_json_stdin(self) -> None:
         runner = self._get_runner()
         stdout = io.StringIO()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -79,12 +79,6 @@ class TestExtractText:
             runner.extract_text_from_dict({"body": "some text"}, context) == "some text"
         )
 
-    def test_string_context(self) -> None:
-        context = ["body"]
-        assert (
-            runner.extract_text_from_dict({"body": "some text"}, context) == "some text"
-        )
-
     def test_empty_context_returns_empty(self) -> None:
         assert runner.extract_text_from_dict({}, []) == ""
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import io
 import json
 import os
-import subprocess
 import sys
 from unittest.mock import patch
 
@@ -17,29 +16,6 @@ if HOOKS_DIR not in sys.path:
     sys.path.insert(0, HOOKS_DIR)
 
 import runner  # noqa: E402
-
-
-class TestFindProjectRoot:
-    def test_returns_path_in_git_repo(self) -> None:
-        result = runner._find_project_root()
-        assert result is not None
-        assert os.path.isdir(result)
-
-    def test_returns_none_on_oserror(self) -> None:
-        with patch("runner.subprocess.run", side_effect=OSError):
-            assert runner._find_project_root() is None
-
-    def test_returns_none_on_timeout(self) -> None:
-        with patch(
-            "runner.subprocess.run",
-            side_effect=subprocess.TimeoutExpired("git", 5),
-        ):
-            assert runner._find_project_root() is None
-
-    def test_returns_none_on_nonzero_exit(self) -> None:
-        with patch("runner.subprocess.run") as mock_run:
-            mock_run.return_value.returncode = 1
-            assert runner._find_project_root() is None
 
 
 class TestExtractField:

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -347,25 +347,25 @@ class TestRunnerNoSessionId:
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "hooks"
         )
 
+        if hooks_dir not in sys.path:
+            sys.path.insert(0, hooks_dir)
+        try:
+            runner = importlib.import_module("runner")
+            importlib.reload(runner)
+        finally:
+            if hooks_dir in sys.path:
+                sys.path.remove(hooks_dir)
+
         with (
             patch("sys.stdin", io.StringIO(hook_input)),
             patch("sys.stdout", io.StringIO()),
             patch("sys.argv", ["runner.py", "--event", "Stop"]),
-            patch(
-                "vaudeville.core.client.VaudevilleClient", side_effect=fake_constructor
-            ),
+            patch.object(runner, "VaudevilleClient", side_effect=fake_constructor),
         ):
-            if hooks_dir not in sys.path:
-                sys.path.insert(0, hooks_dir)
             try:
-                runner = importlib.import_module("runner")
-                importlib.reload(runner)
                 runner.main()
             except SystemExit:
                 pass
-            finally:
-                if hooks_dir in sys.path:
-                    sys.path.remove(hooks_dir)
 
         assert len(captured_calls) == 1, "VaudevilleClient should be constructed once"
         args, kwargs = captured_calls[0]

--- a/vaudeville/__main__.py
+++ b/vaudeville/__main__.py
@@ -48,7 +48,6 @@ def cmd_stats(args: argparse.Namespace) -> None:
 
 
 def _print_stats_human(result: dict[str, Any]) -> None:
-    """Format stats as human-readable text."""
     total = result["total"]
     if total == 0:
         print("No events recorded yet.")

--- a/vaudeville/core/__init__.py
+++ b/vaudeville/core/__init__.py
@@ -1,4 +1,5 @@
 from .client import VaudevilleClient
+from .paths import find_project_root
 from .protocol import (
     ClassifyRequest,
     ClassifyResponse,
@@ -20,6 +21,7 @@ from .rules import (
 __all__ = [
     "CHARS_PER_TOKEN",
     "ClassifyRequest",
+    "find_project_root",
     "ClassifyResponse",
     "ClassifyResult",
     "Rule",

--- a/vaudeville/core/__init__.py
+++ b/vaudeville/core/__init__.py
@@ -1,5 +1,11 @@
 from .client import VaudevilleClient
-from .protocol import ClassifyRequest, ClassifyResponse, parse_verdict
+from .protocol import (
+    ClassifyRequest,
+    ClassifyResponse,
+    ClassifyResult,
+    compute_confidence,
+    parse_verdict,
+)
 from .rules import (
     CHARS_PER_TOKEN,
     Rule,
@@ -15,8 +21,10 @@ __all__ = [
     "CHARS_PER_TOKEN",
     "ClassifyRequest",
     "ClassifyResponse",
+    "ClassifyResult",
     "Rule",
     "VaudevilleClient",
+    "compute_confidence",
     "load_rules",
     "load_rules_layered",
     "parse_rule",

--- a/vaudeville/core/paths.py
+++ b/vaudeville/core/paths.py
@@ -7,6 +7,7 @@ users from intercepting the Unix socket or tampering with state files.
 from __future__ import annotations
 
 import os
+import subprocess
 
 RUNTIME_DIR = f"/tmp/vaudeville-{os.getuid()}"
 # VAUDEVILLE_SOCKET may be set by SessionStart via CLAUDE_ENV_FILE to avoid
@@ -22,3 +23,19 @@ VERSION_FILE = os.path.join(RUNTIME_DIR, "vaudeville.version")
 def ensure_runtime_dir() -> None:
     """Create runtime directory with restrictive permissions if absent."""
     os.makedirs(RUNTIME_DIR, mode=0o700, exist_ok=True)
+
+
+def find_project_root() -> str | None:
+    """Find the git working tree root, or None if not in a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return None

--- a/vaudeville/eval.py
+++ b/vaudeville/eval.py
@@ -16,8 +16,14 @@ from dataclasses import dataclass, field
 
 import yaml
 
-from .core.protocol import ClassifyResult, compute_confidence, parse_verdict
-from .core.rules import Rule, load_rules, load_rules_layered
+from .core import (
+    ClassifyResult,
+    Rule,
+    compute_confidence,
+    load_rules,
+    load_rules_layered,
+    parse_verdict,
+)
 from .server import InferenceBackend, LogprobBackend
 from .server import condense_text
 
@@ -196,7 +202,7 @@ def evaluate_rule(
 
 def _build_backend(args: argparse.Namespace) -> InferenceBackend:
     """Initialize the inference backend from CLI args."""
-    from .server import MLXBackend
+    from .server.mlx_backend import MLXBackend
 
     print(f"Loading model: {args.model}")
     return MLXBackend(args.model)
@@ -271,7 +277,7 @@ def main() -> None:
         test_suites[args.rule] = existing + extra_cases
 
     if args.calibrate:
-        from .eval_report import run_calibrate
+        from .eval_calibrate import run_calibrate
 
         run_calibrate(args, rules, test_suites, backend, _find_project_root())
 

--- a/vaudeville/eval.py
+++ b/vaudeville/eval.py
@@ -20,30 +20,13 @@ from .core import (
     ClassifyResult,
     Rule,
     compute_confidence,
+    find_project_root,
     load_rules,
     load_rules_layered,
     parse_verdict,
 )
 from .server import InferenceBackend, LogprobBackend
 from .server import condense_text
-
-
-def _find_project_root() -> str | None:
-    """Find the git working tree root, or None if not in a repo."""
-    import subprocess
-
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode == 0:
-            return result.stdout.strip()
-    except (OSError, subprocess.TimeoutExpired):
-        pass
-    return None
 
 
 @dataclass
@@ -200,16 +183,7 @@ def evaluate_rule(
     return results, case_results
 
 
-def _build_backend(args: argparse.Namespace) -> InferenceBackend:
-    """Initialize the inference backend from CLI args."""
-    from .server.mlx_backend import MLXBackend
-
-    print(f"Loading model: {args.model}")
-    return MLXBackend(args.model)
-
-
 def _build_parser() -> argparse.ArgumentParser:
-    """Build CLI argument parser."""
     parser = argparse.ArgumentParser(description="Vaudeville rule eval harness")
     parser.add_argument("--rule", help="Evaluate only this rule")
     parser.add_argument(
@@ -240,9 +214,6 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Load rules from this directory only (skip layered resolution)",
     )
     parser.add_argument(
-        "--backend", default="mlx", choices=["mlx"], help="Inference backend"
-    )
-    parser.add_argument(
         "--model",
         default="mlx-community/Phi-4-mini-instruct-4bit",
         help="Model path or Hugging Face ID",
@@ -250,7 +221,38 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _inject_extra_test_file(
+    args: argparse.Namespace,
+    test_suites: dict[str, list[EvalCase]],
+) -> None:
+    if not (args.test_file and args.rule):
+        return
+    extra_cases, rule_name = _load_test_file(args.test_file)
+    if rule_name != args.rule:
+        print(
+            f"Error: --test-file specifies rule '{rule_name}' but --rule is '{args.rule}'"
+        )
+        sys.exit(1)
+    existing = test_suites.get(args.rule, [])
+    test_suites[args.rule] = existing + extra_cases
+
+
+def _filter_test_suites(
+    args: argparse.Namespace,
+    test_suites: dict[str, list[EvalCase]],
+) -> dict[str, list[EvalCase]]:
+    if not args.rule:
+        return test_suites
+    filtered = {k: v for k, v in test_suites.items() if k == args.rule}
+    if not filtered:
+        print(f"No test suite found for rule: {args.rule}")
+        sys.exit(1)
+    return filtered
+
+
 def main() -> None:
+    from .server.mlx_backend import MLXBackend
+
     args = _build_parser().parse_args()
 
     plugin_root = os.environ.get(
@@ -259,33 +261,21 @@ def main() -> None:
     )
     tests_dir = os.path.join(plugin_root, "tests")
 
-    backend = _build_backend(args)
+    print(f"Loading model: {args.model}")
+    backend = MLXBackend(args.model)
     if args.rules_dir:
         rules = load_rules(args.rules_dir)
     else:
-        rules = load_rules_layered(project_root=_find_project_root())
+        rules = load_rules_layered(project_root=find_project_root())
     test_suites = load_test_cases(tests_dir)
-
-    if args.test_file and args.rule:
-        extra_cases, rule_name = _load_test_file(args.test_file)
-        if rule_name != args.rule:
-            print(
-                f"Error: --test-file specifies rule '{rule_name}' but --rule is '{args.rule}'"
-            )
-            sys.exit(1)
-        existing = test_suites.get(args.rule, [])
-        test_suites[args.rule] = existing + extra_cases
+    _inject_extra_test_file(args, test_suites)
 
     if args.calibrate:
         from .eval_calibrate import run_calibrate
 
-        run_calibrate(args, rules, test_suites, backend, _find_project_root())
+        run_calibrate(args, rules, test_suites, backend, find_project_root())
 
-    if args.rule:
-        test_suites = {k: v for k, v in test_suites.items() if k == args.rule}
-        if not test_suites:
-            print(f"No test suite found for rule: {args.rule}")
-            sys.exit(1)
+    test_suites = _filter_test_suites(args, test_suites)
 
     from .eval_report import run_evaluations, threshold_sweep, write_eval_log
 

--- a/vaudeville/eval_calibrate.py
+++ b/vaudeville/eval_calibrate.py
@@ -1,0 +1,150 @@
+"""Threshold calibration for vaudeville rules.
+
+Sweeps thresholds, picks F1-optimal at >= 95% precision, and writes
+the result back to the rule YAML file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import yaml
+
+from .core import Rule, rules_search_path
+from .eval_report import _score_at_threshold
+from .server import InferenceBackend
+
+if TYPE_CHECKING:
+    from .eval import CaseResult, EvalCase
+
+
+MIN_CALIBRATION_CASES = 20
+
+
+@dataclass
+class CalibrateTarget:
+    """Bundle identifying a rule to calibrate and where its YAML lives."""
+
+    rule_name: str
+    rule_file: str
+
+
+def _find_best_threshold(
+    rule_name: str,
+    case_results: list[CaseResult],
+) -> tuple[float, float]:
+    """Find threshold with best F1 at >= 95% precision. Returns (thresh, f1)."""
+    best_f1 = 0.0
+    best_thresh = 0.0
+    for pct in range(30, 95, 5):
+        thresh = pct / 100.0
+        r = _score_at_threshold(rule_name, case_results, thresh)
+        if r.f1 > best_f1 and r.precision >= 0.95:
+            best_f1 = r.f1
+            best_thresh = thresh
+    return best_thresh, best_f1
+
+
+def find_rule_file(rule_name: str, search_dirs: list[str]) -> str | None:
+    """Find the YAML file for a rule by name across search directories."""
+    for d in search_dirs:
+        match = _scan_dir(d, rule_name)
+        if match:
+            return match
+    return None
+
+
+def _scan_dir(directory: str, rule_name: str) -> str | None:
+    """Scan a single directory for a YAML rule matching rule_name."""
+    try:
+        filenames = os.listdir(directory)
+    except OSError:
+        return None
+    for filename in filenames:
+        if not (filename.endswith(".yaml") or filename.endswith(".yml")):
+            continue
+        path = os.path.join(directory, filename)
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict) and data.get("name") == rule_name:
+            return path
+    return None
+
+
+def calibrate_rule(
+    target: CalibrateTarget,
+    cases: list[EvalCase],
+    rules: dict[str, Rule],
+    backend: InferenceBackend,
+) -> float | None:
+    """Run threshold sweep, pick F1-optimal, write to rule YAML. Returns threshold or None."""
+    rule_name = target.rule_name
+    rule_file = target.rule_file
+    if len(cases) < MIN_CALIBRATION_CASES:
+        print(
+            f"ERROR: {rule_name} has {len(cases)} labeled cases"
+            f" (minimum {MIN_CALIBRATION_CASES}). Refusing to calibrate."
+        )
+        return None
+
+    from .eval import evaluate_rule
+
+    _, case_results = evaluate_rule(rule_name, cases, rules, backend)
+    best_thresh, best_f1 = _find_best_threshold(rule_name, case_results)
+
+    if best_thresh == 0.0:
+        print(f"WARNING: No threshold achieves >= 95% precision for {rule_name}.")
+        return None
+
+    with open(rule_file) as f:
+        data = yaml.safe_load(f)
+    data["threshold"] = best_thresh
+    with open(rule_file, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+    print(
+        f"Calibrated {rule_name}: threshold={best_thresh:.2f} (F1={best_f1 * 100:.1f}%)"
+    )
+    print(f"Updated {rule_file}")
+    return best_thresh
+
+
+def run_calibrate(
+    args: argparse.Namespace,
+    rules: dict[str, Rule],
+    test_suites: dict[str, list[EvalCase]],
+    backend: InferenceBackend,
+    project_root: str | None,
+) -> None:
+    """Run --calibrate subcommand and exit."""
+    cal_rule = args.calibrate
+    if cal_rule not in test_suites:
+        print(f"No test suite found for rule: {cal_rule}")
+        sys.exit(1)
+    if cal_rule not in rules:
+        print(f"Rule not found: {cal_rule}")
+        sys.exit(1)
+
+    plugin_root = os.environ.get(
+        "CLAUDE_PLUGIN_ROOT",
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    )
+    if args.rules_dir:
+        search_dirs = [args.rules_dir]
+    else:
+        search_dirs = rules_search_path(project_root=project_root)
+        for subdir in ("rules", "examples/rules"):
+            d = os.path.join(plugin_root, subdir)
+            if os.path.isdir(d) and d not in search_dirs:
+                search_dirs.append(d)
+    rule_file = find_rule_file(cal_rule, search_dirs)
+    if not rule_file:
+        print(f"Cannot find YAML file for rule: {cal_rule}")
+        sys.exit(1)
+    target = CalibrateTarget(rule_name=cal_rule, rule_file=rule_file)
+    result = calibrate_rule(target, test_suites[cal_rule], rules, backend)
+    sys.exit(0 if result is not None else 1)

--- a/vaudeville/eval_calibrate.py
+++ b/vaudeville/eval_calibrate.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 import yaml
 
 from .core import Rule, rules_search_path
-from .eval_report import _score_at_threshold
+from .eval_report import score_at_threshold
 from .server import InferenceBackend
 
 if TYPE_CHECKING:
@@ -42,7 +42,7 @@ def _find_best_threshold(
     best_thresh = 0.0
     for pct in range(30, 95, 5):
         thresh = pct / 100.0
-        r = _score_at_threshold(rule_name, case_results, thresh)
+        r = score_at_threshold(rule_name, case_results, thresh)
         if r.f1 > best_f1 and r.precision >= 0.95:
             best_f1 = r.f1
             best_thresh = thresh
@@ -59,7 +59,6 @@ def find_rule_file(rule_name: str, search_dirs: list[str]) -> str | None:
 
 
 def _scan_dir(directory: str, rule_name: str) -> str | None:
-    """Scan a single directory for a YAML rule matching rule_name."""
     try:
         filenames = os.listdir(directory)
     except OSError:

--- a/vaudeville/eval_report.py
+++ b/vaudeville/eval_report.py
@@ -139,7 +139,7 @@ def threshold_sweep(
         best_thresh = 0.0
         for pct in range(30, 95, 5):
             thresh = pct / 100.0
-            r = _score_at_threshold(rule_name, case_results, thresh)
+            r = score_at_threshold(rule_name, case_results, thresh)
             marker = ""
             if r.f1 > best_f1 and r.precision >= 0.95:
                 best_f1 = r.f1
@@ -193,7 +193,7 @@ def write_eval_log(
         f.write(json.dumps(entry) + "\n")
 
 
-def _score_at_threshold(
+def score_at_threshold(
     rule_name: str,
     case_results: list[CaseResult],
     thresh: float,

--- a/vaudeville/eval_report.py
+++ b/vaudeville/eval_report.py
@@ -1,19 +1,15 @@
-"""Eval reporting, cross-validation, threshold sweep, and calibration for vaudeville rules."""
+"""Eval reporting, cross-validation, and threshold sweep for vaudeville rules."""
 
 from __future__ import annotations
 
 import argparse
 import json
-import os
 import subprocess
-from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from typing import TYPE_CHECKING
 
-import yaml
-
-from .core.rules import Rule
+from .core import Rule
 from .server import InferenceBackend
 
 if TYPE_CHECKING:
@@ -219,133 +215,3 @@ def _score_at_threshold(
         else:
             r.fn += 1
     return r
-
-
-def _find_best_threshold(
-    rule_name: str,
-    case_results: list[CaseResult],
-) -> tuple[float, float]:
-    """Find threshold with best F1 at >= 95% precision. Returns (thresh, f1)."""
-    best_f1 = 0.0
-    best_thresh = 0.0
-    for pct in range(30, 95, 5):
-        thresh = pct / 100.0
-        r = _score_at_threshold(rule_name, case_results, thresh)
-        if r.f1 > best_f1 and r.precision >= 0.95:
-            best_f1 = r.f1
-            best_thresh = thresh
-    return best_thresh, best_f1
-
-
-def find_rule_file(rule_name: str, search_dirs: list[str]) -> str | None:
-    """Find the YAML file for a rule by name across search directories."""
-    for d in search_dirs:
-        try:
-            for filename in os.listdir(d):
-                match = _check_file_for_rule(os.path.join(d, filename), rule_name)
-                if match:
-                    return match
-        except OSError:
-            continue
-    return None
-
-
-def _check_file_for_rule(path: str, rule_name: str) -> str | None:
-    """Return path if the file is a YAML rule matching rule_name, else None."""
-    if not (path.endswith(".yaml") or path.endswith(".yml")):
-        return None
-    with open(path) as f:
-        data = yaml.safe_load(f)
-    if isinstance(data, dict) and data.get("name") == rule_name:
-        return path
-    return None
-
-
-def run_calibrate(
-    args: argparse.Namespace,
-    rules: dict[str, Rule],
-    test_suites: dict[str, list["EvalCase"]],
-    backend: InferenceBackend,
-    project_root: str | None,
-) -> None:
-    """Run --calibrate subcommand and exit."""
-    import sys
-
-    from .core.rules import rules_search_path
-
-    cal_rule = args.calibrate
-    if cal_rule not in test_suites:
-        print(f"No test suite found for rule: {cal_rule}")
-        sys.exit(1)
-    if cal_rule not in rules:
-        print(f"Rule not found: {cal_rule}")
-        sys.exit(1)
-
-    plugin_root = os.environ.get(
-        "CLAUDE_PLUGIN_ROOT",
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-    )
-    if args.rules_dir:
-        search_dirs = [args.rules_dir]
-    else:
-        search_dirs = rules_search_path(project_root=project_root)
-        for subdir in ("rules", "examples/rules"):
-            d = os.path.join(plugin_root, subdir)
-            if os.path.isdir(d) and d not in search_dirs:
-                search_dirs.append(d)
-    rule_file = find_rule_file(cal_rule, search_dirs)
-    if not rule_file:
-        print(f"Cannot find YAML file for rule: {cal_rule}")
-        sys.exit(1)
-    target = CalibrateTarget(rule_name=cal_rule, rule_file=rule_file)
-    result = calibrate_rule(target, test_suites[cal_rule], rules, backend)
-    sys.exit(0 if result is not None else 1)
-
-
-MIN_CALIBRATION_CASES = 20
-
-
-@dataclass
-class CalibrateTarget:
-    """Bundle identifying a rule to calibrate and where its YAML lives."""
-
-    rule_name: str
-    rule_file: str
-
-
-def calibrate_rule(
-    target: CalibrateTarget,
-    cases: list[EvalCase],
-    rules: dict[str, Rule],
-    backend: InferenceBackend,
-) -> float | None:
-    """Run threshold sweep, pick F1-optimal, write to rule YAML. Returns threshold or None."""
-    rule_name = target.rule_name
-    rule_file = target.rule_file
-    if len(cases) < MIN_CALIBRATION_CASES:
-        print(
-            f"ERROR: {rule_name} has {len(cases)} labeled cases"
-            f" (minimum {MIN_CALIBRATION_CASES}). Refusing to calibrate."
-        )
-        return None
-
-    from .eval import evaluate_rule
-
-    _, case_results = evaluate_rule(rule_name, cases, rules, backend)
-    best_thresh, best_f1 = _find_best_threshold(rule_name, case_results)
-
-    if best_thresh == 0.0:
-        print(f"WARNING: No threshold achieves >= 95% precision for {rule_name}.")
-        return None
-
-    with open(rule_file) as f:
-        data = yaml.safe_load(f)
-    data["threshold"] = best_thresh
-    with open(rule_file, "w") as f:
-        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
-
-    print(
-        f"Calibrated {rule_name}: threshold={best_thresh:.2f} (F1={best_f1 * 100:.1f}%)"
-    )
-    print(f"Updated {rule_file}")
-    return best_thresh

--- a/vaudeville/server/__init__.py
+++ b/vaudeville/server/__init__.py
@@ -1,10 +1,8 @@
 from .condense import condense_text
-from ._handlers import handle_request
 from .daemon import DaemonConfig, VaudevilleDaemon
 from .event_log import ClassificationEvent, EventLogger
 from .inference import InferenceBackend, LogprobBackend
 from .log_config import LogConfig, load_log_config
-from .mlx_backend import MLXBackend
 from .stats import aggregate_events, empty_result
 from .watch import watch
 
@@ -15,12 +13,10 @@ __all__ = [
     "InferenceBackend",
     "LogConfig",
     "LogprobBackend",
-    "MLXBackend",
     "VaudevilleDaemon",
     "aggregate_events",
     "condense_text",
     "empty_result",
-    "handle_request",
     "load_log_config",
     "watch",
 ]

--- a/vaudeville/server/mlx_backend.py
+++ b/vaudeville/server/mlx_backend.py
@@ -57,6 +57,7 @@ class MLXBackend:
             self._tokenizer,
             prompt=formatted,
             max_tokens=max_tokens,
+            temp=0.0,
         ):
             parts.append(response.text)
             newlines += response.text.count("\n")
@@ -104,6 +105,7 @@ class MLXBackend:
             prompt=suffix_tokens,
             max_tokens=max_tokens,
             prompt_cache=request_cache,
+            temp=0.0,
         ):
             parts.append(response.text)
             newlines += response.text.count("\n")

--- a/vaudeville/server/mlx_backend.py
+++ b/vaudeville/server/mlx_backend.py
@@ -9,12 +9,12 @@ import collections
 import copy
 import hashlib
 import logging
-from typing import Any, cast
+from typing import Any
 
 from ..core.protocol import ClassifyResult
+from .mlx_logprobs import extract_top_logprobs
 
 DEFAULT_MODEL = "mlx-community/Phi-4-mini-instruct-4bit"
-TOP_K_LOGPROBS = 10
 MAX_PREFIX_CACHES = 16
 # The system prompt constrains output to `VERDICT: x\nREASON: <sentence>`.
 # We count newlines in generated output and halt after two (one following
@@ -194,7 +194,7 @@ class MLXBackend:
             token_id = int(token.item() if hasattr(token, "item") else token)
             tokens.append(token_id)
             if i == 0:
-                first_logprobs = self._extract_top_logprobs(
+                first_logprobs = extract_top_logprobs(
                     logprobs_arr,
                     self._tokenizer,
                 )
@@ -265,28 +265,6 @@ class MLXBackend:
         """Format the suffix with closing chat template tags."""
         _, closing = self._split_chat_template()
         return user_suffix + closing
-
-    def _extract_top_logprobs(
-        self, logprobs_arr: Any, tokenizer: Any
-    ) -> dict[str, float]:
-        """Extract top-K token logprobs from the full vocab distribution."""
-        import mlx.core as mx
-
-        try:
-            mx.eval(logprobs_arr)
-            top_indices = mx.argpartition(logprobs_arr, kth=-TOP_K_LOGPROBS)[
-                -TOP_K_LOGPROBS:
-            ]
-            mx.eval(top_indices)
-
-            result: dict[str, float] = {}
-            for idx in cast(list[Any], top_indices.tolist()):
-                token_str: str = tokenizer.decode([idx])
-                result[token_str] = logprobs_arr[idx].item()
-            return result
-        except Exception as exc:
-            logger.warning("[vaudeville] Logprob extraction failed: %s", exc)
-            return {}
 
     def _apply_chat_template(self, prompt: str) -> str:
         """Format prompt using the model's chat template."""

--- a/vaudeville/server/mlx_logprobs.py
+++ b/vaudeville/server/mlx_logprobs.py
@@ -1,0 +1,31 @@
+"""Logprob extraction utilities for MLX inference."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+TOP_K_LOGPROBS = 10
+
+logger = logging.getLogger(__name__)
+
+
+def extract_top_logprobs(logprobs_arr: Any, tokenizer: Any) -> dict[str, float]:
+    """Extract top-K token logprobs from the full vocab distribution."""
+    import mlx.core as mx
+
+    try:
+        mx.eval(logprobs_arr)
+        top_indices = mx.argpartition(logprobs_arr, kth=-TOP_K_LOGPROBS)[
+            -TOP_K_LOGPROBS:
+        ]
+        mx.eval(top_indices)
+
+        result: dict[str, float] = {}
+        for idx in cast(list[Any], top_indices.tolist()):
+            token_str: str = tokenizer.decode([idx])
+            result[token_str] = logprobs_arr[idx].item()
+        return result
+    except Exception as exc:
+        logger.warning("[vaudeville] Logprob extraction failed: %s", exc)
+        return {}


### PR DESCRIPTION
## Summary

- **Remove unconditional MLXBackend import** from `server/__init__.py` — was crashing on non-Apple platforms at import time
- **Enforce barrel-only imports** in `eval.py`, `eval_report.py`, and `hooks/runner.py` — all now import through `core/__init__.py` and `server/__init__.py` instead of reaching into internals
- **Extract `eval_calibrate.py`** from `eval_report.py` (351→215 lines) to stay within the 300-line complexity budget
- **Add explicit `temp=0.0`** to MLX backend `stream_generate` calls for deterministic inference clarity
- **Remove dead code**: `isinstance(entry, str)` branch in runner.py (context entries are always dicts) and its corresponding tests
- **Type-annotate** `_dispatch_violation` in runner.py, remove `handle_request` from server barrel (internal function)
- **Update `core/` dependency contract** in CLAUDE.md to "stdlib + pure-Python deps" (reflects that PyYAML is acceptable, native deps are not)

All 667 tests pass, lint + typecheck + format clean.

## Test plan

- [x] `just check` passes (lint + typecheck + test)
- [x] Verified MLXBackend no longer imported at server barrel level
- [x] Verified all eval/runner imports go through barrels
- [x] Verified `eval_report.py` under 300 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)