### PR TITLE
fix(commands): restore tune/generate ralph commands

### DIFF
--- a/commands/generate/RALPH.md
+++ b/commands/generate/RALPH.md
@@ -1,12 +1,12 @@
 ---
-agent: claude -p --model claude-sonnet-4-5 --allowedTools Read,Edit,Write,Bash,Glob,Grep,Skill --disallowedTools mcp
+agent: claude -p --model claude-haiku-4-5 --allowedTools Read,Edit,Write,Bash,Glob,Grep,Skill --disallowedTools=mcp
 commands:
   - name: generate_results
-    run: cat generate-results.tsv 2>/dev/null || echo "No generate-results.tsv yet"
+    run: ./show-results.sh
   - name: rules
-    run: ls -la .vaudeville/rules/ 2>/dev/null || echo "No rules directory"
+    run: ./list-rules.sh
   - name: shadow_rules
-    run: grep -l "tier: shadow" .vaudeville/rules/*.yaml 2>/dev/null | wc -l || echo "0"
+    run: ./count-shadow.sh
   - name: git-log
     run: git log --oneline -10
 args:
@@ -124,7 +124,7 @@ Each iteration works on the **current active rule** (or creates a new one if non
    - `threshold: 0.5`
    - `tier: shadow` (all new rules start in shadow)
 4. **Commit** — `git commit -m "feat(rules): add <name>"`.
-5. **Evaluate** — run: `uv run python -m vaudeville.eval --rule <name> > eval.log 2>&1`
+5. **Evaluate** — run: `uv run python -m vaudeville.eval_cli --rule <name> > eval.log 2>&1`
 6. **Read results** — parse eval.log for precision, recall, F1.
 7. **Record** — if `generate-results.tsv` doesn't exist yet, create it with the header row:
    ```

--- a/commands/generate/count-shadow.sh
+++ b/commands/generate/count-shadow.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+shopt -s nullglob
+count=0
+for f in .vaudeville/rules/*.yaml; do
+    if grep -q "^tier: shadow" "$f" 2>/dev/null; then
+        count=$((count + 1))
+    fi
+done
+echo "$count"

--- a/commands/generate/list-rules.sh
+++ b/commands/generate/list-rules.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ -d .vaudeville/rules ]; then
+    ls -la .vaudeville/rules/
+else
+    echo "No rules directory"
+fi

--- a/commands/generate/run-eval.sh
+++ b/commands/generate/run-eval.sh
@@ -12,4 +12,4 @@ if [ -z "$RULE_NAME" ]; then
     exit 1
 fi
 
-uv run python -m vaudeville.eval --rule "$RULE_NAME" 2>&1 | tail -n 100
+uv run python -m vaudeville.eval_cli --rule "$RULE_NAME" 2>&1 | tail -n 100

--- a/commands/generate/show-results.sh
+++ b/commands/generate/show-results.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ -f generate-results.tsv ]; then
+    cat generate-results.tsv
+else
+    echo "No generate-results.tsv yet"
+fi

--- a/commands/tune/RALPH.md
+++ b/commands/tune/RALPH.md
@@ -1,10 +1,10 @@
 ---
-agent: claude -p --model claude-sonnet-4-5 --allowedTools Read,Edit,Write,Bash,Skill --disallowedTools mcp
+agent: claude -p --model claude-haiku-4-5 --allowedTools Read,Edit,Write,Bash,Skill --disallowedTools=mcp
 commands:
   - name: eval
-    run: ./commands/tune/run-eval.sh
+    run: ./run-eval.sh {{ args.rule_name }}
   - name: metrics
-    run: ./commands/tune/show-metrics.sh
+    run: ./show-metrics.sh
   - name: git-log
     run: git log --oneline -10
 args:
@@ -60,7 +60,7 @@ Each iteration, do exactly one improvement:
    - Adjusting the threshold value
 4. **Implement** — edit the rule YAML with your change.
 5. **Commit** — `git commit` your change with a short descriptive message.
-6. **Evaluate** — run: `uv run python -m vaudeville.eval --rule {{ args.rule_name }} > eval.log 2>&1`
+6. **Evaluate** — run: `uv run python -m vaudeville.eval_cli --rule {{ args.rule_name }} > eval.log 2>&1`
 7. **Read results** — parse eval.log for precision, recall, F1. If empty/error, run `tail -n 50 eval.log` to diagnose.
 8. **Record** — append results to `tune-results.tsv` (tab-separated). Do NOT commit tune-results.tsv.
 9. **Decide**:

--- a/commands/tune/run-eval.sh
+++ b/commands/tune/run-eval.sh
@@ -7,4 +7,4 @@ if [ -z "$RULE_NAME" ]; then
     exit 1
 fi
 
-uv run python -m vaudeville.eval --rule "$RULE_NAME" 2>&1 | tail -n 100
+uv run python -m vaudeville.eval_cli --rule "$RULE_NAME" 2>&1 | tail -n 100


### PR DESCRIPTION
## Summary

Seven bugs were preventing both `vaudeville tune` and `vaudeville generate` from running end-to-end after the PR #55 eval refactor. All fixed in one commit; both commands now run to completion against the current ralph (haiku) setup.

## Fixes

1. **Model** — `claude-sonnet-4-5` → `claude-haiku-4-5` (setting up for upcoming multi-phase architecture where sonnet handles design/judge and haiku runs the tuning loop).
2. **Eval entrypoint** — PR #55 moved the CLI out of `vaudeville.eval` into `vaudeville.eval_cli`. The old module has no `__main__` guard, so `python -m vaudeville.eval` silently no-ops. Updated `run-eval.sh` (both) plus the RALPH.md step instructions that tell the haiku agent what command to run.
3. **Ralph path resolution** — ralph routes `./`-prefixed commands to the ralph directory, not the project root. `./commands/tune/run-eval.sh` failed to resolve because ralph looked in `commands/tune/commands/tune/`. Changed to `./run-eval.sh`.
4. **Missing rule_name arg** — tune's `eval` command wasn't passing `{{ args.rule_name }}` to the script, which then usage-errored.
5. **`--disallowedTools` variadic bug** — the space form (`--disallowedTools mcp`) breaks claude's stdin detection with `--output-format stream-json --verbose`. Using `--disallowedTools=mcp` works.
6. **YAML frontmatter parse error** — generate's `shadow_rules` command had an unquoted colon inside a shell pattern (`grep -l \"tier: shadow\"`). Since ralph runs commands without a shell and cannot handle pipes, redirects, or `||`, extracted the command to a script.
7. **Shell constructs in frontmatter** — the other generate commands used `2>/dev/null` and `||` which also need a shell. Extracted `show-results.sh`, `list-rules.sh`, `count-shadow.sh` for clarity.

## Smoke tests (worktree)

- `tune sycophancy-detector` → 1 iter, 68s, `THRESHOLDS_MET` (precision 1.0, recall 0.833, F1 0.909)
- `generate \"detect excessive em-dashes\"` → 1 iter, 6m21s, 3 shadow rules all passing thresholds

## Test plan

- [ ] Run `ralph run -n 1 commands/tune --rule_name sycophancy-detector --p_min 0.95 --r_min 0.80 --f1_min 0.85` and verify exit 0 + THRESHOLDS_MET
- [ ] Run `ralph run -n 1 commands/generate --instructions \"<any>\" --p_min 0.95 --r_min 0.80 --f1_min 0.85 --mode shadow` and verify exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)