### PR TITLE
fix(commands): ralph command path prefixes and eval entrypoint

### DIFF
--- a/commands/design/RALPH.md
+++ b/commands/design/RALPH.md
@@ -2,11 +2,11 @@
 agent: claude -p --model claude-sonnet-4-6 --allowedTools Read,Write,Bash --disallowedTools=mcp
 commands:
   - name: rule
-    run: ./commands/design/read-rule.sh {{ args.rule_name }}
+    run: ./read-rule.sh {{ args.rule_name }}
   - name: last-eval
-    run: ./commands/design/last-eval-log.sh {{ args.rule_name }}
+    run: ./last-eval-log.sh {{ args.rule_name }}
   - name: prior-plan
-    run: ./commands/design/read-prior-plan.sh {{ args.rule_name }}
+    run: ./read-prior-plan.sh {{ args.rule_name }}
   - name: git-log
     run: git log --oneline -10
 args:

--- a/commands/generate/RALPH.md
+++ b/commands/generate/RALPH.md
@@ -2,9 +2,9 @@
 agent: claude -p --model claude-sonnet-4-6 --allowedTools Read,Write,Bash,Skill --disallowedTools=mcp
 commands:
   - name: existing_rules
-    run: ls -la .vaudeville/rules/ 2>/dev/null || echo "empty"
+    run: ./list-rules.sh
   - name: session_patterns
-    run: ./commands/generate/session-analytics.sh
+    run: ./session-analytics.sh
 args: [instructions, p_min, r_min, f1_min, mode]
 ---
 

--- a/commands/generate/list-rules.sh
+++ b/commands/generate/list-rules.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# List existing .vaudeville/rules/*.yaml; print "empty" if the dir is missing
+# List files in .vaudeville/rules/; print "empty" if the dir is missing
 # or contains no rules. Extracted from RALPH.md frontmatter because ralph
 # runs commands via shlex.split + subprocess (no shell), which mangles
 # `2>/dev/null || echo ...` into literal args.

--- a/commands/generate/list-rules.sh
+++ b/commands/generate/list-rules.sh
@@ -3,7 +3,7 @@
 # or contains no rules. Extracted from RALPH.md frontmatter because ralph
 # runs commands via shlex.split + subprocess (no shell), which mangles
 # `2>/dev/null || echo ...` into literal args.
-set -eu
+set -euo pipefail
 
 if [ -d .vaudeville/rules ] && [ -n "$(ls -A .vaudeville/rules 2>/dev/null)" ]; then
     ls -la .vaudeville/rules/

--- a/commands/generate/list-rules.sh
+++ b/commands/generate/list-rules.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# List existing .vaudeville/rules/*.yaml; print "empty" if the dir is missing
+# or contains no rules. Extracted from RALPH.md frontmatter because ralph
+# runs commands via shlex.split + subprocess (no shell), which mangles
+# `2>/dev/null || echo ...` into literal args.
+set -eu
+
+if [ -d .vaudeville/rules ] && [ -n "$(ls -A .vaudeville/rules 2>/dev/null)" ]; then
+    ls -la .vaudeville/rules/
+else
+    echo "empty"
+fi

--- a/commands/generate/run-eval.sh
+++ b/commands/generate/run-eval.sh
@@ -12,4 +12,4 @@ if [ -z "$RULE_NAME" ]; then
     exit 1
 fi
 
-uv run python -m vaudeville.eval --rule "$RULE_NAME" 2>&1 | tail -n 100
+uv run python -m vaudeville.eval_cli --rule "$RULE_NAME" 2>&1 | tail -n 100

--- a/commands/judge/RALPH.md
+++ b/commands/judge/RALPH.md
@@ -2,15 +2,15 @@
 agent: claude -p --model claude-sonnet-4-6 --allowedTools Read,Bash --disallowedTools=mcp
 commands:
   - name: rule
-    run: ./commands/judge/read-rule.sh {{ args.rule_name }}
+    run: ./read-rule.sh {{ args.rule_name }}
   - name: results
-    run: ./commands/judge/read-tune-results.sh {{ args.rule_name }}
+    run: ./read-tune-results.sh {{ args.rule_name }}
   - name: last-eval
-    run: ./commands/judge/last-eval-log.sh {{ args.rule_name }}
+    run: ./last-eval-log.sh {{ args.rule_name }}
   - name: plan
