### PR TITLE
feat(cli): unified rule management commands with argcomplete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.11"
 dependencies = [
+    "argcomplete>=3.0",
     "loguru>=0.7.0",
     "pyyaml>=6.0.1",
     "rich>=13.0",

--- a/skills/rule-admin/SKILL.md
+++ b/skills/rule-admin/SKILL.md
@@ -8,72 +8,68 @@ description: >
   or invokes /rule-admin. Typically used after /tier-advisor produces
   recommendations. Do NOT use for analysis — use /tier-advisor for that.
 model: sonnet
-allowed-tools: Read, Edit, Write, Glob, Bash(cp:*), Bash(rm:*), Bash(ls:*)
+allowed-tools: Read, Bash(vaudeville:*)
 ---
 
 # rule-admin
 
-Applies tier changes to vaudeville rule YAML files. Handles the mechanical
-steps of promoting, demoting, or deleting rules after /tier-advisor has
-produced recommendations.
+Applies tier changes to vaudeville rule YAML files via the `vaudeville` CLI.
+All mechanical operations (locate, read, write, delete) are handled by the CLI.
+
+## Available CLI commands
+
+```bash
+vaudeville list [--tier shadow|warn|enforce|disabled] [--event Stop] [--json]
+vaudeville show <name> [--json]
+vaudeville promote <name>       # shadow → warn → enforce
+vaudeville demote <name>        # enforce → warn → shadow
+vaudeville enable <name>        # restore from disabled
+vaudeville disable <name>       # disable (saves previous tier)
+vaudeville delete <name> [--yes]
+vaudeville path <name>
+vaudeville validate [name]
+```
 
 ## Input
 
-A rule name and action. If not provided, ask. Valid actions:
-
-| Action | What it does |
-|--------|-------------|
-| `promote-to-warn` | Set `tier: warn` in `rules_dev/`, copy to `~/.vaudeville/rules/` |
-| `promote-to-block` | Set `tier: block` in `rules_dev/`, copy to `~/.vaudeville/rules/` |
-| `demote-to-shadow` | Set `tier: shadow` in `rules_dev/`, remove from `~/.vaudeville/rules/` |
-| `delete` | Remove from both `rules_dev/` and `~/.vaudeville/rules/` (confirm first) |
+A rule name and action. If not provided, ask. Valid actions: `promote`,
+`demote`, `enable`, `disable`, `delete`.
 
 ## Steps
 
-### 1. Locate the rule
+### 1. Confirm the rule exists
 
-Find the rule YAML file. Search in order:
-1. `${CLAUDE_PLUGIN_ROOT}/rules_dev/<rule-name>.yaml`
-2. `${CLAUDE_PLUGIN_ROOT}/rules/<rule-name>.yaml`
-3. `~/.vaudeville/rules/<rule-name>.yaml`
+```bash
+vaudeville show <rule-name>
+```
 
-If not found, tell the user and stop.
+Show the user the current tier, event, and threshold. If not found, stop.
 
-### 2. Read current state
+### 2. Apply the change
 
-Read the rule file and show the user:
-- Current `tier:` value (or "none" if field is absent)
-- Current `threshold:` value
-- Rule `event:` type
+Use the matching CLI command. Examples:
 
-### 3. Apply the change
+```bash
+vaudeville promote sycophancy-detector
+vaudeville demote hedging-detector
+vaudeville disable stale-rule
+vaudeville enable restored-rule
+vaudeville delete old-rule --yes
+```
 
-For **promote-to-warn**:
-1. Set `tier: warn` in the rule YAML
-2. Copy the file to `~/.vaudeville/rules/<rule-name>.yaml`
+`promote` and `demote` step one tier at a time (shadow↔warn↔enforce).
+Use `disable` / `enable` for the disabled tier — they preserve the previous
+tier in a sidecar comment so `enable` can restore it.
 
-For **promote-to-block**:
-1. Set `tier: block` in the rule YAML
-2. Copy the file to `~/.vaudeville/rules/<rule-name>.yaml`
+### 3. Confirm
 
-For **demote-to-shadow**:
-1. Set `tier: shadow` in the rule YAML
-2. Remove `~/.vaudeville/rules/<rule-name>.yaml` if it exists
-
-For **delete**:
-1. Confirm with the user before proceeding
-2. Remove the rule file from `rules_dev/` and `~/.vaudeville/rules/`
-
-### 4. Confirm
-
-Show the user what changed and where.
+Run `vaudeville show <rule-name>` again and report the new tier to the user.
 
 ## Gotchas
 
-- Always read the YAML before editing — rules may have comments or
-  non-standard field ordering that blind writes would destroy
-- The `~/.vaudeville/rules/` directory may not exist yet — create it
-  if needed when copying
-- Delete is destructive — always confirm before removing files
-- Some rules exist only in `~/.vaudeville/rules/` (user-created),
-  not in `rules_dev/` — handle both locations
+- `delete` prompts for confirmation unless `--yes` is passed. In non-interactive
+  contexts always pass `--yes`.
+- If a rule exists in both project and home, `delete` will ask which location
+  to remove.
+- `promote` / `demote` refuse to move a disabled rule — use `enable` first.
+- Rules search order: project `.vaudeville/rules/` first, then `~/.vaudeville/rules/`.

--- a/tests/test_cli_rule_admin.py
+++ b/tests/test_cli_rule_admin.py
@@ -1,0 +1,1078 @@
+"""Tests for rule management CLI commands and core rule-file helpers."""
+
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from vaudeville.cli_rules import (
+    cmd_delete,
+    cmd_demote,
+    cmd_disable,
+    cmd_enable,
+    cmd_list,
+    cmd_path,
+    cmd_promote,
+    cmd_show,
+    cmd_validate,
+    cmd_completion,
+    dispatch_rule_command,
+)
+from vaudeville.core.rules import (
+    locate_rule_file,
+    locate_all_rule_files,
+    set_tier,
+    list_rules_with_source,
+    load_rule_file,
+)
+
+
+def _write_rule(
+    rules_dir: Path,
+    name: str,
+    tier: str = "shadow",
+    event: str = "Stop",
+    examples: list[dict[str, str]] | None = None,
+) -> Path:
+    rules_dir.mkdir(parents=True, exist_ok=True)
+    path = rules_dir / f"{name}.yaml"
+    data: dict[str, object] = {
+        "name": name,
+        "event": event,
+        "tier": tier,
+        "threshold": 0.5,
+        "action": "warn",
+        "message": "{reason}",
+        "prompt": "Is this a violation? {{ examples }}\n{text}",
+        "context": [{"field": "last_assistant_message"}],
+        "labels": ["violation", "clean"],
+        "test_cases": [
+            {"text": "bad text", "label": "violation"},
+            {"text": "good text", "label": "clean"},
+        ],
+    }
+    if examples:
+        data["examples"] = examples
+    path.write_text(yaml.dump(data))
+    return path
+
+
+def _home_rules(tmp_path: Path) -> Path:
+    return tmp_path / ".vaudeville" / "rules"
+
+
+def _proj_rules(tmp_path: Path) -> Path:
+    return tmp_path / "proj" / ".vaudeville" / "rules"
+
+
+# ---------------------------------------------------------------------------
+# Core helpers: locate_rule_file
+# ---------------------------------------------------------------------------
+
+
+class TestLocateRuleFile:
+    def test_finds_in_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "test-rule")
+        path = locate_rule_file("test-rule")
+        assert path.name == "test-rule.yaml"
+
+    def test_finds_in_project_first(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "test-rule", tier="shadow")
+        _write_rule(_proj_rules(tmp_path), "test-rule", tier="warn")
+        path = locate_rule_file("test-rule", str(tmp_path / "proj"))
+        assert "proj" in str(path)
+
+    def test_falls_back_to_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "test-rule")
+        path = locate_rule_file("test-rule", str(tmp_path / "proj"))
+        assert path.parent.parent.parent == tmp_path
+
+    def test_raises_when_not_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with pytest.raises(FileNotFoundError, match="test-rule"):
+            locate_rule_file("test-rule")
+
+
+class TestLocateAllRuleFiles:
+    def test_returns_empty_when_not_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert locate_all_rule_files("test-rule") == []
+
+    def test_returns_single_location(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "test-rule")
+        paths = locate_all_rule_files("test-rule")
+        assert len(paths) == 1
+
+    def test_returns_both_locations(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "test-rule")
+        _write_rule(_proj_rules(tmp_path), "test-rule")
+        paths = locate_all_rule_files("test-rule", str(tmp_path / "proj"))
+        assert len(paths) == 2
+
+
+class TestSetTier:
+    def test_updates_existing_tier(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "test-rule", tier="shadow")
+        set_tier("test-rule", "warn")
+        content = (_home_rules(tmp_path) / "test-rule.yaml").read_text()
+        assert "tier: warn" in content
+        assert "tier: shadow" not in content
+
+    def test_appends_tier_when_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        rules_dir = _home_rules(tmp_path)
+        rules_dir.mkdir(parents=True)
+        p = rules_dir / "no-tier.yaml"
+        p.write_text("name: no-tier\nevent: Stop\n")
+        set_tier("no-tier", "enforce")
+        assert "tier: enforce" in p.read_text()
+
+    def test_raises_on_invalid_tier(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "test-rule")
+        with pytest.raises(ValueError, match="Invalid tier"):
+            set_tier("test-rule", "invalid")
+
+    def test_returns_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "test-rule", tier="shadow")
+        result = set_tier("test-rule", "warn")
+        assert isinstance(result, Path)
+        assert result.exists()
+
+
+class TestListRulesWithSource:
+    def test_returns_pairs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "rule-a")
+        _write_rule(_home_rules(tmp_path), "rule-b", tier="warn")
+        pairs = list_rules_with_source()
+        names = {r.name for r, _ in pairs}
+        assert "rule-a" in names and "rule-b" in names
+
+    def test_project_overrides_global(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "test-rule", tier="shadow")
+        _write_rule(_proj_rules(tmp_path), "test-rule", tier="warn")
+        pairs = list_rules_with_source(str(tmp_path / "proj"))
+        rule, source = next((r, s) for r, s in pairs if r.name == "test-rule")
+        assert rule.tier == "warn"
+        assert "proj" in source
+
+    def test_empty_when_no_rules(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert list_rules_with_source() == []
+
+
+class TestLoadRuleFile:
+    def test_loads_valid_rule(self, tmp_path: Path) -> None:
+        rules_dir = tmp_path / "rules"
+        path = _write_rule(rules_dir, "test-rule")
+        rule = load_rule_file(path)
+        assert rule is not None
+        assert rule.name == "test-rule"
+
+    def test_returns_none_for_draft(self, tmp_path: Path) -> None:
+        rules_dir = tmp_path / "rules"
+        rules_dir.mkdir(parents=True)
+        p = rules_dir / "draft.yaml"
+        p.write_text("name: draft\ndraft: true\nevent: Stop\nprompt: x\n")
+        assert load_rule_file(p) is None
+
+
+# ---------------------------------------------------------------------------
+# CLI: cmd_list
+# ---------------------------------------------------------------------------
+
+
+class TestCmdList:
+    def _args(self, **kwargs: object) -> Namespace:
+        defaults = {"tier": None, "event": None, "json": False}
+        defaults.update(kwargs)  # type: ignore[arg-type]
+        return Namespace(**defaults)
+
+    def test_human_output(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "rule-a")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_list(self._args())
+        out = capsys.readouterr().out
+        assert "rule-a" in out
+
+    def test_json_output(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "rule-a")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_list(self._args(json=True))
+        data = json.loads(capsys.readouterr().out)
+        assert data[0]["name"] == "rule-a"
+
+    def test_filter_by_tier(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "rule-shadow", tier="shadow")
+        _write_rule(_home_rules(tmp_path), "rule-warn", tier="warn")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_list(self._args(tier="warn"))
+        out = capsys.readouterr().out
+        assert "rule-warn" in out
+        assert "rule-shadow" not in out
+
+    def test_filter_by_event(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "stop-rule", event="Stop")
+        _write_rule(_home_rules(tmp_path), "pre-rule", event="PreToolUse")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_list(self._args(event="Stop"))
+        out = capsys.readouterr().out
+        assert "stop-rule" in out
+        assert "pre-rule" not in out
+
+    def test_empty_when_no_rules(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_list(self._args())
+        assert "No rules found." in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# CLI: cmd_show
+# ---------------------------------------------------------------------------
+
+
+class TestCmdShow:
+    def test_human_output(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "my-rule", tier="warn")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_show(Namespace(name="my-rule", json=False))
+        out = capsys.readouterr().out
+        assert "my-rule" in out
+        assert "warn" in out
+
+    def test_json_output(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "my-rule")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_show(Namespace(name="my-rule", json=True))
+        data = json.loads(capsys.readouterr().out)
+        assert data["name"] == "my-rule"
+        assert "path" in data
+
+    def test_not_found_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with pytest.raises(SystemExit):
+                cmd_show(Namespace(name="missing", json=False))
+
+    def test_shows_test_case_counts(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "my-rule")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_show(Namespace(name="my-rule", json=False))
+        out = capsys.readouterr().out
+        assert "test_cases: 2" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI: cmd_delete
+# ---------------------------------------------------------------------------
+
+
+class TestCmdDelete:
+    def test_delete_with_yes(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = _write_rule(_home_rules(tmp_path), "my-rule")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_delete(Namespace(name="my-rule", yes=True))
+        assert not p.exists()
+        assert "Deleted" in capsys.readouterr().out
+
+    def test_delete_aborts_on_no(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = _write_rule(_home_rules(tmp_path), "my-rule")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with patch("builtins.input", return_value="N"):
+                with patch("sys.stdin") as mock_stdin:
+                    mock_stdin.isatty.return_value = True
+                    cmd_delete(Namespace(name="my-rule", yes=False))
+        assert p.exists()
+        assert "Aborted" in capsys.readouterr().out
+
+    def test_delete_not_found_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with pytest.raises(SystemExit):
+                cmd_delete(Namespace(name="missing", yes=True))
+
+    def test_non_interactive_without_yes_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "my-rule")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with patch("sys.stdin") as mock_stdin:
+                mock_stdin.isatty.return_value = False
+                with pytest.raises(SystemExit):
+                    cmd_delete(Namespace(name="my-rule", yes=False))
+
+
+# ---------------------------------------------------------------------------
+# CLI: cmd_promote / cmd_demote
+# ---------------------------------------------------------------------------
+
+
+class TestCmdPromote:
+    def test_shadow_to_warn(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = _write_rule(_home_rules(tmp_path), "my-rule", tier="shadow")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_promote(Namespace(name="my-rule"))
+        assert "tier: warn" in p.read_text()
+        assert "shadow → warn" in capsys.readouterr().out
+
+    def test_warn_to_enforce(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = _write_rule(_home_rules(tmp_path), "my-rule", tier="warn")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_promote(Namespace(name="my-rule"))
+        assert "tier: enforce" in p.read_text()
+
+    def test_ceiling_is_noop(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = _write_rule(_home_rules(tmp_path), "my-rule", tier="enforce")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_promote(Namespace(name="my-rule"))
+        assert "ceiling" in capsys.readouterr().out
+        assert "tier: enforce" in p.read_text()
+
+    def test_disabled_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "my-rule", tier="disabled")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with pytest.raises(SystemExit):
+                cmd_promote(Namespace(name="my-rule"))
+
+
+class TestCmdDemote:
+    def test_enforce_to_warn(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = _write_rule(_home_rules(tmp_path), "my-rule", tier="enforce")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_demote(Namespace(name="my-rule"))
+        assert "tier: warn" in p.read_text()
+        assert "enforce → warn" in capsys.readouterr().out
+
+    def test_warn_to_shadow(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = _write_rule(_home_rules(tmp_path), "my-rule", tier="warn")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_demote(Namespace(name="my-rule"))
+        assert "tier: shadow" in p.read_text()
+
+    def test_floor_is_noop(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "my-rule", tier="shadow")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_demote(Namespace(name="my-rule"))
+        assert "floor" in capsys.readouterr().out
+
+    def test_disabled_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "my-rule", tier="disabled")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with pytest.raises(SystemExit):
+                cmd_demote(Namespace(name="my-rule"))
+
+
+# ---------------------------------------------------------------------------
+# CLI: cmd_disable / cmd_enable
+# ---------------------------------------------------------------------------
+
+
+class TestCmdDisable:
+    def test_sets_tier_disabled_and_saves_sidecar(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = _write_rule(_home_rules(tmp_path), "my-rule", tier="warn")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_disable(Namespace(name="my-rule"))
+        content = p.read_text()
+        assert "tier: disabled" in content
+        assert "# previous-tier: warn" in content
+        assert "was" in capsys.readouterr().out
+
+    def test_already_disabled_is_noop(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "my-rule", tier="disabled")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_disable(Namespace(name="my-rule"))
+        assert "already disabled" in capsys.readouterr().out
+
+    def test_not_found_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with pytest.raises(SystemExit):
+                cmd_disable(Namespace(name="missing"))
+
+
+class TestCmdEnable:
+    def test_restores_previous_tier(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = _write_rule(_home_rules(tmp_path), "my-rule", tier="warn")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_disable(Namespace(name="my-rule"))
+            cmd_enable(Namespace(name="my-rule"))
+        content = p.read_text()
+        assert "tier: warn" in content
+        assert "# previous-tier:" not in content
+
+    def test_defaults_to_shadow_without_sidecar(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        p = _write_rule(_home_rules(tmp_path), "my-rule", tier="disabled")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_enable(Namespace(name="my-rule"))
+        assert "tier: shadow" in p.read_text()
+
+    def test_already_enabled_is_noop(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "my-rule", tier="warn")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_enable(Namespace(name="my-rule"))
+        assert "already enabled" in capsys.readouterr().out
+
+    def test_not_found_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with pytest.raises(SystemExit):
+                cmd_enable(Namespace(name="missing"))
+
+
+# ---------------------------------------------------------------------------
+# CLI: cmd_path
+# ---------------------------------------------------------------------------
+
+
+class TestCmdPath:
+    def test_prints_path(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "my-rule")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_path(Namespace(name="my-rule"))
+        out = capsys.readouterr().out.strip()
+        assert out.endswith("my-rule.yaml")
+
+    def test_not_found_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with pytest.raises(SystemExit):
+                cmd_path(Namespace(name="missing"))
+
+
+# ---------------------------------------------------------------------------
+# CLI: cmd_validate
+# ---------------------------------------------------------------------------
+
+
+class TestCmdValidate:
+    def test_single_valid_rule(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "my-rule")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_validate(Namespace(name="my-rule"))
+        assert "OK" in capsys.readouterr().out
+
+    def test_single_rule_not_found_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with pytest.raises(SystemExit):
+                cmd_validate(Namespace(name="missing"))
+
+    def test_all_rules_valid(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "rule-a")
+        _write_rule(_home_rules(tmp_path), "rule-b")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_validate(Namespace(name=None))
+        out = capsys.readouterr().out
+        assert "OK" in out
+        assert "rule-a" in out
+
+    def test_invalid_rule_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        rules_dir = _home_rules(tmp_path)
+        rules_dir.mkdir(parents=True)
+        bad = rules_dir / "bad.yaml"
+        bad.write_text("tier: bad-tier\nname: bad\nevent: Stop\nprompt: x\n")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with pytest.raises(SystemExit):
+                cmd_validate(Namespace(name=None))
+
+
+# ---------------------------------------------------------------------------
+# CLI: cmd_completion
+# ---------------------------------------------------------------------------
+
+
+class TestCmdCompletion:
+    def test_bash(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cmd_completion(Namespace(shell="bash"))
+        assert "register-python-argcomplete" in capsys.readouterr().out
+
+    def test_zsh(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cmd_completion(Namespace(shell="zsh"))
+        assert "register-python-argcomplete" in capsys.readouterr().out
+
+    def test_fish(self, capsys: pytest.CaptureFixture[str]) -> None:
+        cmd_completion(Namespace(shell="fish"))
+        assert "fish" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# dispatch_rule_command
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchRuleCommand:
+    def test_dispatches_known_command(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "my-rule")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            handled = dispatch_rule_command(Namespace(command="path", name="my-rule"))
+        assert handled is True
+
+    def test_returns_false_for_unknown(self) -> None:
+        assert dispatch_rule_command(Namespace(command="unknown")) is False
+
+
+# ---------------------------------------------------------------------------
+# attach_rule_parsers
+# ---------------------------------------------------------------------------
+
+
+class TestAttachRuleParsers:
+    def test_registers_all_subcommands(self) -> None:
+        import argparse
+
+        from vaudeville.cli_rules import attach_rule_parsers
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="cmd")
+        attach_rule_parsers(sub)
+
+        name_cmds = ("show", "delete", "promote", "demote", "enable", "disable", "path")
+        for cmd in name_cmds:
+            args = parser.parse_args([cmd, "x"])
+            assert args.cmd == cmd
+        args = parser.parse_args(["list"])
+        assert args.cmd == "list"
+        args = parser.parse_args(["validate"])
+        assert args.cmd == "validate"
+        args = parser.parse_args(["completion", "bash"])
+        assert args.cmd == "completion"
+
+    def test_list_filters_registered(self) -> None:
+        import argparse
+
+        from vaudeville.cli_rules import attach_rule_parsers
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="cmd")
+        attach_rule_parsers(sub)
+        args = parser.parse_args(
+            ["list", "--tier", "warn", "--event", "Stop", "--json"]
+        )
+        assert args.tier == "warn"
+        assert args.event == "Stop"
+        assert args.json is True
+
+    def test_completion_choices_registered(self) -> None:
+        import argparse
+
+        from vaudeville.cli_rules import attach_rule_parsers
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="cmd")
+        attach_rule_parsers(sub)
+        args = parser.parse_args(["completion", "bash"])
+        assert args.shell == "bash"
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: not-found paths, edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestCoverageEdgeCases:
+    def test_promote_not_found_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch(
+            "vaudeville.cli_rules._find_project_root", return_value=str(tmp_path)
+        ):
+            with pytest.raises(SystemExit):
+                cmd_promote(Namespace(name="missing"))
+
+    def test_demote_not_found_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        with patch(
+            "vaudeville.cli_rules._find_project_root", return_value=str(tmp_path)
+        ):
+            with pytest.raises(SystemExit):
+                cmd_demote(Namespace(name="missing"))
+
+    def test_show_with_examples(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(
+            _home_rules(tmp_path),
+            "ex-rule",
+            examples=[
+                {
+                    "id": "1",
+                    "input": "bad output",
+                    "label": "violation",
+                    "reason": "sycophantic",
+                }
+            ],
+        )
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_show(Namespace(name="ex-rule", json=False))
+        out = capsys.readouterr().out
+        assert "examples (from prompt)" in out
+        assert "bad output" in out
+
+    def test_show_draft_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        rules_dir = _home_rules(tmp_path)
+        rules_dir.mkdir(parents=True)
+        p = rules_dir / "draft-rule.yaml"
+        p.write_text("name: draft-rule\ndraft: true\nevent: Stop\nprompt: x\n")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with pytest.raises(SystemExit):
+                cmd_show(Namespace(name="draft-rule", json=False))
+
+    def test_disable_rule_without_tier_field(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        rules_dir = _home_rules(tmp_path)
+        rules_dir.mkdir(parents=True)
+        p = rules_dir / "no-tier.yaml"
+        p.write_text("name: no-tier\nevent: Stop\nprompt: x\n")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_disable(Namespace(name="no-tier"))
+        assert "tier: disabled" in p.read_text()
+        assert "# previous-tier: shadow" in p.read_text()
+
+    def test_validate_single_invalid_rule(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        rules_dir = _home_rules(tmp_path)
+        rules_dir.mkdir(parents=True)
+        p = rules_dir / "bad.yaml"
+        p.write_text("name: bad\ntier: invalid-tier\nevent: Stop\nprompt: x\n")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with pytest.raises(SystemExit):
+                cmd_validate(Namespace(name="bad"))
+
+    def test_validate_all_skips_non_yaml(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        rules_dir = _home_rules(tmp_path)
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "README.txt").write_text("not a rule")
+        _write_rule(rules_dir, "good-rule")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_validate(Namespace(name=None))
+        out = capsys.readouterr().out
+        assert "good-rule" in out
+        assert "README" not in out
+
+    def test_delete_multiple_all(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        ph = _write_rule(_home_rules(tmp_path), "dup-rule")
+        pp = _write_rule(_proj_rules(tmp_path), "dup-rule")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with patch("builtins.input", return_value="all"):
+                with patch("sys.stdin") as ms:
+                    ms.isatty.return_value = True
+                    cmd_delete(Namespace(name="dup-rule", yes=False))
+        assert not ph.exists()
+        assert not pp.exists()
+
+    def test_delete_multiple_invalid_choice(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "dup-rule")
+        _write_rule(_proj_rules(tmp_path), "dup-rule")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            with patch("builtins.input", return_value="99"):
+                with patch("sys.stdin") as ms:
+                    ms.isatty.return_value = True
+                    cmd_delete(Namespace(name="dup-rule", yes=False))
+        assert "Aborted" in capsys.readouterr().out
+
+    def test_rule_names_completer_exception(self) -> None:
+        from vaudeville.cli_rules import _rule_names_completer
+
+        with patch(
+            "vaudeville.cli_rules.load_rules_layered", side_effect=Exception("boom")
+        ):
+            result = _rule_names_completer("my")
+        assert result == []
+
+    def test_rule_names_completer_happy_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _write_rule(_home_rules(tmp_path), "my-rule")
+        from vaudeville.cli_rules import _rule_names_completer
+
+        result = _rule_names_completer("my")
+        assert "my-rule" in result
+
+    def test_find_project_root_fallback(self) -> None:
+        import os
+
+        from vaudeville.cli_rules import _find_project_root
+
+        with patch("vaudeville.core.paths.find_project_root", return_value=None):
+            result = _find_project_root()
+        assert result == os.getcwd()
+
+    def test_disable_no_trailing_newline(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        rules_dir = _home_rules(tmp_path)
+        rules_dir.mkdir(parents=True)
+        p = rules_dir / "notail.yaml"
+        p.write_text("name: notail\nevent: Stop\nprompt: x\ntier: warn")
+        with patch(
+            "vaudeville.cli_rules._find_project_root",
+            return_value=str(tmp_path / "proj"),
+        ):
+            cmd_disable(Namespace(name="notail"))
+        content = p.read_text()
+        assert "tier: disabled" in content
+        assert "# previous-tier: warn" in content

--- a/tests/test_orchestrator_adversarial.py
+++ b/tests/test_orchestrator_adversarial.py
@@ -326,7 +326,7 @@ class TestAbandonRuleAdversarial:
 
     def test_locate_rule_yaml_wins_over_yml(self, tmp_path: Path) -> None:
         """.yaml candidate comes before .yml in the candidate list → yaml wins."""
-        from vaudeville.orchestrator import _locate_rule_file
+        from vaudeville.core.rules import locate_rule_file as _locate_rule_file
 
         rules_dir = tmp_path / ".vaudeville" / "rules"
         rules_dir.mkdir(parents=True)
@@ -340,7 +340,7 @@ class TestAbandonRuleAdversarial:
 
     def test_locate_rule_only_yml_extension(self, tmp_path: Path) -> None:
         """Only .yml exists → returned correctly."""
-        from vaudeville.orchestrator import _locate_rule_file
+        from vaudeville.core.rules import locate_rule_file as _locate_rule_file
 
         rules_dir = tmp_path / ".vaudeville" / "rules"
         rules_dir.mkdir(parents=True)
@@ -352,7 +352,7 @@ class TestAbandonRuleAdversarial:
 
     def test_locate_rule_home_fallback(self, tmp_path: Path) -> None:
         """Rule not in project path but exists in home fallback."""
-        from vaudeville.orchestrator import _locate_rule_file
+        from vaudeville.core.rules import locate_rule_file as _locate_rule_file
 
         user_home = tmp_path / "fakehome"
         home_rules = user_home / ".vaudeville" / "rules"
@@ -371,7 +371,7 @@ class TestAbandonRuleAdversarial:
         assert found == home_file
 
     def test_locate_rule_missing_everywhere_raises(self, tmp_path: Path) -> None:
-        from vaudeville.orchestrator import _locate_rule_file
+        from vaudeville.core.rules import locate_rule_file as _locate_rule_file
 
         with patch("os.path.expanduser", return_value=str(tmp_path / "fakehome")):
             with pytest.raises(FileNotFoundError):

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,15 @@ wheels = [
 ]
 
 [[package]]
+name = "argcomplete"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -1241,6 +1250,7 @@ name = "vaudeville"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "argcomplete" },
     { name = "loguru" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -1265,6 +1275,7 @@ mlx = [
 
 [package.metadata]
 requires-dist = [
+    { name = "argcomplete", specifier = ">=3.0" },
     { name = "loguru", specifier = ">=0.7.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "rich", specifier = ">=13.0" },

--- a/vaudeville/__main__.py
+++ b/vaudeville/__main__.py
@@ -15,6 +15,7 @@ from rich.console import Console
 from rich.text import Text
 
 from vaudeville import orchestrator
+from vaudeville.cli_rules import attach_rule_parsers, dispatch_rule_command
 from vaudeville.core.paths import find_project_root as _core_find_project_root
 from vaudeville.orchestrator import RalphError, Thresholds
 from vaudeville.server import latency_text, styled_table
@@ -252,6 +253,8 @@ def _build_generate_parser(sub: Any) -> None:
 
 
 def _dispatch(args: argparse.Namespace) -> None:
+    
+
     if args.command == "watch":
         cmd_watch(args)
     elif args.command == "setup":
@@ -262,6 +265,8 @@ def _dispatch(args: argparse.Namespace) -> None:
         sys.exit(cmd_tune(args))
     elif args.command == "generate":
         sys.exit(cmd_generate(args))
+    elif dispatch_rule_command(args):
+        pass
 
 
 def main() -> None:
@@ -282,6 +287,14 @@ def main() -> None:
 
     _build_tune_parser(sub)
     _build_generate_parser(sub)
+    attach_rule_parsers(sub)
+
+    try:
+        import argcomplete
+
+        argcomplete.autocomplete(parser)
+    except ImportError:
+        pass
 
     args = parser.parse_args()
     if args.command is None:

--- a/vaudeville/__main__.py
+++ b/vaudeville/__main__.py
@@ -253,7 +253,6 @@ def _build_generate_parser(sub: Any) -> None:
 
 
 def _dispatch(args: argparse.Namespace) -> None:
-    
 
     if args.command == "watch":
         cmd_watch(args)

--- a/vaudeville/cli_rules.py
+++ b/vaudeville/cli_rules.py
@@ -1,5 +1,3 @@
-"""Rule management CLI commands for vaudeville."""
-
 from __future__ import annotations
 
 import argparse
@@ -155,12 +153,15 @@ def cmd_delete(args: argparse.Namespace) -> None:
             print(f"Rule {args.name!r} exists in multiple locations:")
             for i, p in enumerate(paths, 1):
                 print(f"  {i}. {p}")
-            raw = input("Delete which? (1/2/all): ").strip().lower()
+            raw = input(f"Delete which? (1-{len(paths)}/all): ").strip().lower()
             if raw == "all":
                 pass
             else:
                 try:
-                    paths = [paths[int(raw) - 1]]
+                    idx = int(raw) - 1
+                    if not (0 <= idx < len(paths)):
+                        raise IndexError
+                    paths = [paths[idx]]
                 except (ValueError, IndexError):
                     print("Invalid choice. Aborted.")
                     return
@@ -234,7 +235,8 @@ def cmd_disable(args: argparse.Namespace) -> None:
         print(f"Rule {args.name!r} not found.", file=sys.stderr)
         sys.exit(1)
     content = path.read_text()
-    current = _load_tier(path)
+    m = re.search(r"^tier:\s*(\S+)", content, re.MULTILINE)
+    current = m.group(1) if m else "shadow"
     if current == "disabled":
         print(f"Rule {args.name!r} is already disabled.")
         return
@@ -261,7 +263,8 @@ def cmd_enable(args: argparse.Namespace) -> None:
         print(f"Rule {args.name!r} not found.", file=sys.stderr)
         sys.exit(1)
     content = path.read_text()
-    current = _load_tier(path)
+    m = re.search(r"^tier:\s*(\S+)", content, re.MULTILINE)
+    current = m.group(1) if m else "shadow"
     if current != "disabled":
         print(f"Rule {args.name!r} is already enabled (tier: {current!r}).")
         return
@@ -312,7 +315,7 @@ def cmd_validate(args: argparse.Namespace) -> None:
                 load_rule_file(p)
                 print(f"OK      {name}")
             except Exception as exc:
-                print(f"INVALID {name}: {exc}")
+                print(f"INVALID {name}: {exc}", file=sys.stderr)
                 errors += 1
     if errors:
         sys.exit(1)
@@ -326,8 +329,6 @@ def cmd_completion(args: argparse.Namespace) -> None:
 
 
 def attach_rule_parsers(sub: Any) -> None:
-    """Register all rule management subparsers with argcomplete support."""
-
     def _name(p: Any) -> Any:
         action = p.add_argument("name", help="Rule name")
         action.completer = _rule_names_completer
@@ -379,7 +380,7 @@ _RULE_COMMANDS: dict[str, _CmdHandler] = {
 
 
 def dispatch_rule_command(args: argparse.Namespace) -> bool:
-    """Dispatch to a rule management command. Returns True if the command was handled."""
+    """Returns True if handled, False if command unknown."""
     handler = _RULE_COMMANDS.get(args.command)
     if handler is None:
         return False

--- a/vaudeville/cli_rules.py
+++ b/vaudeville/cli_rules.py
@@ -1,0 +1,387 @@
+"""Rule management CLI commands for vaudeville."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+from vaudeville.core.paths import find_project_root as _core_find_project_root
+from vaudeville.core.rules import (
+    VALID_TIERS,
+    Rule,
+    load_rule_file,
+    load_rules_layered,
+    list_rules_with_source,
+    locate_all_rule_files,
+    locate_rule_file,
+    rules_search_path,
+    set_tier,
+)
+
+_ACTIVE_TIERS = ("shadow", "warn", "enforce")
+_CmdHandler = Callable[[argparse.Namespace], None]
+
+
+def _find_project_root() -> str:
+    return _core_find_project_root() or os.getcwd()
+
+
+def _rule_names_completer(prefix: str, **_: object) -> list[str]:
+    try:
+        rules = load_rules_layered()
+        return [name for name in rules if name.startswith(prefix)]
+    except Exception:
+        return []
+
+
+def cmd_list(args: argparse.Namespace) -> None:
+    project_root = _find_project_root()
+    pairs = list_rules_with_source(project_root)
+    if args.tier:
+        pairs = [(r, s) for r, s in pairs if r.tier == args.tier]
+    if args.event:
+        pairs = [(r, s) for r, s in pairs if r.event == args.event]
+    pairs.sort(key=lambda x: x[0].name)
+    if args.json:
+        print(
+            json.dumps(
+                [
+                    {
+                        "name": r.name,
+                        "tier": r.tier,
+                        "event": r.event,
+                        "threshold": r.threshold,
+                        "source": s,
+                    }
+                    for r, s in pairs
+                ],
+                indent=2,
+            )
+        )
+        return
+    if not pairs:
+        print("No rules found.")
+        return
+    hdr = f"{'Name':<35} {'Tier':<10} {'Event':<15} {'Threshold':>9}  Source"
+    print(hdr)
+    print("-" * len(hdr))
+    for rule, source in pairs:
+        print(
+            f"{rule.name:<35} {rule.tier:<10} {rule.event:<15} {rule.threshold:>9.2f}  {source}"
+        )
+
+
+def _print_rule_human(rule: Rule, path: Path) -> None:
+    home = os.path.expanduser("~")
+    display_path = str(path).replace(home, "~")
+    print(rule.name)
+    print(f"  tier: {rule.tier:<12} event: {rule.event:<14} action: {rule.action}")
+    print(f"  threshold: {rule.threshold:<7} labels: {rule.labels}")
+    print(f"  path: {display_path}")
+    print()
+    print(f'  message: "{rule.message}"')
+    if rule.context:
+        print()
+        print("  context:")
+        for entry in rule.context:
+            for k, v in entry.items():
+                print(f"    - {k}: {v}")
+    if rule.test_cases:
+        print()
+        counts: dict[str, int] = {}
+        for tc in rule.test_cases:
+            counts[tc.label] = counts.get(tc.label, 0) + 1
+        counts_str = ", ".join(f"{v} {k}" for k, v in sorted(counts.items()))
+        print(f"  test_cases: {len(rule.test_cases)} ({counts_str})")
+    examples = (rule.examples or rule.candidates)[:2]
+    if examples:
+        print()
+        print("  examples (from prompt):")
+        for ex in examples:
+            print(f'    [{ex.label}] "{ex.input[:80]}"')
+
+
+def cmd_show(args: argparse.Namespace) -> None:
+    project_root = _find_project_root()
+    try:
+        path = locate_rule_file(args.name, project_root)
+    except FileNotFoundError:
+        print(f"Rule {args.name!r} not found.", file=sys.stderr)
+        sys.exit(1)
+    rule = load_rule_file(path)
+    if rule is None:
+        print(f"Rule {args.name!r} is a draft.", file=sys.stderr)
+        sys.exit(1)
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "name": rule.name,
+                    "tier": rule.tier,
+                    "event": rule.event,
+                    "threshold": rule.threshold,
+                    "action": rule.action,
+                    "message": rule.message,
+                    "labels": rule.labels,
+                    "test_case_count": len(rule.test_cases),
+                    "path": str(path),
+                },
+                indent=2,
+            )
+        )
+        return
+    _print_rule_human(rule, path)
+
+
+def cmd_delete(args: argparse.Namespace) -> None:
+    project_root = _find_project_root()
+    paths = locate_all_rule_files(args.name, project_root)
+    if not paths:
+        print(f"Rule {args.name!r} not found.", file=sys.stderr)
+        sys.exit(1)
+    if not args.yes:
+        if not sys.stdin.isatty():
+            print(
+                f"Rule {args.name!r}: pass --yes for non-interactive delete.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if len(paths) > 1:
+            print(f"Rule {args.name!r} exists in multiple locations:")
+            for i, p in enumerate(paths, 1):
+                print(f"  {i}. {p}")
+            raw = input("Delete which? (1/2/all): ").strip().lower()
+            if raw == "all":
+                pass
+            else:
+                try:
+                    paths = [paths[int(raw) - 1]]
+                except (ValueError, IndexError):
+                    print("Invalid choice. Aborted.")
+                    return
+        else:
+            resp = input(f"Delete {paths[0]}? [y/N] ").strip().lower()
+            if resp != "y":
+                print("Aborted.")
+                return
+    for p in paths:
+        p.unlink()
+        print(f"Deleted {p}")
+
+
+def _load_tier(path: Path) -> str:
+    content = path.read_text()
+    m = re.search(r"^tier:\s*(\S+)", content, re.MULTILINE)
+    return m.group(1) if m else "shadow"
+
+
+def cmd_promote(args: argparse.Namespace) -> None:
+    project_root = _find_project_root()
+    try:
+        path = locate_rule_file(args.name, project_root)
+    except FileNotFoundError:
+        print(f"Rule {args.name!r} not found.", file=sys.stderr)
+        sys.exit(1)
+    current = _load_tier(path)
+    if current not in _ACTIVE_TIERS:
+        print(
+            f"Rule {args.name!r} is {current!r}; use 'enable' to restore it first.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    idx = _ACTIVE_TIERS.index(current)
+    if idx == len(_ACTIVE_TIERS) - 1:
+        print(f"Rule {args.name!r} is already at ceiling (enforce).")
+        return
+    new_tier = _ACTIVE_TIERS[idx + 1]
+    set_tier(args.name, new_tier, project_root)
+    print(f"Promoted {args.name!r}: {current} → {new_tier}")
+
+
+def cmd_demote(args: argparse.Namespace) -> None:
+    project_root = _find_project_root()
+    try:
+        path = locate_rule_file(args.name, project_root)
+    except FileNotFoundError:
+        print(f"Rule {args.name!r} not found.", file=sys.stderr)
+        sys.exit(1)
+    current = _load_tier(path)
+    if current not in _ACTIVE_TIERS:
+        print(
+            f"Rule {args.name!r} is {current!r}; use 'disable' instead.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    idx = _ACTIVE_TIERS.index(current)
+    if idx == 0:
+        print(f"Rule {args.name!r} is already at floor (shadow).")
+        return
+    new_tier = _ACTIVE_TIERS[idx - 1]
+    set_tier(args.name, new_tier, project_root)
+    print(f"Demoted {args.name!r}: {current} → {new_tier}")
+
+
+def cmd_disable(args: argparse.Namespace) -> None:
+    project_root = _find_project_root()
+    try:
+        path = locate_rule_file(args.name, project_root)
+    except FileNotFoundError:
+        print(f"Rule {args.name!r} not found.", file=sys.stderr)
+        sys.exit(1)
+    content = path.read_text()
+    current = _load_tier(path)
+    if current == "disabled":
+        print(f"Rule {args.name!r} is already disabled.")
+        return
+    new_content, count = re.subn(
+        r"^tier:\s*\S+", "tier: disabled", content, flags=re.MULTILINE
+    )
+    if count == 0:
+        sep = "" if not content or content.endswith("\n") else "\n"
+        new_content = content + sep + "tier: disabled\n"
+    if not new_content.endswith("\n"):
+        new_content += "\n"
+    new_content += f"# previous-tier: {current}\n"
+    path.write_text(new_content)
+    print(
+        f"Disabled {args.name!r} (was {current!r}). Use 'vaudeville enable {args.name}' to restore."
+    )
+
+
+def cmd_enable(args: argparse.Namespace) -> None:
+    project_root = _find_project_root()
+    try:
+        path = locate_rule_file(args.name, project_root)
+    except FileNotFoundError:
+        print(f"Rule {args.name!r} not found.", file=sys.stderr)
+        sys.exit(1)
+    content = path.read_text()
+    current = _load_tier(path)
+    if current != "disabled":
+        print(f"Rule {args.name!r} is already enabled (tier: {current!r}).")
+        return
+    pm = re.search(r"^# previous-tier:\s*(\S+)", content, re.MULTILINE)
+    restore = pm.group(1) if pm else "shadow"
+    new_content = re.sub(
+        r"^tier:\s*\S+", f"tier: {restore}", content, flags=re.MULTILINE
+    )
+    new_content = re.sub(
+        r"^# previous-tier:[^\n]*\n?", "", new_content, flags=re.MULTILINE
+    )
+    path.write_text(new_content)
+    print(f"Enabled {args.name!r} (tier: {restore!r}).")
+
+
+def cmd_path(args: argparse.Namespace) -> None:
+    project_root = _find_project_root()
+    try:
+        path = locate_rule_file(args.name, project_root)
+    except FileNotFoundError:
+        print(f"Rule {args.name!r} not found.", file=sys.stderr)
+        sys.exit(1)
+    print(path)
+
+
+def cmd_validate(args: argparse.Namespace) -> None:
+    project_root = _find_project_root()
+    if args.name:
+        try:
+            path = locate_rule_file(args.name, project_root)
+            load_rule_file(path)
+            print(f"OK      {args.name}")
+        except FileNotFoundError:
+            print(f"NOT FOUND  {args.name}", file=sys.stderr)
+            sys.exit(1)
+        except Exception as exc:
+            print(f"INVALID {args.name}: {exc}", file=sys.stderr)
+            sys.exit(1)
+        return
+    errors = 0
+    for rules_dir in rules_search_path(project_root):
+        for filename in sorted(os.listdir(rules_dir)):
+            if not (filename.endswith(".yaml") or filename.endswith(".yml")):
+                continue
+            p = Path(rules_dir) / filename
+            name = filename.rsplit(".", 1)[0]
+            try:
+                load_rule_file(p)
+                print(f"OK      {name}")
+            except Exception as exc:
+                print(f"INVALID {name}: {exc}")
+                errors += 1
+    if errors:
+        sys.exit(1)
+
+
+def cmd_completion(args: argparse.Namespace) -> None:
+    if args.shell in ("bash", "zsh"):
+        print('eval "$(register-python-argcomplete vaudeville)"')
+    elif args.shell == "fish":
+        print("register-python-argcomplete --shell fish vaudeville | source")
+
+
+def attach_rule_parsers(sub: Any) -> None:
+    """Register all rule management subparsers with argcomplete support."""
+
+    def _name(p: Any) -> Any:
+        action = p.add_argument("name", help="Rule name")
+        action.completer = _rule_names_completer
+        return action
+
+    lp = sub.add_parser("list", help="List all rules")
+    lp.add_argument("--tier", choices=VALID_TIERS, help="Filter by tier")
+    lp.add_argument("--event", help="Filter by event type")
+    lp.add_argument("--json", action="store_true", help="Output raw JSON")
+
+    sp = sub.add_parser("show", help="Show rule details")
+    _name(sp)
+    sp.add_argument("--json", action="store_true", help="Output raw JSON")
+
+    dp = sub.add_parser("delete", help="Delete a rule file")
+    _name(dp)
+    dp.add_argument("--yes", "-y", action="store_true", help="Skip confirmation")
+
+    for cmd, help_txt in (
+        ("promote", "Promote rule one tier (shadow→warn→enforce)"),
+        ("demote", "Demote rule one tier (enforce→warn→shadow)"),
+        ("enable", "Restore a disabled rule to its previous tier"),
+        ("disable", "Disable a rule (saves previous tier for restore)"),
+        ("path", "Print the resolved path of a rule file"),
+    ):
+        _name(sub.add_parser(cmd, help=help_txt))
+
+    vp = sub.add_parser(
+        "validate", help="Validate rule YAML (all rules if name omitted)"
+    )
+    vp.add_argument("name", nargs="?", help="Rule name")
+
+    cp = sub.add_parser("completion", help="Print shell completion setup command")
+    cp.add_argument("shell", choices=["bash", "zsh", "fish"])
+
+
+_RULE_COMMANDS: dict[str, _CmdHandler] = {
+    "list": cmd_list,
+    "show": cmd_show,
+    "delete": cmd_delete,
+    "promote": cmd_promote,
+    "demote": cmd_demote,
+    "enable": cmd_enable,
+    "disable": cmd_disable,
+    "path": cmd_path,
+    "validate": cmd_validate,
+    "completion": cmd_completion,
+}
+
+
+def dispatch_rule_command(args: argparse.Namespace) -> bool:
+    """Dispatch to a rule management command. Returns True if the command was handled."""
+    handler = _RULE_COMMANDS.get(args.command)
+    if handler is None:
+        return False
+    handler(args)
+    return True

--- a/vaudeville/core/rules.py
+++ b/vaudeville/core/rules.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import yaml
@@ -252,6 +253,80 @@ def parse_rule(data: dict[str, Any]) -> Rule:
         labels=labels,
         test_cases=test_cases,
     )
+
+
+def locate_rule_file(rule_name: str, project_root: str | None = None) -> Path:
+    """Find a rule YAML; searches project then home, raises FileNotFoundError if absent."""
+    home = os.path.expanduser("~")
+    candidates: list[Path] = []
+    if project_root:
+        proj_rules = Path(project_root) / ".vaudeville" / "rules"
+        candidates += [
+            proj_rules / f"{rule_name}.yaml",
+            proj_rules / f"{rule_name}.yml",
+        ]
+    home_rules = Path(home) / ".vaudeville" / "rules"
+    candidates += [home_rules / f"{rule_name}.yaml", home_rules / f"{rule_name}.yml"]
+    for path in candidates:
+        if path.exists():
+            return path
+    raise FileNotFoundError(f"rule file not found for {rule_name!r}")
+
+
+def locate_all_rule_files(
+    rule_name: str, project_root: str | None = None
+) -> list[Path]:
+    """Return all matching rule YAML paths across project and home search dirs."""
+    home = os.path.expanduser("~")
+    candidates: list[Path] = []
+    if project_root:
+        proj_rules = Path(project_root) / ".vaudeville" / "rules"
+        candidates += [
+            proj_rules / f"{rule_name}.yaml",
+            proj_rules / f"{rule_name}.yml",
+        ]
+    home_rules = Path(home) / ".vaudeville" / "rules"
+    candidates += [home_rules / f"{rule_name}.yaml", home_rules / f"{rule_name}.yml"]
+    return [p for p in candidates if p.exists()]
+
+
+def set_tier(rule_name: str, new_tier: str, project_root: str | None = None) -> Path:
+    """Update the tier field in a rule file in-place. Returns the modified path."""
+    if new_tier not in VALID_TIERS:
+        raise ValueError(f"Invalid tier {new_tier!r}, must be one of {VALID_TIERS}")
+    path = locate_rule_file(rule_name, project_root)
+    content = path.read_text()
+    new_content, count = re.subn(
+        r"^tier:\s*\S+", f"tier: {new_tier}", content, flags=re.MULTILINE
+    )
+    if count == 0:
+        sep = "" if not content or content.endswith("\n") else "\n"
+        new_content = content + sep + f"tier: {new_tier}\n"
+    path.write_text(new_content)
+    return path
+
+
+def list_rules_with_source(project_root: str | None = None) -> list[tuple[Rule, str]]:
+    """Return (rule, source_dir) pairs; project-level rules override global by name."""
+    seen: dict[str, tuple[Rule, str]] = {}
+    for rules_dir in rules_search_path(project_root):
+        for filename in os.listdir(rules_dir):
+            if not (filename.endswith(".yaml") or filename.endswith(".yml")):
+                continue
+            path = os.path.join(rules_dir, filename)
+            try:
+                rule = _load_rule_file(path)
+                if rule is None:
+                    continue
+                seen[rule.name] = (rule, rules_dir)
+            except Exception:
+                continue
+    return list(seen.values())
+
+
+def load_rule_file(path: str | Path) -> Rule | None:
+    """Public wrapper: load and parse a single rule YAML. Returns None for drafts."""
+    return _load_rule_file(str(path))
 
 
 def _parse_test_cases(raw: object, rule_name: str, labels: list[str]) -> list[EvalCase]:

--- a/vaudeville/core/rules.py
+++ b/vaudeville/core/rules.py
@@ -276,7 +276,6 @@ def locate_rule_file(rule_name: str, project_root: str | None = None) -> Path:
 def locate_all_rule_files(
     rule_name: str, project_root: str | None = None
 ) -> list[Path]:
-    """Return all matching rule YAML paths across project and home search dirs."""
     home = os.path.expanduser("~")
     candidates: list[Path] = []
     if project_root:
@@ -325,12 +324,11 @@ def list_rules_with_source(project_root: str | None = None) -> list[tuple[Rule, 
 
 
 def load_rule_file(path: str | Path) -> Rule | None:
-    """Public wrapper: load and parse a single rule YAML. Returns None for drafts."""
+    """Returns None for drafts."""
     return _load_rule_file(str(path))
 
 
 def _parse_test_cases(raw: object, rule_name: str, labels: list[str]) -> list[EvalCase]:
-    """Parse and validate test_cases list from rule YAML."""
     if not raw:
         return []
     if not isinstance(raw, list):

--- a/vaudeville/orchestrator.py
+++ b/vaudeville/orchestrator.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Literal, cast
 
+from vaudeville.core.rules import set_tier
+
 
 @dataclass(frozen=True)
 class Thresholds:
@@ -89,41 +91,16 @@ def parse_judge_signal(output: str) -> JudgeVerdict:
     raise JudgeParseError("no JUDGE_* signal found in output")
 
 
-def _locate_rule_file(rule_name: str, project_root: str) -> Path:
-    """Find the rule YAML by searching project path then user home."""
-    home = os.path.expanduser("~")
-    home_rules = Path(home) / ".vaudeville" / "rules"
-    candidates = [
-        Path(project_root) / ".vaudeville" / "rules" / f"{rule_name}.yaml",
-        Path(project_root) / ".vaudeville" / "rules" / f"{rule_name}.yml",
-        home_rules / f"{rule_name}.yaml",
-        home_rules / f"{rule_name}.yml",
-    ]
-    for path in candidates:
-        if path.exists():
-            return path
-    raise FileNotFoundError(f"rule file not found for {rule_name!r}")
-
-
 def abandon_rule(
     rule_name: str, reason: str, metrics: dict[str, object], project_root: str
 ) -> None:
     """Disable rule tier, append ABANDONED comment, and log to abandoned.jsonl."""
-    rule_file = _locate_rule_file(rule_name, project_root)
-    content = rule_file.read_text()
-
+    rule_file = set_tier(rule_name, "disabled", project_root)
     sanitized = reason.replace("\n", " ").replace("\r", " ")
     ts = datetime.datetime.now(datetime.UTC).isoformat(timespec="seconds")
-
-    new_content, count = re.subn(
-        r"^tier:\s*\S+", "tier: disabled", content, flags=re.MULTILINE
-    )
-    if count == 0:
-        separator = "" if not content or content.endswith("\n") else "\n"
-        new_content = content + separator + "tier: disabled\n"
-
-    new_content += f"\n# ABANDONED {ts}: {sanitized}\n"
-    rule_file.write_text(new_content)
+    content = rule_file.read_text()
+    content += f"\n# ABANDONED {ts}: {sanitized}\n"
+    rule_file.write_text(content)
 
     log_dir = Path(project_root) / ".vaudeville" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Extracted rule management CLI commands from orchestrator into a dedicated `cli_rules.py` module. Moved rule-file helper functions (locate_rule_file, set_tier, list_rules_with_source) to core/rules.py for shared use across daemon, hooks, and CLI. Integrated CLI via argparse with argcomplete for shell completion. Added comprehensive test coverage (71 tests) for all commands and core helpers.

## Changes

- New `vaudeville/cli_rules.py` module with unified rule management commands
- Extracted rule helpers from orchestrator into `vaudeville/core/rules.py`
- Integrated argcomplete for shell tab completion support
- Comprehensive test suite (`tests/test_cli_rule_admin.py`) with 71 tests
- Updated CLI entry point in `vaudeville/__main__.py`

## Commands Supported

- `vaudeville list` - List all rules with source info
- `vaudeville show <rule>` - Show rule details
- `vaudeville promote <rule>` - Promote rule tier
- `vaudeville demote <rule>` - Demote rule tier
- `vaudeville enable <rule>` - Enable rule
- `vaudeville disable <rule>` - Disable rule
- `vaudeville delete <rule>` - Delete rule
- `vaudeville validate [<rule>]` - Validate a rule (or all rules if name omitted)
- `vaudeville path <rule>` - Print the resolved rule file path
- `vaudeville completion {bash|zsh|fish}` - Print shell completion setup command

## Testing

All changes include comprehensive test coverage:
- Rule admin command tests (71 tests)
- Core rule helper function tests
- Shell completion integration tested

## Breaking Changes

None - new feature additions only.