### PR TITLE
fix(watch): truncate reason to first sentence, display LLM output not prompt

### DIFF
--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -212,7 +212,11 @@ def _run_event_rules(event: str, hook_input: dict, client: VaudevilleClient) -> 
         prompt, prefix_len = rule.split_prompt(text, context_str)
 
         result = client.classify(
-            prompt, rule=rule.name, prefix_len=prefix_len, tier=rule.tier
+            prompt,
+            rule=rule.name,
+            prefix_len=prefix_len,
+            tier=rule.tier,
+            input_text=text,
         )
         if result is None:
             continue

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -61,6 +61,24 @@ class TestParseVerdict:
         result = parse_verdict("VERDICT: clean\nREASON:   leading spaces  ")
         assert result.reason == "leading spaces"
 
+    def test_reason_truncated_to_first_sentence(self) -> None:
+        result = parse_verdict(
+            "VERDICT: clean\nREASON: The response is fine. Are you certain? Extra fluff."
+        )
+        assert result.reason == "The response is fine."
+
+    def test_reason_single_sentence_preserved(self) -> None:
+        result = parse_verdict("VERDICT: violation\nREASON: Bad response detected.")
+        assert result.reason == "Bad response detected."
+
+    def test_reason_no_punctuation_preserved(self) -> None:
+        result = parse_verdict("VERDICT: clean\nREASON: no issues found")
+        assert result.reason == "no issues found"
+
+    def test_reason_exclamation_truncated(self) -> None:
+        result = parse_verdict("VERDICT: violation\nREASON: Bad! And more stuff here.")
+        assert result.reason == "Bad!"
+
     def test_mixed_case_verdict_value(self) -> None:
         result = parse_verdict("VERDICT: Violation\nREASON: test")
         assert result.verdict == "violation"

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -89,7 +89,9 @@ class TestHandleRequestEventLogging:
         el = EventLogger(config=LogConfig(), logs_dir=logs_dir)
         try:
             backend = MockBackend(verdict="violation", reason="bad stuff")
-            data = json.dumps({"prompt": "bad input", "rule": "no-slop"}).encode()
+            data = json.dumps(
+                {"prompt": "bad input", "rule": "no-slop", "input_text": "bad input"}
+            ).encode()
             handle_request(data, backend, event_logger=el)
             time.sleep(0.05)
 
@@ -101,6 +103,30 @@ class TestHandleRequestEventLogging:
             assert v["verdict"] == "violation"
             assert v["reason"] == "bad stuff"
             assert v["input_snippet"] == "bad input"
+        finally:
+            el.close()
+
+    def test_input_text_used_as_snippet_when_present(self, tmp_path: str) -> None:
+        """input_text field is stored as input_snippet instead of the full prompt."""
+        from pathlib import Path
+
+        logs_dir = str(Path(tmp_path) / "logs")
+        el = EventLogger(config=LogConfig(), logs_dir=logs_dir)
+        try:
+            backend = MockBackend(verdict="clean", reason="ok")
+            data = json.dumps(
+                {
+                    "prompt": "RULE TEMPLATE claude said: hello there",
+                    "rule": "test",
+                    "input_text": "hello there",
+                }
+            ).encode()
+            handle_request(data, backend, event_logger=el)
+            time.sleep(0.05)
+
+            events_path = Path(logs_dir) / "events.jsonl"
+            evt = json.loads(events_path.read_text().strip())
+            assert evt["input_snippet"] == "hello there"
         finally:
             el.close()
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -217,7 +217,7 @@ class TestRunPipeline:
         from unittest.mock import ANY
 
         mock_client.classify.assert_called_once_with(
-            ANY, rule="test-hedging", prefix_len=ANY, tier="enforce"
+            ANY, rule="test-hedging", prefix_len=ANY, tier="enforce", input_text=ANY
         )
 
     def test_shadow_tier_logs_but_passes(

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -156,12 +156,12 @@ def test_build_table_has_tier_column() -> None:
     assert "Tier" in [str(h) for h in col_names]
 
 
-def test_build_table_has_reason_and_text_columns() -> None:
+def test_build_table_has_reason_and_llm_output_columns() -> None:
     events = [_make_event()]
     table = _build_table(events, (1, 0))
     col_names = [str(c.header) for c in table.columns]
     assert "Reason" in col_names
-    assert "Text" in col_names
+    assert "LLM Output" in col_names
 
 
 def test_sanitize_display_short_text() -> None:

--- a/vaudeville/core/client.py
+++ b/vaudeville/core/client.py
@@ -30,13 +30,18 @@ class VaudevilleClient:
         rule: str = "",
         prefix_len: int = 0,
         tier: str = "enforce",
+        input_text: str = "",
     ) -> ClassifyResponse | None:
         """Send a classify request and return the verdict.
 
         Returns None if the daemon is unavailable (fail-open semantics).
         """
         request = ClassifyRequest(
-            prompt=prompt, rule=rule, prefix_len=prefix_len, tier=tier
+            prompt=prompt,
+            rule=rule,
+            prefix_len=prefix_len,
+            tier=tier,
+            input_text=input_text,
         )
         try:
             return self._send(request)

