### PR TITLE
fix(runner): skip disabled rules before SLM inference

### DIFF
--- a/hooks/runner.py
+++ b/hooks/runner.py
@@ -174,9 +174,6 @@ def _maybe_condense(text: str, event: str, client: VaudevilleClient) -> str:
 
 def _dispatch_violation(rule: Rule, result: ClassifyResponse) -> bool:
     """Handle a tier-aware violation. Returns True if the rule loop should continue."""
-    if rule.tier == "disabled":
-        return True
-
     if rule.tier == "shadow":
         _dbg(
             "shadow %s: %s (%.2f)",
@@ -202,6 +199,10 @@ def _run_event_rules(event: str, hook_input: dict, client: VaudevilleClient) -> 
     rules = _load_rules_for_event(event)
     condensed: dict[str, str] = {}
     for rule in rules:
+        if rule.tier == "disabled":
+            _dbg("skipping disabled rule: %s", rule.name)
+            continue
+
         text = extract_text_from_dict(hook_input, rule.context)
         if not text or len(text) < MIN_TEXT_LENGTH:
             continue

--- a/tests/test_orchestrator_adversarial.py
+++ b/tests/test_orchestrator_adversarial.py
@@ -946,21 +946,16 @@ class TestDisabledTierSideEffects:
         assert "disabled-rule" in rules
         assert rules["disabled-rule"].tier == "disabled"
 
-    def test_dispatch_violation_disabled_tier_falls_into_enforce_branch(self) -> None:
-        """In hooks/runner.py, disabled tier falls into the else (enforce) branch.
-        This means a disabled rule can still block — a potential bug."""
-        # We test this by reading the runner logic, not importing it (it has heavy deps)
-        # Instead, verify the tier value is 'disabled' and document the risk
+    def test_disabled_tier_short_circuits_before_inference(self) -> None:
+        """Disabled rules are skipped at the top of _run_event_rules — no SLM call.
+
+        See tests/test_runner.py::TestRunPipeline::test_disabled_tier_skips_inference
+        for the behavioral assertion. This test pins the contract that 'disabled'
+        remains a valid tier value.
+        """
         from vaudeville.core.rules import VALID_TIERS
 
-        # disabled is a valid tier
         assert "disabled" in VALID_TIERS
-
-        # The runner's _dispatch_violation checks:
-        #   if rule.tier == "shadow": ...
-        #   if rule.tier == "warn": ...
-        #   else: enforce  ← disabled falls here!
-        # This is a logic gap — no guard for disabled tier in the hook runner
 
     def test_valid_tiers_contains_all_four(self) -> None:
         """VALID_TIERS contains all expected tiers including disabled."""

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -383,6 +383,35 @@ class TestRunPipeline:
         assert exc_info.value.code == 0
         assert "fail open" in capsys.readouterr().err
 
+    def test_disabled_tier_skips_inference(self) -> None:
+        """Disabled rules must not invoke classify or condense — zero SLM cost."""
+        from unittest.mock import MagicMock
+
+        from vaudeville.core.rules import Rule
+
+        mock_rule = Rule(
+            name="test-disabled",
+            event="Stop",
+            prompt="Check: {text}",
+            context=[{"field": "body"}],
+            action="block",
+            message="{reason}",
+            threshold=0.5,
+            tier="disabled",
+        )
+        mock_client = MagicMock()
+        hook_input = {"body": "x" * 100}
+
+        with (
+            patch("runner._load_rules_for_event", return_value=[mock_rule]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            runner._run_event_rules("Stop", hook_input, mock_client)
+
+        assert exc_info.value.code == 0
+        mock_client.classify.assert_not_called()
+        mock_client.condense.assert_not_called()
+
 
 class TestMaybeCondense:
     """Tests for _maybe_condense — SLM condensing gate."""


### PR DESCRIPTION
## Summary

- Disabled rules previously ran the full pipeline (extract → condense → classify) and were only short-circuited *after* inference completed in `_dispatch_violation`. This wasted SLM cycles on every hook firing.
- `_run_event_rules` now checks `rule.tier == \"disabled\"` at the top of the loop and continues immediately — no text extraction, no condense, no classify call.
- Removed the now-unreachable disabled branch in `_dispatch_violation`.

## Test plan

- [x] New `tests/test_runner.py::TestRunPipeline::test_disabled_tier_skips_inference` asserts `client.classify` and `client.condense` are never called for a disabled rule.
- [x] Updated `tests/test_orchestrator_adversarial.py::TestDisabledTierSideEffects` — the prior test documented this as a known logic gap; it now pins the fixed contract.
- [x] `just build` clean — 1029 tests passing, lint + typecheck + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)