### PR TITLE
fix(hooks,server): invalid warn decision, run-on regex, and inference budget

### DIFF
--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -84,7 +84,6 @@ def verdict_to_hook_response(
         return {}
     elif action == "warn":
         return {
-            "decision": "warn",
             "reason": reason,
             "systemMessage": (
                 f"\U0001fa9d vaudeville hook [{name}] warned about: {message}"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -79,6 +79,12 @@ class TestParseVerdict:
         result = parse_verdict("VERDICT: violation\nREASON: Bad! And more stuff here.")
         assert result.reason == "Bad!"
 
+    def test_reason_run_on_sentence_truncated(self) -> None:
+        result = parse_verdict(
+            "VERDICT: violation\nREASON: Missing fix.Are you familiar with Latin?"
+        )
+        assert result.reason == "Missing fix."
+
     def test_mixed_case_verdict_value(self) -> None:
         result = parse_verdict("VERDICT: Violation\nREASON: test")
         assert result.verdict == "violation"

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -57,6 +57,29 @@ class TestHandleRequest:
         response = handle_request(data, backend)
         assert response.endswith(b"\n")
 
+    def test_classify_max_tokens_is_tight(self) -> None:
+        """Runtime must cap Phi at ~one short sentence to avoid hallucinated run-ons.
+
+        Regression for bug where `max_tokens=50` let Phi-4-mini continue past
+        the REASON line (e.g. "...confirmed fix.Are you familiar with..."),
+        corrupting systemMessage output.
+        """
+        from vaudeville.server import CLASSIFY_MAX_TOKENS
+
+        captured: dict[str, int] = {}
+
+        class RecordingBackend:
+            def classify(self, prompt: str, max_tokens: int) -> str:  # noqa: ARG002
+                captured["max_tokens"] = max_tokens
+                return "VERDICT: clean\nREASON: ok."
+
+        data = json.dumps({"prompt": "test"}).encode() + b"\n"
+        handle_request(data, RecordingBackend())
+        assert captured["max_tokens"] == CLASSIFY_MAX_TOKENS
+        assert CLASSIFY_MAX_TOKENS <= 35, (
+            "classify budget must stay tight — loosening invites run-on REASONs"
+        )
+
 
 class TestHandleRequestEventLogging:
     def test_event_logger_called_on_clean(self, tmp_path: str) -> None:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -609,13 +609,16 @@ class TestCachedInferenceRouting:
             def classify(self, prompt: str, max_tokens: int = 50) -> str:  # noqa: ARG002
                 raise AssertionError("Should not call uncached classify")
 
-            def classify_cached(self, prompt: str, prefix_len: int) -> str:  # noqa: ARG002
+            def classify_cached(
+                self, prompt: str, prefix_len: int, max_tokens: int = 50
+            ) -> str:  # noqa: ARG002
                 raise AssertionError("Should prefer logprob variant")
 
             def classify_cached_with_logprobs(
                 self,
                 prompt: str,
                 prefix_len: int,
+                max_tokens: int = 50,
             ) -> ClassifyResult:
                 cached_calls.append((prompt, prefix_len))
                 return ClassifyResult(
@@ -644,6 +647,7 @@ class TestCachedInferenceRouting:
                 self,
                 prompt: str,
                 prefix_len: int,
+                max_tokens: int = 50,
             ) -> str:
                 cached_calls.append((prompt, prefix_len))
                 return "VERDICT: violation\nREASON: cached plain"
@@ -678,7 +682,9 @@ class TestCachedInferenceRouting:
                 route_taken.append("uncached")
                 return "VERDICT: clean\nREASON: uncached"
 
-            def classify_cached(self, prompt: str, prefix_len: int) -> str:  # noqa: ARG002
+            def classify_cached(
+                self, prompt: str, prefix_len: int, max_tokens: int = 50
+            ) -> str:  # noqa: ARG002
                 route_taken.append("cached_plain")
                 return "VERDICT: clean\nREASON: cached plain"
 
@@ -686,6 +692,7 @@ class TestCachedInferenceRouting:
                 self,
                 prompt: str,
                 prefix_len: int,
+                max_tokens: int = 50,
             ) -> ClassifyResult:  # noqa: ARG002
                 route_taken.append("cached_logprobs")
                 return ClassifyResult(
@@ -722,6 +729,7 @@ class TestCachedInferenceRouting:
                 self,
                 prompt: str,
                 prefix_len: int,
+                max_tokens: int = 50,
             ) -> ClassifyResult:  # noqa: ARG002
                 route_taken.append("cached_logprobs")
                 return ClassifyResult(
@@ -731,6 +739,68 @@ class TestCachedInferenceRouting:
 
         _run_inference(FullBackend(), "prompt", prefix_len=0)
         assert route_taken == ["uncached_logprobs"]
+
+    def test_classify_cached_max_tokens_is_tight_logprob(self) -> None:
+        """Cached logprob path must also cap at CLASSIFY_MAX_TOKENS.
+
+        Regression for the bug where cached requests silently used the
+        MLX backend's max_tokens=50 default after the uncached path was
+        tightened to 30, letting run-on REASONs slip through on cache hits.
+        """
+        from vaudeville.server import CLASSIFY_MAX_TOKENS
+
+        captured: dict[str, int] = {}
+
+        class RecordingCachedLogprob:
+            def classify(self, prompt: str, max_tokens: int) -> str:  # noqa: ARG002
+                raise AssertionError("should route to cached logprob path")
+
+            def classify_cached(
+                self,
+                prompt: str,
+                prefix_len: int,
+                max_tokens: int = 50,
+            ) -> str:  # noqa: ARG002
+                raise AssertionError("should prefer logprob variant")
+
+            def classify_cached_with_logprobs(
+                self,
+                prompt: str,
+                prefix_len: int,
+                max_tokens: int = 50,
+            ) -> ClassifyResult:  # noqa: ARG002
+                captured["max_tokens"] = max_tokens
+                return ClassifyResult(
+                    text="VERDICT: clean\nREASON: ok.",
+                    logprobs={"clean": -0.1, "violation": -3.0},
+                )
+
+        data = json.dumps({"prompt": "x", "prefix_len": 5}).encode() + b"\n"
+        handle_request(data, RecordingCachedLogprob())
+        assert captured["max_tokens"] == CLASSIFY_MAX_TOKENS
+
+    def test_classify_cached_max_tokens_is_tight_plain(self) -> None:
+        """Cached plain path (no logprobs) must also cap at CLASSIFY_MAX_TOKENS."""
+        from vaudeville.server import CLASSIFY_MAX_TOKENS
+
+        captured: dict[str, int] = {}
+
+        class RecordingCachedPlain:
+            def classify(self, prompt: str, max_tokens: int) -> str:  # noqa: ARG002
+                raise AssertionError("should route to cached plain path")
+
+            def classify_cached(
+                self,
+                prompt: str,
+                prefix_len: int,
+                max_tokens: int = 50,
+            ) -> str:  # noqa: ARG002
+                captured["max_tokens"] = max_tokens
+                return "VERDICT: clean\nREASON: ok."
+
+        data = json.dumps({"prompt": "x", "prefix_len": 5}).encode() + b"\n"
+        handle_request(data, RecordingCachedPlain())
+        assert captured["max_tokens"] == CLASSIFY_MAX_TOKENS
 
 
 class TestConfidenceScoring:

--- a/tests/test_gguf_backend.py
+++ b/tests/test_gguf_backend.py
@@ -259,6 +259,23 @@ class TestGGUFBackend:
         call_kwargs = mock_llm.create_chat_completion.call_args[1]
         assert "grammar" not in call_kwargs
 
+    def test_grammar_forces_sentence_terminator(self) -> None:
+        """Grammar must require a [.!?] terminator at the end of REASON.
+
+        Regression for bug where Phi-4-mini ran past the REASON line
+        ("...fix.Are you familiar with..."). Forcing a terminator at the
+        grammar level bounds the runaway window and guarantees clean shape.
+        """
+        from vaudeville.server.gguf_backend import GBNF_GRAMMAR
+
+        assert "reason ::= [^\\n.!?]" in GBNF_GRAMMAR, (
+            "grammar must exclude newlines and sentence terminators from "
+            "the reason body"
+        )
+        assert "[.!?]" in GBNF_GRAMMAR, (
+            "grammar must end the reason with a sentence terminator"
+        )
+
     def test_grammar_is_cached_across_calls(self) -> None:
         mock_llm = self._make_mock_llama()
         mock_lm_cls = MagicMock(return_value=mock_llm)

--- a/tests/test_prompt_tuning.py
+++ b/tests/test_prompt_tuning.py
@@ -424,7 +424,6 @@ class TestRunnerHelpers:
             "test-rule", "{reason}", "test reason", "warn"
         )
         assert result == {
-            "decision": "warn",
             "reason": "test reason",
             "systemMessage": "\U0001fa9d vaudeville hook [test-rule] warned about: test reason",
         }

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -83,7 +83,7 @@ class TestVerdictToHookResponse:
         resp = runner.verdict_to_hook_response(
             "test-rule", "Caught: {reason}", "mild issue", "warn"
         )
-        assert resp["decision"] == "warn"
+        assert "decision" not in resp
         assert "vaudeville hook [test-rule] warned about:" in resp["systemMessage"]
         assert "mild issue" in resp["systemMessage"]
 
@@ -294,10 +294,15 @@ class TestRunPipeline:
         captured = capsys.readouterr()
         assert "shadow test-shadow" in captured.err
 
-    def test_warn_tier_returns_warn_decision(
+    def test_warn_tier_omits_decision_field(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """Warn tier returns warn decision even for block-action rules."""
+        """Warn tier emits systemMessage-only response (no decision field).
+
+        Claude Code's Stop hook schema only accepts decision="approve"|"block";
+        a "warn" value would fail JSON validation. Warnings must ride on
+        systemMessage with no decision field.
+        """
         from unittest.mock import MagicMock
 
         from vaudeville.core.protocol import ClassifyResponse
@@ -329,7 +334,8 @@ class TestRunPipeline:
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
         response = json.loads(captured.out.strip())
-        assert response["decision"] == "warn"
+        assert "decision" not in response
+        assert "warned about" in response["systemMessage"]
 
     def test_enforce_tier_uses_rule_action(
         self, capsys: pytest.CaptureFixture[str]

--- a/vaudeville/core/protocol.py
+++ b/vaudeville/core/protocol.py
@@ -11,7 +11,7 @@ import re
 from dataclasses import dataclass, field
 
 _SPECIAL_TOKEN_RE = re.compile(r"<\|[a-z_]+\|>")
-_FIRST_SENTENCE_RE = re.compile(r"^(.*?[.!?])(?:\s|$)")
+_FIRST_SENTENCE_RE = re.compile(r"^(.*?[.!?])(?:\s|$|(?=[A-Z]))")
 _NEGATION_VIOLATION_RE = re.compile(
     r"\b(?:no\s+violation|not\s+(?:a\s+)?violation|isn't\s+(?:a\s+)?violation|is\s+not\s+(?:a\s+)?violation)\b[.!?,;:)]*"
 )

--- a/vaudeville/eval.py
+++ b/vaudeville/eval.py
@@ -11,7 +11,12 @@ from dataclasses import dataclass, field
 import yaml
 
 from .core import ClassifyResult, EvalCase, Rule, compute_confidence, parse_verdict
-from .server import InferenceBackend, LogprobBackend, condense_text
+from .server import (
+    CLASSIFY_MAX_TOKENS,
+    InferenceBackend,
+    LogprobBackend,
+    condense_text,
+)
 
 __all__ = [
     "CaseResult",
@@ -95,8 +100,8 @@ def _load_test_file(path: str) -> tuple[list[EvalCase], str]:
 def _run_inference(backend: InferenceBackend, prompt: str) -> ClassifyResult:
     """Run inference with logprobs, falling back to plain classify."""
     if isinstance(backend, LogprobBackend):
-        return backend.classify_with_logprobs(prompt, max_tokens=50)
-    text = backend.classify(prompt, max_tokens=50)
+        return backend.classify_with_logprobs(prompt, max_tokens=CLASSIFY_MAX_TOKENS)
+    text = backend.classify(prompt, max_tokens=CLASSIFY_MAX_TOKENS)
     return ClassifyResult(text=text)
 
 

--- a/vaudeville/server/__init__.py
+++ b/vaudeville/server/__init__.py
@@ -1,3 +1,4 @@
+from ._handlers import CLASSIFY_MAX_TOKENS
 from .condense import condense_text
 from .daemon import DaemonConfig, VaudevilleDaemon
 from .daemon_backend import DaemonBackend, daemon_is_alive
@@ -8,6 +9,7 @@ from .stats import aggregate_events, empty_result
 from .watch import watch
 
 __all__ = [
+    "CLASSIFY_MAX_TOKENS",
     "ClassificationEvent",
     "DaemonBackend",
     "DaemonConfig",

--- a/vaudeville/server/_handlers.py
+++ b/vaudeville/server/_handlers.py
@@ -30,9 +30,13 @@ def _run_inference(
     prefix_len: int = 0,
 ) -> ClassifyResult:
     if prefix_len > 0 and isinstance(backend, CachedLogprobBackend):
-        return backend.classify_cached_with_logprobs(prompt, prefix_len)
+        return backend.classify_cached_with_logprobs(
+            prompt, prefix_len, max_tokens=CLASSIFY_MAX_TOKENS
+        )
     elif prefix_len > 0 and isinstance(backend, CachedBackend):
-        text = backend.classify_cached(prompt, prefix_len)
+        text = backend.classify_cached(
+            prompt, prefix_len, max_tokens=CLASSIFY_MAX_TOKENS
+        )
         return ClassifyResult(text=text)
     elif prefix_len > 0:
         logger.debug(

--- a/vaudeville/server/_handlers.py
+++ b/vaudeville/server/_handlers.py
@@ -18,6 +18,11 @@ from .inference import (
 
 logger = logging.getLogger(__name__)
 
+# Budget for a classify verdict: `VERDICT: <label>\nREASON: <one short sentence>`.
+# ~5 tokens for VERDICT line + ~20 for REASON gives a tight cap that prevents
+# Phi-4-mini from hallucinating extra sentences past the REASON line.
+CLASSIFY_MAX_TOKENS = 30
+
 
 def _run_inference(
     backend: InferenceBackend,
@@ -34,8 +39,8 @@ def _run_inference(
             "prefix_len=%d but backend lacks cached methods — uncached", prefix_len
         )
     if isinstance(backend, LogprobBackend):
-        return backend.classify_with_logprobs(prompt, max_tokens=50)
-    text = backend.classify(prompt, max_tokens=50)
+        return backend.classify_with_logprobs(prompt, max_tokens=CLASSIFY_MAX_TOKENS)
+    text = backend.classify(prompt, max_tokens=CLASSIFY_MAX_TOKENS)
     return ClassifyResult(text=text)
 
 

--- a/vaudeville/server/gguf_backend.py
+++ b/vaudeville/server/gguf_backend.py
@@ -22,7 +22,7 @@ SYSTEM_PROMPT = (
 
 GBNF_GRAMMAR = r"""root ::= "VERDICT: " verdict "\nREASON: " reason
 verdict ::= "violation" | "clean"
-reason ::= [^\n]{1,200}"""
+reason ::= [^\n.!?]{1,150} [.!?]"""
 
 _compiled_grammar: Any = None
 

--- a/vaudeville/server/inference.py
+++ b/vaudeville/server/inference.py
@@ -31,8 +31,11 @@ class LogprobBackend(InferenceBackend, Protocol):
 class CachedBackend(InferenceBackend, Protocol):
     """Backend that supports KV cache prefix reuse."""
 
-    def classify_cached(self, prompt: str, prefix_len: int) -> str:
-        """Run inference reusing a precomputed KV cache for prompt[:prefix_len]."""
+    def classify_cached(self, prompt: str, prefix_len: int, max_tokens: int) -> str:
+        """Run inference reusing a precomputed KV cache for prompt[:prefix_len].
+
+        Callers must pass max_tokens (typically CLASSIFY_MAX_TOKENS) to bound output.
+        """
         ...
 
 
@@ -44,6 +47,10 @@ class CachedLogprobBackend(CachedBackend, Protocol):
         self,
         prompt: str,
         prefix_len: int,
+        max_tokens: int,
     ) -> ClassifyResult:
-        """Cached inference with first-token logprobs."""
+        """Cached inference with first-token logprobs.
+
+        Callers must pass max_tokens (typically CLASSIFY_MAX_TOKENS) to bound output.
+        """
         ...


### PR DESCRIPTION
## Summary

Three related fixes for Phi-4-mini hook output quality:

1. **Invalid Stop-hook decision** (`hooks/runner.py`): Stop hook schema only accepts `decision="approve"` or `"block"`; the vaudeville-internal `"warn"` tier was emitting `"decision": "warn"` and failing JSON validation. Warn-tier now emits `{reason, systemMessage}` only — Stop hooks continue by default when no decision is given.

2. **Run-on sentence truncation** (`vaudeville/core/protocol.py`): `_FIRST_SENTENCE_RE` required whitespace after `.!?`, so Phi hallucinations like `"...confirmed fix.Are you familiar with Latin?"` slipped the clipper. Added uppercase-letter lookahead so `fix.Are` splits at the period.

3. **Inference budget and grammar tightening** (`vaudeville/server/_handlers.py`, `vaudeville/server/gguf_backend.py`): Root-cause fix for the run-on itself.
   - New shared `CLASSIFY_MAX_TOKENS = 30` (was 50) for both `classify` and `classify_with_logprobs`. Tight budget for `VERDICT: <label>\nREASON: <one sentence>`.
   - GGUF GBNF grammar: `reason ::= [^\n.!?]{1,150} [.!?]`. Reason body excludes sentence terminators and must end with exactly one `[.!?]`, making mid-line continuations unsampleable at the grammar level.
   - MLX backend already stops after the second `\n` via existing `REASON_NEWLINE_STOP`; the tighter `max_tokens` bounds the rare case where the model emits no trailing newline.

## Test plan

- [x] `just check` (ruff format, ruff check, mypy --strict) clean
- [x] `just test` — 739 passed, 5 skipped
- [x] Regression tests added:
  - `test_classify_max_tokens_is_tight` — locks the ≤35 budget via a recording backend
  - `test_grammar_forces_sentence_terminator` — asserts grammar has `[^\n.!?]` body and `[.!?]` terminator
  - `test_reason_run_on_sentence_truncated` (from prior commit) — locks uppercase-boundary clipping
- [x] Warn-tier runner tests updated to assert no `decision` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)