--- a/vaudeville/core/protocol.py
+++ b/vaudeville/core/protocol.py
@@ -11,6 +11,7 @@ import re
 from dataclasses import dataclass, field
 
 _SPECIAL_TOKEN_RE = re.compile(r"<\|[a-z_]+\|>")
+_FIRST_SENTENCE_RE = re.compile(r"^(.*?[.!?])(?:\s|$)")
 _NEGATION_VIOLATION_RE = re.compile(
     r"\b(?:no\s+violation|not\s+(?:a\s+)?violation|isn't\s+(?:a\s+)?violation|is\s+not\s+(?:a\s+)?violation)\b[.!?,;:)]*"
 )
@@ -24,6 +25,7 @@ class ClassifyRequest:
 
     prefix_len: int = 0  # 0 = no caching (backward compatible)
     tier: str = "enforce"
+    input_text: str = ""  # raw LLM output text, before prompt construction
 
     def to_json_dict(self) -> dict[str, object]:
         d: dict[str, object] = {"prompt": self.prompt}
@@ -33,6 +35,8 @@ class ClassifyRequest:
             d["prefix_len"] = self.prefix_len
         if self.tier != "enforce":
             d["tier"] = self.tier
+        if self.input_text:
+            d["input_text"] = self.input_text
         return d
 
 
@@ -86,6 +90,9 @@ def parse_verdict(raw: str) -> ClassifyResponse:
         reason = raw.strip()[:200]
 
     reason = _SPECIAL_TOKEN_RE.sub("", reason).strip()
+    m = _FIRST_SENTENCE_RE.match(reason)
+    if m:
+        reason = m.group(1)
     return ClassifyResponse(verdict=verdict, reason=reason)
 
 

--- a/vaudeville/server/_handlers.py
+++ b/vaudeville/server/_handlers.py
@@ -66,6 +66,7 @@ def _handle_classify(
     tier = str(request.get("tier", "enforce"))
     raw_prefix = request.get("prefix_len", 0)
     prefix_len = int(float(str(raw_prefix))) if raw_prefix else 0
+    input_text = str(request.get("input_text", ""))
 
     logger.debug("prompt=%d chars prefix_len=%d", len(prompt), prefix_len)
     t0 = time.monotonic()
@@ -91,7 +92,7 @@ def _handle_classify(
         latency_ms=elapsed_ms,
         prompt_chars=len(prompt),
         reason=response.reason,
-        input_snippet=prompt[:500],
+        input_snippet=input_text[:500],
         tier=tier,
     )
     if event_logger is not None:

--- a/vaudeville/server/watch.py
+++ b/vaudeville/server/watch.py
@@ -114,7 +114,9 @@ def _build_table(events: list[dict[str, Any]], totals: tuple[int, int]) -> Table
         no_wrap=True,
     )
     table.add_column("Reason", min_width=_REASON_MIN_WIDTH, ratio=1, overflow="fold")
-    table.add_column("Text", min_width=_SNIPPET_MIN_WIDTH, ratio=1, overflow="fold")
+    table.add_column(
+        "LLM Output", min_width=_SNIPPET_MIN_WIDTH, ratio=1, overflow="fold"
+    )
 
     for evt in events[-_MAX_ROWS:]:
         table.add_row(


### PR DESCRIPTION
## Summary

Three fixes for the watch TUI display:

1. **Reason truncation**: SLM generates multi-sentence text within the 50-token budget; `parse_verdict()` now captures only the first sentence (ending in `.!?`) to prevent run-on periods in the Reason column.

2. **Display LLM output**: `input_snippet` was showing the full SLM prompt (rule template + Claude text) instead of Claude's original output. Thread `input_text` through the request pipeline (runner → client → handler) and use it for display instead of the prompt.

3. **Column rename**: "Text" → "LLM Output" for clarity about what's being displayed.

## Test Plan

- All 676 tests pass ✓
- `just check` passes ✓
- `just coverage` meets 70% floor ✓