### PR TITLE
docs(readme): add "Get the Hook" intro with demo gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,19 @@
 
 SLM-powered semantic hook enforcement for [Claude Code](https://claude.ai/code). Classifies AI assistant output against YAML rules using local Phi-4-mini inference.
 
+## Get the Hook
+
+![Get the hook](.github/assets/get-the-hook.gif)
+
+In turn-of-the-century vaudeville theatres, a stagehand waited in the wings with a long shepherd's crook. When an act started flailing — forgetting lines, losing the crowd, running past its slot — the manager would signal and the hook would shoot out from the curtain and yank the performer offstage before the audience soured on the whole bill. "Get the hook!" became shorthand for cutting a bad act short.
+
+That's the job here. A local small language model watches what Claude is about to say or do and, when the performance goes off the rails — hedging about untested code, dismissing a test failure as "pre-existing," deferring a reviewer's concern to a follow-up PR, declaring work complete with known gaps — it reaches out from the wings and pulls the act. Unlike regex hooks, the SLM reads *intent*, so it catches the act whether Claude says "this should work," "I believe this addresses it," or "we can tighten this up later." Bad patterns get yanked; honest uncertainty gets through.
+
 ## How It Works
 
 Vaudeville runs a local inference daemon (Phi-4-mini, 3.8B params, int4) that classifies Claude Code's output in real time. You write rules as YAML files with few-shot prompt templates. The daemon evaluates them on every hook event and returns block/warn/log verdicts.
+
+**Apple Silicon is the first-class target.** On Macs the daemon uses the MLX backend, running Phi-4-mini on the GPU via unified memory (~200ms per classification). On x86_64 the daemon falls back to the GGUF backend (llama-cpp-python, CPU only) — same Phi-4-mini weights, but expect noticeably higher latency. Other platforms/models aren't supported; both backends hard-code the Phi-4-mini repos.
 
 **Fail-open by design** — if the daemon is down, the model isn't downloaded, or inference errors out, your session continues normally. Vaudeville never blocks you from working.
 
@@ -36,16 +46,20 @@ This detects your platform (Apple Silicon or x86_64) and downloads the appropria
 
 ## Bundled Rules
 
-These ship with vaudeville and are ready to use out of the box:
+The plugin ships a set of example rules in [`examples/rules/`](examples/rules/). **They are examples, not active configuration** — the rule loader reads from `~/.vaudeville/rules/` (global) and `<project>/.vaudeville/rules/`, so nothing fires until you copy the ones you want into one of those directories (see Quick Start step 1).
+
+The bundled examples:
 
 | Rule | Event | What it catches |
 |---|---|---|
 | `violation-detector` | Stop | Hedging, TODOs, unresolved findings in final responses |
-| `dismissal-detector` | Stop | Dismissing test/CI failures without evidence |
-| `hedging-detector` | Stop | Uncertain language about code that should have been verified |
+| `sycophancy-detector` | Stop | Unearned praise or flattery openers ("Great question!") |
+| `turn-waste-detector` | Stop | Responses that narrate a failure journey without a working solution |
+| `over-asking-detector` | Stop | Stalling on trivial permission requests instead of proceeding |
+| `preexisting-fix-detector` | Stop | Dismissing failures as "pre-existing" without evidence |
 | `deferral-detector` | PreToolUse | PR replies that defer reviewer concerns to "follow-up PRs" |
 
-`examples/rules/` also contains experimental rules marked `draft: true`. These are copied by the quick-start command but automatically skipped by the rule loader — they won't fire until you remove the `draft: true` line.
+Any rule can be gated with `draft: true` at the top of its YAML — the loader will skip it until that line is removed. Useful while iterating on a new rule without removing it from the directory.
 
 ## Custom Rules
 
@@ -67,7 +81,7 @@ Each rule is a YAML file with a `name`, `event`, `prompt`, `labels`, `action`, a
 
 **Which event should my rule use?**
 
-- **Reviewing what the assistant said** → `Stop`. Most quality rules (violation-detector, dismissal-detector, hedging-detector) use this because they evaluate the assistant's final output.
+- **Reviewing what the assistant said** → `Stop`. Most quality rules (violation-detector, sycophancy-detector, turn-waste-detector) use this because they evaluate the assistant's final output.
 - **Blocking a bad action before it happens** → `PreToolUse`. The deferral-detector uses this to catch low-quality PR replies before they're posted.
 - **Checking what a tool returned** → `PostToolUse`. Use this when the rule needs to see both the tool input and its result.
 
@@ -75,7 +89,7 @@ Other events (`SessionStart`, `UserPromptSubmit`, `Notification`, etc.) are avai
 
 ### Backend Differences
 
-The GGUF backend (llama-cpp-python) enforces the `VERDICT: .../REASON: ...` output format via GBNF grammar-constrained decoding, guaranteeing structurally valid responses. The MLX backend relies on prompt compliance alone, as MLX-LM does not support GBNF grammars. Both backends use temperature 0.0 for deterministic inference; the GGUF backend additionally applies `repeat_penalty=1.1`.
+The GGUF backend (llama-cpp-python) enforces the `VERDICT: .../REASON: ...` output format via GBNF grammar-constrained decoding, guaranteeing structurally valid responses. MLX-LM doesn't support GBNF grammars, so the MLX backend relies on a system prompt plus a newline-count stop condition (halts after two newlines once the VERDICT and REASON lines are emitted). Both backends use temperature 0.0 for deterministic inference; the GGUF backend additionally applies `repeat_penalty=1.1`.
 
 ## Observability
 
@@ -113,7 +127,7 @@ Edit `~/.vaudeville/logs/config.yaml` to change these. Raise `max_size_mb` if yo
 - Python 3.11+
 - [uv](https://docs.astral.sh/uv/) (Python package manager)
 - ~4 GB disk for the model
-- Apple Silicon (MLX backend) or x86_64 (GGUF backend)
+- Apple Silicon (recommended — MLX backend, GPU-accelerated) or x86_64 (GGUF backend, CPU only, slower)
 
 ## Development
 
@@ -127,10 +141,10 @@ just eval       # evaluate rules against test cases
 ## Troubleshooting
 
 **Daemon not starting?**
-Check that the model is downloaded: `ls ~/.vaudeville/models/`. If empty, run `/vaudeville:setup` again.
+Check that the model is downloaded to the Hugging Face cache: `ls ~/.cache/huggingface/hub/ | grep -i phi-4`. If nothing matches, run `/vaudeville:setup` again.
 
 **Rules not firing?**
-Verify rules are in `~/.vaudeville/rules/` and have valid YAML. Check the daemon socket exists: `ls /tmp/vaudeville-*.sock`.
+Verify rules are in `~/.vaudeville/rules/` and have valid YAML. Check the daemon socket exists: `ls /tmp/vaudeville-*/vaudeville.sock`.
 
 **False positives?**
 Raise the rule's `threshold` value in its YAML file (e.g., `threshold: 0.7` → `threshold: 0.85`). Higher threshold = fewer but more confident matches.


### PR DESCRIPTION
## Summary
- Adds a "Get the Hook" section explaining vaudeville's namesake (stagehand's crook → SLM intent classification) with a demo gif.
- Documents Apple Silicon (MLX) as the first-class target and x86_64 (GGUF) as the slower CPU fallback.
- Clarifies that `examples/rules/` are samples, not active config — the loader reads from `~/.vaudeville/rules/` or project-local `.vaudeville/rules/`.
- Updates the bundled rule list to match the current set (sycophancy, turn-waste, over-asking, preexisting-fix) and explains `draft: true` gating.
- Fixes troubleshooting paths: model cache (`~/.cache/huggingface/hub/`) and daemon socket (`/tmp/vaudeville-*/vaudeville.sock`).