### PR TITLE
feat(stats): Rich TUI for stats and shared table styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,37 @@ Other events (`SessionStart`, `UserPromptSubmit`, `Notification`, etc.) are avai
 
 The GGUF backend (llama-cpp-python) enforces the `VERDICT: .../REASON: ...` output format via GBNF grammar-constrained decoding, guaranteeing structurally valid responses. The MLX backend relies on prompt compliance alone, as MLX-LM does not support GBNF grammars. Both backends use temperature 0.0 for deterministic inference; the GGUF backend additionally applies `repeat_penalty=1.1`.
 
+## Observability
+
+Every classification is appended as a JSONL event by the daemon, so you can inspect rule behavior after the fact.
+
+### Commands
+
+```bash
+uv run vaudeville stats           # aggregated per-rule totals, pass rate, latency p50/p95, histogram
+uv run vaudeville stats --json    # same data as raw JSON
+uv run vaudeville watch           # live TUI of rule firings
+```
+
+Both commands accept `--log-path` to point at a non-default events file.
+
+### Log Location
+
+- `~/.vaudeville/logs/events.jsonl` — every classification (ts, rule, verdict, confidence, latency_ms, tier, reason, input_snippet)
+- `~/.vaudeville/logs/violations.jsonl` — subset where `verdict == "violation"`
+- `~/.vaudeville/logs/config.yaml` — retention settings (auto-created with defaults on first run)
+
+### Retention
+
+Loguru rotates each log file when it reaches `max_size_mb` and deletes rotated siblings older than `retention_days`. Defaults:
+
+```yaml
+max_size_mb: 10
+retention_days: 7
+```
+
+Edit `~/.vaudeville/logs/config.yaml` to change these. Raise `max_size_mb` if you want `stats` to reflect a longer window — `stats` reads only the live `events.jsonl`, not rotated siblings, so once rotation fires only post-rotation data is aggregated.
+
 ## Requirements
 
 - Python 3.11+

--- a/tests/test_cli_stats.py
+++ b/tests/test_cli_stats.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 
 import pytest
 
+from rich.console import Console
+
 from vaudeville.__main__ import _print_stats_human, cmd_stats, cmd_watch, main
 from vaudeville.server import empty_result
 
@@ -23,12 +25,16 @@ def _sample_result() -> dict[str, Any]:
                 "violations": 1,
                 "pass_rate": 66.7,
                 "avg_latency_ms": 120.5,
