### PR TITLE
chore(github): add issue/PR templates and point marketplace at GitHub

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,11 @@
   "plugins": [
     {
       "name": "vaudeville",
-      "source": "./",
+      "source": {
+        "source": "github",
+        "repo": "paulnsorensen/vaudeville",
+        "ref": "main"
+      },
       "description": "SLM-powered semantic hook enforcement — classifies AI output against YAML rules using local Phi-4-mini inference",
       "category": "development",
       "tags": ["hooks", "enforcement", "slm", "quality-gates"],

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug Report
+description: Report unexpected behavior in Vaudeville
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing: check the [Troubleshooting section](https://github.com/paulnsorensen/vaudeville#troubleshooting) in the README.
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Backend
+      options:
+        - MLX (Apple Silicon)
+        - GGUF (x86_64 / Linux)
+        - Unknown
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Vaudeville version
+      placeholder: "e.g. 0.1.0 — run: uv run vaudeville --version"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Rule YAML used (or "bundled rule X")
+        2. Hook event that fired
+        3. What the daemon logged
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste from `~/.vaudeville/logs/events.jsonl` or daemon stderr.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/paulnsorensen/vaudeville/security/advisories/new
+    about: Report security issues privately via GitHub's advisory process.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature Request
+description: Propose a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Open an issue before starting significant work — this avoids building something that doesn't fit.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What are you trying to do that Vaudeville doesn't support today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see added or changed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, and why you prefer this one.
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Which part of the system does this touch?
+      options:
+        - label: Inference / backends (MLX, GGUF)
+        - label: Rule format / loader
+        - label: Hook runner
+        - label: CLI / observability
+        - label: Eval harness
+        - label: Documentation

--- a/.github/ISSUE_TEMPLATE/new_rule.yml
+++ b/.github/ISSUE_TEMPLATE/new_rule.yml
@@ -1,0 +1,61 @@
+name: New Bundled Rule
+description: Propose a rule to include in the bundled examples
+labels: ["rule"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Bundled rules need a `.yaml` rule file and test cases with at least one positive (fires) and one negative (doesn't fire) example. See [`examples/rules/`](https://github.com/paulnsorensen/vaudeville/tree/main/examples/rules) for the format.
+
+  - type: input
+    id: rule_name
+    attributes:
+      label: Proposed rule name
+      placeholder: "e.g. scope-creep-detector"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: event
+    attributes:
+      label: Hook event
+      options:
+        - Stop
+        - PreToolUse
+        - PostToolUse
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What behavior does this rule catch?
+      description: Describe what the assistant does wrong that this rule fires on.
+    validations:
+      required: true
+
+  - type: textarea
+    id: positive_example
+    attributes:
+      label: Positive example (should fire)
+      description: Paste an assistant response or tool call that the rule should classify as a violation.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: negative_example
+    attributes:
+      label: Negative example (should not fire)
+      description: Paste an example that should pass cleanly.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: rule_yaml
+    attributes:
+      label: Draft rule YAML (optional)
+      description: If you have a draft, paste it here.
+      render: yaml

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR do? One or two sentences. -->
+
+Fixes #<!-- issue number, if applicable -->
+
+## Changes
+
+<!-- Bullet list of concrete changes. -->
+
+-
+
+## Testing
+
+- [ ] `just check` passes (lint + format + typecheck)
+- [ ] `just coverage` passes (90%+ on new code)
+- [ ] New rule: `just eval-rule <name>` passes (if adding a bundled rule)
+- [ ] `CHANGELOG.md` updated under `[Unreleased]`
+
+## Notes for reviewer
+
+<!-- Anything that needs context, tradeoffs made, or areas of uncertainty. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
 
 ## [0.1.0] - 2026-04-11
 


### PR DESCRIPTION
## Summary

Prepares the repo for OSS contributions: adds GitHub issue templates (bug, feature, new-rule), a PR template, and repoints the `.claude-plugin/marketplace.json` plugin `source` from the local `./` path to the `paulnsorensen/vaudeville` GitHub repo so external users can install via the marketplace.

## Changes

- `.github/ISSUE_TEMPLATE/`: `bug_report.yml`, `feature_request.yml`, `new_rule.yml`, plus `config.yml` disabling blank issues and linking security reports to GitHub advisories
- `.github/PULL_REQUEST_TEMPLATE/pull_request_template.md`: Summary / Changes / Testing / Notes structure with `just check`, coverage, eval, and CHANGELOG checkboxes
- `.claude-plugin/marketplace.json`: plugin `source` switched from `./` to `{source: github, repo: paulnsorensen/vaudeville, ref: main}`

## Testing

- [x] Templates are metadata-only (no runtime code path), `just build` unaffected
- [x] Manifest remains valid JSON against the marketplace schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)