-    run: ./commands/judge/read-plan.sh {{ args.rule_name }}
+    run: ./read-plan.sh {{ args.rule_name }}
   - name: prior-judge
-    run: ./commands/judge/read-judge-log.sh {{ args.rule_name }}
+    run: ./read-judge-log.sh {{ args.rule_name }}
 args:
   - rule_name
   - p_min

--- a/commands/tune/RALPH.md
+++ b/commands/tune/RALPH.md
@@ -2,13 +2,13 @@
 agent: claude -p --model claude-haiku-4-5 --allowedTools Read,Edit,Write,Bash --disallowedTools=mcp
 commands:
   - name: plan
-    run: ./commands/tune/read-plan.sh {{ args.rule_name }}
+    run: ./read-plan.sh {{ args.rule_name }}
   - name: metrics
-    run: ./commands/tune/show-metrics.sh {{ args.rule_name }}
+    run: ./show-metrics.sh {{ args.rule_name }}
   - name: eval
-    run: ./commands/tune/run-eval.sh {{ args.rule_name }}
+    run: ./run-eval.sh {{ args.rule_name }}
   - name: results
-    run: ./commands/tune/read-tune-results.sh {{ args.rule_name }}
+    run: ./read-tune-results.sh {{ args.rule_name }}
   - name: git-log
     run: git log --oneline -10
 args:

--- a/commands/tune/run-eval.sh
+++ b/commands/tune/run-eval.sh
@@ -7,4 +7,4 @@ if [ -z "$RULE_NAME" ]; then
     exit 1
 fi
 
-uv run python -m vaudeville.eval --rule "$RULE_NAME" 2>&1 | tail -n 100
+uv run python -m vaudeville.eval_cli --rule "$RULE_NAME" 2>&1 | tail -n 100


### PR DESCRIPTION
## Summary

Three bugs were blocking the multi-phase tune/generate pipeline after PR #58 landed. All fixed here; supersedes #56 (which was against the pre-#58 single-phase architecture and no longer applies cleanly).

## Fixes

1. **Ralph path resolution** — ralphify's engine runs `./`-prefixed commands from the ralph directory (`commands/<phase>/`), not the project root. `./commands/tune/read-plan.sh` with cwd=`commands/tune/` resolves to `commands/tune/commands/tune/read-plan.sh` — ENOENT. Stripped the redundant `commands/<phase>/` prefix from all four phase RALPH.md files (design/judge/tune/generate).

2. **Eval entrypoint** — PR #55 moved the CLI out of `vaudeville/eval.py` into `vaudeville/eval_cli.py`. The old module has no `__main__` guard, so `python -m vaudeville.eval --rule foo` silently exits 0 with no output. Updated `run-eval.sh` in both tune and generate.

3. **Shell constructs in frontmatter** — ralphify executes commands via `shlex.split` + `subprocess.run` without `shell=True`, so `||`, `2>/dev/null`, pipes, and redirects get passed as literal positional args. `commands/generate/RALPH.md` had `ls -la .vaudeville/rules/ 2>/dev/null || echo "empty"` inline; extracted to `list-rules.sh`.

## Verification

- `just check` — ruff format + ruff check + mypy strict: ✅
- `just test` — 833 passed, 5 skipped: ✅
- Manual: `cd commands/tune && ./run-eval.sh sycophancy-detector` produces full eval output (previously silent no-op).
- Manual: `bash commands/generate/list-rules.sh` prints `empty` when `.vaudeville/rules/` is absent.

## Relationship to #56

PR #56 identified these same bugs (and four others) against the pre-#58 pipeline. #58 fixed its four: model change, `--disallowedTools=mcp` form, missing `{{ args.rule_name }}` arg, and the unquoted YAML colon. The three fixes here are what remained, rebased onto #58's new Designer → Tuner → Judge architecture. #56 can be closed.

## Test plan

- [ ] `ralph run commands/tune --rule_name sycophancy-detector --p_min 0.95 --r_min 0.80 --f1_min 0.85` — commands resolve, eval produces output
- [ ] `ralph run commands/generate --instructions "test" --p_min 0.95 --r_min 0.80 --f1_min 0.85 --mode shadow` — list-rules.sh prints existing rules or "empty"

🤖 Generated with [Claude Code](https://claude.com/claude-code)