+                "p50_latency_ms": 110.0,
+                "p95_latency_ms": 130.0,
             },
             "no-todo": {
                 "total": 2,
                 "violations": 0,
                 "pass_rate": 100.0,
                 "avg_latency_ms": 80.0,
+                "p50_latency_ms": 75.0,
+                "p95_latency_ms": 85.0,
             },
         },
         "latency": {
@@ -68,15 +74,17 @@ class TestCmdStats:
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         args = Namespace(json=False, log_path="/fake/events.jsonl")
+        console = Console(force_terminal=False, width=200)
         with patch(
             "vaudeville.server.aggregate_events",
             return_value=_sample_result(),
         ):
-            cmd_stats(args)
+            with patch("vaudeville.__main__._console", console):
+                cmd_stats(args)
         captured = capsys.readouterr()
         assert "no-yolo" in captured.out
         assert "no-todo" in captured.out
-        assert "Total classifications: 5" in captured.out
+        assert "5 classifications" in captured.out
 
     def test_human_output_empty_log(self, capsys: pytest.CaptureFixture[str]) -> None:
         args = Namespace(json=False, log_path="/fake/events.jsonl")
@@ -89,34 +97,47 @@ class TestCmdStats:
         assert "No events recorded yet." in captured.out
 
 
+def _make_console() -> Console:
+    return Console(force_terminal=False, width=200)
+
+
 class TestPrintStatsHuman:
     def test_empty_result(self, capsys: pytest.CaptureFixture[str]) -> None:
-        _print_stats_human(empty_result())
+        _print_stats_human(empty_result(), console=_make_console())
         captured = capsys.readouterr()
         assert "No events recorded yet." in captured.out
 
     def test_includes_latency_line(self, capsys: pytest.CaptureFixture[str]) -> None:
-        _print_stats_human(_sample_result())
+        _print_stats_human(_sample_result(), console=_make_console())
         captured = capsys.readouterr()
-        assert "p50=100.0ms" in captured.out
-        assert "p95=200.0ms" in captured.out
+        assert "p50" in captured.out
+        assert "100.0ms" in captured.out
+        assert "p95" in captured.out
+        assert "200.0ms" in captured.out
 
     def test_includes_histogram(self, capsys: pytest.CaptureFixture[str]) -> None:
-        _print_stats_human(_sample_result())
+        _print_stats_human(_sample_result(), console=_make_console())
         captured = capsys.readouterr()
-        assert "Histogram:" in captured.out
+        assert "Histogram" in captured.out
         assert "<=100ms" in captured.out
 
-    def test_includes_time_range(self, capsys: pytest.CaptureFixture[str]) -> None:
-        _print_stats_human(_sample_result())
+    def test_includes_rule_name(self, capsys: pytest.CaptureFixture[str]) -> None:
+        _print_stats_human(_sample_result(), console=_make_console())
         captured = capsys.readouterr()
-        assert "2026-04-12T10:00:00" in captured.out
+        assert "no-yolo" in captured.out
 
     def test_pass_rate_formatting(self, capsys: pytest.CaptureFixture[str]) -> None:
-        _print_stats_human(_sample_result())
+        _print_stats_human(_sample_result(), console=_make_console())
         captured = capsys.readouterr()
-        assert "66.7%" in captured.out
-        assert "100.0%" in captured.out
+        assert "66.7" in captured.out
+
+    def test_human_output_contains_p50_p95_columns(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _print_stats_human(_sample_result(), console=_make_console())
+        captured = capsys.readouterr()
+        assert "p50" in captured.out
+        assert "p95" in captured.out
 
 
 class TestCmdWatch:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import pathlib
 
-from vaudeville.server.stats import _bucket_for_latency, aggregate_events
+from vaudeville.server.stats import _bucket_for_latency, _percentiles, aggregate_events
 
 
 def _write_events(path: pathlib.Path, events: list[dict[str, object]]) -> str:
@@ -230,3 +230,41 @@ def test_single_event_latency_percentiles(tmp_path: pathlib.Path) -> None:
     assert lat["p50_ms"] == 42.0
     assert lat["p95_ms"] == 42.0
     assert lat["mean_ms"] == 42.0
+
+
+def test_per_rule_percentiles(tmp_path: pathlib.Path) -> None:
+    """Each rule summary contains p50_latency_ms and p95_latency_ms."""
+    events = [_make_event(latency_ms=float(i)) for i in range(1, 101)]
+    path = _write_events(tmp_path, events)
+    result = aggregate_events(path)
+
+    rule = result["rules"]["no-hedging"]
+    assert "p50_latency_ms" in rule
+    assert "p95_latency_ms" in rule
+    assert isinstance(rule["p50_latency_ms"], float)
+    assert isinstance(rule["p95_latency_ms"], float)
+
+
+def test_per_rule_percentiles_single_event(tmp_path: pathlib.Path) -> None:
+    """Single-event rule: p50 == p95 == the latency."""
+    path = _write_events(tmp_path, [_make_event(latency_ms=77.0)])
+    result = aggregate_events(path)
+
+    rule = result["rules"]["no-hedging"]
+    assert rule["p50_latency_ms"] == 77.0
+    assert rule["p95_latency_ms"] == 77.0
+
+
+class TestPercentiles:
+    """Unit tests for the _percentiles helper."""
+
+    def test_single_value(self) -> None:
+        p50, p95 = _percentiles([42.0])
+        assert p50 == 42.0
+        assert p95 == 42.0
+
+    def test_multiple_values(self) -> None:
+        data = [float(i) for i in range(1, 101)]
+        p50, p95 = _percentiles(data)
+        assert p50 == 50.5
+        assert round(p95, 1) == 96.0

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,84 @@
+"""Tests for vaudeville.server.tui shared UI primitives."""
+
+from __future__ import annotations
+
+from rich import box
+from rich.table import Table
+
+from vaudeville.server.tui import latency_text, styled_table
+
+
+class TestStyledTable:
+    def test_returns_table(self) -> None:
+        result = styled_table("My Title")
+        assert isinstance(result, Table)
+
+    def test_title(self) -> None:
+        result = styled_table("My Title")
+        assert result.title == "My Title"
+
+    def test_title_style(self) -> None:
+        result = styled_table("T")
+        assert result.title_style == "bold cyan"
+
+    def test_header_style(self) -> None:
+        result = styled_table("T")
+        assert result.header_style == "bold magenta"
+
+    def test_caption_style(self) -> None:
+        result = styled_table("T", caption="some caption")
+        assert result.caption_style == "dim"
+
+    def test_caption_set(self) -> None:
+        result = styled_table("T", caption="my cap")
+        assert result.caption == "my cap"
+
+    def test_caption_none(self) -> None:
+        result = styled_table("T")
+        assert result.caption is None
+
+    def test_expand(self) -> None:
+        result = styled_table("T")
+        assert result.expand is True
+
+    def test_show_lines_false(self) -> None:
+        result = styled_table("T")
+        assert result.show_lines is False
+
+    def test_box_simple_heavy(self) -> None:
+        result = styled_table("T")
+        assert result.box is box.SIMPLE_HEAVY
+
+
+class TestLatencyText:
+    def test_at_or_below_100_is_green(self) -> None:
+        text = latency_text(100.0)
+        assert text.style == "green"
+
+    def test_below_100_is_green(self) -> None:
+        text = latency_text(50.0)
+        assert text.style == "green"
+
+    def test_just_above_100_is_yellow(self) -> None:
+        text = latency_text(101.0)
+        assert text.style == "yellow"
+
+    def test_at_500_is_yellow(self) -> None:
+        text = latency_text(500.0)
+        assert text.style == "yellow"
+
+    def test_above_500_is_red(self) -> None:
+        text = latency_text(501.0)
+        assert text.style == "red"
+
+    def test_very_high_is_red(self) -> None:
+        text = latency_text(9999.0)
+        assert text.style == "red"
+
+    def test_zero_is_green(self) -> None:
+        text = latency_text(0.0)
+        assert text.style == "green"
+
+    def test_formatted_value(self) -> None:
+        text = latency_text(123.456)
+        assert text.plain == "123.5"

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -9,14 +9,16 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from vaudeville.server.tui import (
+    confidence_text as _confidence_text,
+    tier_text as _tier_text,
+    verdict_text as _verdict_text,
+)
 from vaudeville.server.watch import (
     _MAX_ROWS,
     _build_table,
-    _confidence_text,
     _parse_ts_display,
     _sanitize_display,
-    _tier_text,
-    _verdict_text,
     watch,
 )
 

--- a/vaudeville/__main__.py
+++ b/vaudeville/__main__.py
@@ -17,7 +17,7 @@ from rich.text import Text
 from vaudeville import orchestrator
 from vaudeville.core.paths import find_project_root as _core_find_project_root
 from vaudeville.orchestrator import RalphError, Thresholds
-from vaudeville.server.tui import latency_text, styled_table
+from vaudeville.server import latency_text, styled_table
 
 
 _EVENTS_LOG = os.path.join(
@@ -116,49 +116,31 @@ def cmd_generate(args: argparse.Namespace) -> int:
         return 2
 
 
-def _print_stats_human(result: dict[str, Any], console: Console | None = None) -> None:
-    con = console if console is not None else _console
-    total = result["total"]
-    if total == 0:
-        con.print("No events recorded yet.")
-        return
+def _render_rules_table(con: Console, rules: dict[str, Any], total: int) -> None:
+    table = styled_table(
+        "Per-Rule Breakdown",
+        caption=f"{total} classifications",
+    )
+    table.add_column("Rule", justify="left")
+    for col in ("Total", "Violations", "Pass %", "Avg ms", "p50 ms", "p95 ms"):
+        table.add_column(col, justify="right")
 
-    con.rule("Vaudeville Stats", style="bold cyan")
-
-    rules = result["rules"]
-    if rules:
-        table = styled_table(
-            "Per-Rule Breakdown",
-            caption=f"{total} classifications",
+    for name, data in rules.items():
+        pass_rate = data["pass_rate"]
+        style = "green" if pass_rate >= 90 else "yellow" if pass_rate >= 50 else "red"
+        table.add_row(
+            name,
+            str(data["total"]),
+            str(data["violations"]),
+            Text(f"{pass_rate:.1f}%", style=style),
+            latency_text(data["avg_latency_ms"]),
+            latency_text(data["p50_latency_ms"]),
+            latency_text(data["p95_latency_ms"]),
         )
-        table.add_column("Rule", justify="left")
-        table.add_column("Total", justify="right")
-        table.add_column("Violations", justify="right")
-        table.add_column("Pass %", justify="right")
-        table.add_column("Avg ms", justify="right")
-        table.add_column("p50 ms", justify="right")
-        table.add_column("p95 ms", justify="right")
+    con.print(table)
 
-        for name, data in rules.items():
-            pass_rate = data["pass_rate"]
-            if pass_rate >= 90:
-                pass_style = "green"
-            elif pass_rate >= 50:
-                pass_style = "yellow"
-            else:
-                pass_style = "red"
-            table.add_row(
-                name,
-                str(data["total"]),
-                str(data["violations"]),
-                Text(f"{pass_rate:.1f}%", style=pass_style),
-                latency_text(data["avg_latency_ms"]),
-                latency_text(data["p50_latency_ms"]),
-                latency_text(data["p95_latency_ms"]),
-            )
-        con.print(table)
 
-    lat = result["latency"]
+def _render_latency_summary(con: Console, lat: dict[str, Any]) -> None:
     summary = Text.assemble(
         "Overall latency \u2014 p50: ",
         (f"{lat['p50_ms']:.1f}ms", "bold"),
@@ -170,27 +152,47 @@ def _print_stats_human(result: dict[str, Any], console: Console | None = None) -
     con.print(summary)
     con.print()
 
+
+def _render_histogram(con: Console, histogram: dict[str, int]) -> None:
     hist_table = styled_table("Latency Histogram")
     hist_table.add_column("Bucket", justify="right")
     hist_table.add_column("Count", justify="right")
     hist_table.add_column("Bar")
 
-    histogram = lat["histogram"]
     max_count = max(histogram.values()) if histogram else 1
     bar_width = 40
     for bucket, count in histogram.items():
         bar_len = int((count / max_count) * bar_width) if max_count else 0
-        bar = "\u2588" * bar_len
-        hist_table.add_row(bucket, str(count), bar)
+        hist_table.add_row(bucket, str(count), "\u2588" * bar_len)
     con.print(hist_table)
 
 
-def _build_tune_parser(sub: Any) -> None:
-    p = sub.add_parser(
-        "tune",
-        help="Tune a rule to meet precision/recall/f1 thresholds (autonomous agent)",
+def _print_stats_human(result: dict[str, Any], console: Console | None = None) -> None:
+    con = console if console is not None else _console
+    total = result["total"]
+    if total == 0:
+        con.print("No events recorded yet.")
+        return
+
+    con.rule("Vaudeville Stats", style="bold cyan")
+    rules = result["rules"]
+    if rules:
+        _render_rules_table(con, rules, total)
+    lat = result["latency"]
+    _render_latency_summary(con, lat)
+    _render_histogram(con, lat["histogram"])
+
+
+def _add_log_path_arg(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--log-path",
+        default=_EVENTS_LOG,
+        help="Path to events.jsonl (default: ~/.vaudeville/logs/events.jsonl)",
     )
-    p.add_argument("rule", help="Rule name to tune")
+
+
+def _add_pipeline_args(p: argparse.ArgumentParser) -> None:
+    """Add threshold + orchestration args shared by tune and generate."""
     p.add_argument(
         "--p-min",
         type=_threshold_float,
@@ -221,6 +223,15 @@ def _build_tune_parser(sub: Any) -> None:
         default=10,
         help="Ralph iterations for tune phase (default: 10)",
     )
+
+
+def _build_tune_parser(sub: Any) -> None:
+    p = sub.add_parser(
+        "tune",
+        help="Tune a rule to meet precision/recall/f1 thresholds (autonomous agent)",
+    )
+    p.add_argument("rule", help="Rule name to tune")
+    _add_pipeline_args(p)
 
 
 def _build_generate_parser(sub: Any) -> None:
@@ -233,74 +244,14 @@ def _build_generate_parser(sub: Any) -> None:
         help="Description of what the rule should detect",
     )
     p.add_argument(
-        "--p-min",
-        type=_threshold_float,
-        default=0.95,
-        help="Minimum precision threshold (default: 0.95)",
-    )
-    p.add_argument(
-        "--r-min",
-        type=_threshold_float,
-        default=0.80,
-        help="Minimum recall threshold (default: 0.80)",
-    )
-    p.add_argument(
-        "--f1-min",
-        type=_threshold_float,
-        default=0.85,
-        help="Minimum F1 threshold (default: 0.85)",
-    )
-    p.add_argument(
         "--live",
         action="store_true",
         help="Run generation in live mode instead of shadow mode",
     )
-    p.add_argument(
-        "--rounds",
-        type=int,
-        default=3,
-        help="Maximum orchestration rounds (default: 3)",
-    )
-    p.add_argument(
-        "--tuner-iters",
-        type=int,
-        default=10,
-        help="Ralph iterations for tune phase (default: 10)",
-    )
+    _add_pipeline_args(p)
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
-        prog="vaudeville",
-        description="Vaudeville SLM hook enforcement",
-    )
-    sub = parser.add_subparsers(dest="command")
-
-    watch_parser = sub.add_parser("watch", help="Live TUI of rule firings")
-    watch_parser.add_argument(
-        "--log-path",
-        default=_EVENTS_LOG,
-        help="Path to events.jsonl (default: ~/.vaudeville/logs/events.jsonl)",
-    )
-
-    sub.add_parser("setup", help="Download model and verify inference")
-
-    stats_parser = sub.add_parser("stats", help="Show classification statistics")
-    stats_parser.add_argument("--json", action="store_true", help="Output raw JSON")
-    stats_parser.add_argument(
-        "--log-path",
-        default=_EVENTS_LOG,
-        help="Path to events.jsonl (default: ~/.vaudeville/logs/events.jsonl)",
-    )
-
-    _build_tune_parser(sub)
-    _build_generate_parser(sub)
-
-    args = parser.parse_args()
-    if args.command is None:
-        parser.print_help()
-        sys.exit(1)
-
+def _dispatch(args: argparse.Namespace) -> None:
     if args.command == "watch":
         cmd_watch(args)
     elif args.command == "setup":
@@ -311,6 +262,33 @@ def main() -> None:
         sys.exit(cmd_tune(args))
     elif args.command == "generate":
         sys.exit(cmd_generate(args))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="vaudeville",
+        description="Vaudeville SLM hook enforcement",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    watch_parser = sub.add_parser("watch", help="Live TUI of rule firings")
+    _add_log_path_arg(watch_parser)
+
+    sub.add_parser("setup", help="Download model and verify inference")
+
+    stats_parser = sub.add_parser("stats", help="Show classification statistics")
+    stats_parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    _add_log_path_arg(stats_parser)
+
+    _build_tune_parser(sub)
+    _build_generate_parser(sub)
+
+    args = parser.parse_args()
+    if args.command is None:
+        parser.print_help()
+        sys.exit(1)
+
+    _dispatch(args)
 
 
 if __name__ == "__main__":

--- a/vaudeville/__main__.py
+++ b/vaudeville/__main__.py
@@ -120,7 +120,7 @@ def _print_stats_human(result: dict[str, Any], console: Console | None = None) -
     con = console if console is not None else _console
     total = result["total"]
     if total == 0:
-        print("No events recorded yet.")
+        con.print("No events recorded yet.")
         return
 
     con.rule("Vaudeville Stats", style="bold cyan")

--- a/vaudeville/__main__.py
+++ b/vaudeville/__main__.py
@@ -11,14 +11,20 @@ import os
 import sys
 from typing import Any
 
+from rich.console import Console
+from rich.text import Text
+
 from vaudeville import orchestrator
 from vaudeville.core.paths import find_project_root as _core_find_project_root
 from vaudeville.orchestrator import RalphError, Thresholds
+from vaudeville.server.tui import latency_text, styled_table
 
 
 _EVENTS_LOG = os.path.join(
     os.path.expanduser("~"), ".vaudeville", "logs", "events.jsonl"
 )
+
+_console = Console()
 
 
 def cmd_watch(args: argparse.Namespace) -> None:
@@ -110,43 +116,73 @@ def cmd_generate(args: argparse.Namespace) -> int:
         return 2
 
 
-def _print_stats_human(result: dict[str, Any]) -> None:
+def _print_stats_human(result: dict[str, Any], console: Console | None = None) -> None:
+    con = console if console is not None else _console
     total = result["total"]
     if total == 0:
         print("No events recorded yet.")
         return
 
-    tr = result["time_range"]
-    print(f"=== Vaudeville Stats ({tr['earliest']} — {tr['latest']}) ===")
-    print()
+    con.rule("Vaudeville Stats", style="bold cyan")
 
     rules = result["rules"]
     if rules:
-        hdr = (
-            f"{'Rule':<30} {'Total':>6} {'Violations':>11} {'Pass %':>7} {'Avg ms':>7}"
+        table = styled_table(
+            "Per-Rule Breakdown",
+            caption=f"{total} classifications",
         )
-        print(hdr)
-        print("-" * len(hdr))
+        table.add_column("Rule", justify="left")
+        table.add_column("Total", justify="right")
+        table.add_column("Violations", justify="right")
+        table.add_column("Pass %", justify="right")
+        table.add_column("Avg ms", justify="right")
+        table.add_column("p50 ms", justify="right")
+        table.add_column("p95 ms", justify="right")
+
         for name, data in rules.items():
-            print(
-                f"{name:<30} {data['total']:>6} {data['violations']:>11}"
-                f" {data['pass_rate']:>6.1f}% {data['avg_latency_ms']:>7.1f}"
+            pass_rate = data["pass_rate"]
+            if pass_rate >= 90:
+                pass_style = "green"
+            elif pass_rate >= 50:
+                pass_style = "yellow"
+            else:
+                pass_style = "red"
+            table.add_row(
+                name,
+                str(data["total"]),
+                str(data["violations"]),
+                Text(f"{pass_rate:.1f}%", style=pass_style),
+                latency_text(data["avg_latency_ms"]),
+                latency_text(data["p50_latency_ms"]),
+                latency_text(data["p95_latency_ms"]),
             )
-        print()
+        con.print(table)
 
     lat = result["latency"]
-    print(
-        f"Latency: p50={lat['p50_ms']:.1f}ms  p95={lat['p95_ms']:.1f}ms  mean={lat['mean_ms']:.1f}ms"
+    summary = Text.assemble(
+        "Overall latency \u2014 p50: ",
+        (f"{lat['p50_ms']:.1f}ms", "bold"),
+        "   p95: ",
+        (f"{lat['p95_ms']:.1f}ms", "bold"),
+        "   mean: ",
+        (f"{lat['mean_ms']:.1f}ms", "bold"),
     )
-    print()
+    con.print(summary)
+    con.print()
 
-    print("Histogram:")
-    for bucket, count in lat["histogram"].items():
-        bar = "#" * min(count, 50)
-        print(f"  {bucket:>10}: {count:>5}  {bar}")
-    print()
+    hist_table = styled_table("Latency Histogram")
+    hist_table.add_column("Bucket", justify="right")
+    hist_table.add_column("Count", justify="right")
+    hist_table.add_column("Bar")
 
-    print(f"Total classifications: {total}")
+    histogram = lat["histogram"]
+    max_count = max(histogram.values()) if histogram else 1
+    bar_width = 40
+    for bucket, count in histogram.items():
+        bar_len = int((count / max_count) * bar_width) if max_count else 0
+        bar = "\u2588" * bar_len
+        hist_table.add_row(bucket, str(count), bar)
+    con.print(hist_table)
 
 
 def _build_tune_parser(sub: Any) -> None:

--- a/vaudeville/server/__init__.py
+++ b/vaudeville/server/__init__.py
@@ -6,6 +6,13 @@ from .event_log import ClassificationEvent, EventLogger
 from .inference import InferenceBackend, LogprobBackend
 from .log_config import LogConfig, load_log_config
 from .stats import aggregate_events, empty_result
+from .tui import (
+    confidence_text,
+    latency_text,
+    styled_table,
+    tier_text,
+    verdict_text,
+)
 from .watch import watch
 
 __all__ = [
@@ -20,8 +27,13 @@ __all__ = [
     "VaudevilleDaemon",
     "aggregate_events",
     "condense_text",
+    "confidence_text",
     "daemon_is_alive",
     "empty_result",
+    "latency_text",
     "load_log_config",
+    "styled_table",
+    "tier_text",
+    "verdict_text",
     "watch",
 ]

--- a/vaudeville/server/stats.py
+++ b/vaudeville/server/stats.py
@@ -111,15 +111,7 @@ def _bucket_for_latency(lat: float) -> str:
 
 def _latency_stats(latencies: list[float]) -> dict[str, Any]:
     sorted_lat = sorted(latencies)
-    n = len(sorted_lat)
-
-    if n == 1:
-        p50 = p95 = sorted_lat[0]
-    else:
-        quantiles = statistics.quantiles(sorted_lat, n=100)
-        p50 = quantiles[49]
-        p95 = quantiles[94]
-
+    p50, p95 = _percentiles(sorted_lat)
     histogram = _empty_histogram()
 
     for lat in sorted_lat:

--- a/vaudeville/server/stats.py
+++ b/vaudeville/server/stats.py
@@ -86,20 +86,22 @@ def _summarize_rules(
     return summaries
 
 
+def _parse_line(line: str) -> dict[str, Any] | None:
+    stripped = line.strip()
+    if not stripped:
+        return None
+    try:
+        evt: dict[str, Any] = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    return evt
+
+
 def _parse_events(log_path: str) -> list[dict[str, Any]]:
     if not os.path.exists(log_path):
         return []
-    events: list[dict[str, Any]] = []
     with open(log_path) as f:
-        for line in f:
-            stripped = line.strip()
-            if not stripped:
-                continue
-            try:
-                events.append(json.loads(stripped))
-            except json.JSONDecodeError:
-                continue
-    return events
+        return [evt for line in f if (evt := _parse_line(line)) is not None]
 
 
 def _bucket_for_latency(lat: float) -> str:

--- a/vaudeville/server/stats.py
+++ b/vaudeville/server/stats.py
@@ -47,6 +47,15 @@ def aggregate_events(log_path: str) -> dict[str, Any]:
     }
 
 
+def _percentiles(latencies: list[float]) -> tuple[float, float]:
+    """Return (p50, p95) for *latencies*. Handles the n==1 special case."""
+    n = len(latencies)
+    if n == 1:
+        return latencies[0], latencies[0]
+    quantiles = statistics.quantiles(sorted(latencies), n=100)
+    return quantiles[49], quantiles[94]
+
+
 def _summarize_rules(
     events: list[dict[str, Any]],
 ) -> dict[str, dict[str, Any]]:
@@ -65,11 +74,14 @@ def _summarize_rules(
         total = data["total"]
         violations = data["violations"]
         pass_rate = ((total - violations) / total) * 100 if total else 0.0
+        p50, p95 = _percentiles(data["latencies"])
         summaries[name] = {
             "total": total,
             "violations": violations,
             "pass_rate": round(pass_rate, 1),
             "avg_latency_ms": round(statistics.mean(data["latencies"]), 1),
+            "p50_latency_ms": round(p50, 1),
+            "p95_latency_ms": round(p95, 1),
         }
     return summaries
 

--- a/vaudeville/server/tui.py
+++ b/vaudeville/server/tui.py
@@ -1,0 +1,61 @@
+"""Shared Rich UI primitives for vaudeville TUI components."""
+
+from __future__ import annotations
+
+from rich import box
+from rich.table import Table
+from rich.text import Text
+
+
+def styled_table(title: str, caption: str | None = None) -> Table:
+    """Return a pre-configured Rich Table with the vaudeville house style."""
+    return Table(
+        title=title,
+        caption=caption,
+        title_style="bold cyan",
+        header_style="bold magenta",
+        caption_style="dim",
+        box=box.SIMPLE_HEAVY,
+        expand=True,
+        show_lines=False,
+    )
+
+
+def verdict_text(verdict: str) -> Text:
+    if verdict == "violation":
+        return Text(verdict, style="bold red")
+    return Text(verdict, style="bold green")
+
+
+def tier_text(tier: str) -> Text:
+    if tier == "shadow":
+        return Text(tier, style="dim")
+    if tier == "warn":
+        return Text(tier, style="yellow")
+    return Text(tier, style="bold green")
+
+
+_CONFIDENCE_HIGH = 0.8
+_CONFIDENCE_MEH = 0.5
+
+
+def confidence_text(conf: float) -> Text:
+    formatted = f"{conf:.2f}"
+    if conf >= _CONFIDENCE_HIGH:
+        return Text(formatted, style="green")
+    if conf >= _CONFIDENCE_MEH:
+        return Text(formatted, style="yellow")
+    return Text(formatted, style="dim")
+
+
+_LATENCY_OK = 100.0
+_LATENCY_WARN = 500.0
+
+
+def latency_text(ms: float) -> Text:
+    formatted = f"{ms:.1f}"
+    if ms <= _LATENCY_OK:
+        return Text(formatted, style="green")
+    if ms <= _LATENCY_WARN:
+        return Text(formatted, style="yellow")
+    return Text(formatted, style="red")

--- a/vaudeville/server/tui.py
+++ b/vaudeville/server/tui.py
@@ -18,6 +18,7 @@ def styled_table(title: str, caption: str | None = None) -> Table:
         box=box.SIMPLE_HEAVY,
         expand=True,
         show_lines=False,
+        padding=(0, 1),
     )
 
 

--- a/vaudeville/server/watch.py
+++ b/vaudeville/server/watch.py
@@ -15,6 +15,14 @@ from rich.live import Live
 from rich.table import Table
 from rich.text import Text
 
+from vaudeville.server.tui import (
+    confidence_text as _confidence_text,
+    latency_text as _latency_text,
+    styled_table,
+    tier_text as _tier_text,
+    verdict_text as _verdict_text,
+)
+
 _EVENTS_LOG = os.path.join(
     os.path.expanduser("~"), ".vaudeville", "logs", "events.jsonl"
 )
@@ -51,34 +59,6 @@ def _to_float(value: object) -> float:
         return 0.0
 
 
-def _verdict_text(verdict: str) -> Text:
-    if verdict == "violation":
-        return Text(verdict, style="bold red")
-    return Text(verdict, style="bold green")
-
-
-def _tier_text(tier: str) -> Text:
-    if tier == "shadow":
-        return Text(tier, style="dim")
-    if tier == "warn":
-        return Text(tier, style="yellow")
-    return Text(tier, style="bold green")
-
-
-# Confidence heat-map thresholds. Red is reserved for violation verdicts.
-_CONFIDENCE_HIGH = 0.8
-_CONFIDENCE_MEH = 0.5
-
-
-def _confidence_text(confidence: float) -> Text:
-    formatted = f"{confidence:.2f}"
-    if confidence >= _CONFIDENCE_HIGH:
-        return Text(formatted, style="green")
-    if confidence >= _CONFIDENCE_MEH:
-        return Text(formatted, style="yellow")
-    return Text(formatted, style="dim")
-
-
 def _sanitize_display(value: object) -> Text:
     """Return *value* as single-line Text, with newlines flattened to spaces."""
     text = (
@@ -92,10 +72,9 @@ def _sanitize_display(value: object) -> Text:
 
 def _build_table(events: list[dict[str, Any]], totals: tuple[int, int]) -> Table:
     total_seen, violations = totals
-    table = Table(
+    table = styled_table(
         title="Vaudeville \u2014 Live Rule Firings",
         caption=f"Session: {total_seen} events, {violations} violations",
-        expand=True,
     )
     table.add_column("Time", style="dim", min_width=_TIME_MIN_WIDTH, no_wrap=True)
     table.add_column("Rule", min_width=_RULE_MIN_WIDTH, overflow="fold")
@@ -125,7 +104,7 @@ def _build_table(events: list[dict[str, Any]], totals: tuple[int, int]) -> Table
             _tier_text(evt.get("tier", "enforce")),
             _verdict_text(evt.get("verdict", "?")),
             _confidence_text(_to_float(evt.get("confidence", 0))),
-            f"{_to_float(evt.get('latency_ms', 0)):.1f}",
+            _latency_text(_to_float(evt.get("latency_ms", 0))),
             _sanitize_display(evt.get("reason", "")),
             _sanitize_display(evt.get("input_snippet", "")),
         )


### PR DESCRIPTION
## Summary

- Renders `vaudeville stats` with Rich so it matches `watch` — per-rule table, latency summary, histogram table.
- Extracts a shared `styled_table` factory in `vaudeville/server/tui.py` so both commands converge on one house style (title/header/caption/box/padding). `watch.py` is mechanically swapped onto it with zero behavior change.
- Adds per-rule **p50 ms** and **p95 ms** columns next to **Avg ms** (JSON shape is additive — existing consumers of `--json` still see `avg_latency_ms`).
- Colors latency cells via `latency_text` (≤100 ms green, ≤500 ms yellow, >500 ms red) so slow rules visibly stand out.
- README now documents the observability commands, log paths, and retention behavior.

## Test plan

- [x] `just check` — ruff check + format + mypy --strict (77 files formatted, 63 files typechecked clean)
- [x] `just coverage` — 856 tests pass, project coverage 96.1%, new code (`server/tui.py`, `server/stats.py`) at 100%
- [x] `test_tui.py` covers factory style + latency color thresholds
- [x] `test_stats.py` adds per-rule p50/p95 (including `n == 1` case)
- [x] `test_cli_stats.py` injects a deterministic `Console(force_terminal=False, width=200)` and asserts p50/p95 columns render
- [x] `test_watch.py` updated for new shared imports; behavior unchanged
- [ ] Manual smoke: `uv run vaudeville stats` against a live `~/.vaudeville/logs/events.jsonl`
- [ ] Manual smoke: `uv run vaudeville stats --json` — confirm additive `p50_latency_ms`/`p95_latency_ms` fields per rule
- [ ] Manual smoke: `uv run vaudeville watch` — confirm identical rendering after factory refactor